### PR TITLE
fix: cross-platform shell trap guidance + simplified README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,180 +1,70 @@
 # Azure Cost Calculator — AI Agent Skill
 
-An AI coding agent skill that estimates Azure resource costs using **live pricing data** from the [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices). Compatible with 35+ agents that support the [skills.sh](https://skills.sh) ecosystem, including [GitHub Copilot](https://docs.github.com/en/copilot/customizing-copilot/copilot-extensions/building-copilot-skills), [Claude Code](https://claude.ai), [Cursor](https://cursor.sh), and [Windsurf](https://windsurf.com).
+Real-time Azure cost estimation using the public [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices). Works with any agent in the [skills.sh](https://skills.sh) ecosystem. No guessing, no stale data — deterministic price lookups from the live API. No Azure subscription required.
 
-No guessing, no stale spreadsheets — just real-time price lookups and clear cost breakdowns.
-
-## Supported Services (140+ mapped)
-
-18 categories covering the full breadth of Azure. Services with reference files have fully documented query patterns; all others are routable via the [service routing map](skills/azure-cost-calculator/references/service-routing.md).
-
-| Category            | Example Services                                                                   |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| **Compute**         | Virtual Machines, App Service, Azure Functions, Container Apps, AKS, Batch         |
-| **Containers**      | Container Instances, Container Registry                                            |
-| **Databases**       | SQL Database, Cosmos DB, PostgreSQL Flexible Server, Redis Cache, MySQL, MariaDB   |
-| **Networking**      | Application Gateway, Azure Firewall, Load Balancer, VPN Gateway, Private Link, DNS |
-| **Storage**         | Blob / File / Queue / Table Storage, Managed Disks, NetApp Files, Data Box         |
-| **Security**        | Key Vault, Defender for Cloud, Purview, Confidential Ledger, HSMs                  |
-| **Monitoring**      | Azure Monitor, Application Insights, Log Analytics                                 |
-| **Management**      | Sentinel, Automation, Site Recovery, Azure Arc, Migrate, Cost Management           |
-| **Integration**     | API Management, Service Bus, Logic Apps, Event Grid                                |
-| **Analytics**       | Synapse Analytics, Data Factory, Databricks, Data Explorer, HDInsight, Fabric      |
-| **AI + ML**         | Azure OpenAI, Azure ML, AI Services, Bot Service, Foundry Models                   |
-| **IoT**             | IoT Hub, IoT Central, Event Hubs, Digital Twins, Azure Maps                        |
-| **Developer Tools** | App Configuration, DevTest Labs, Dev Box, Load Testing, Grafana                    |
-| **Identity**        | Entra ID, Entra Domain Services, Azure AD B2C, External Identities                 |
-| **Migration**       | Database Migration Service, Azure Migrate                                          |
-| **Web**             | Azure AI Search, Static Web Apps, Spring Apps                                      |
-| **Communication**   | ACS Voice, SMS, Email, Phone Numbers, Packet Core                                  |
-| **Specialist**      | Azure Quantum, Remote Rendering, FHIR API, Copilot Studio, Stack Edge              |
-
-## Installation
-
-### Via skills.sh (any agent)
+## Install
 
 ```bash
 npx skills add ahmadabdalla/azure-cost-calculator-skill
 ```
 
-### Via agent chat
-
-Some agents support installing skills directly from the chat interface:
-
-```
-install skill ahmadabdalla/azure-cost-calculator-skill
-```
-
-Refer to your agent's documentation for the exact install command syntax.
-
-### Manual install
-
-Point your agent's configuration to the skill entry point at `skills/azure-cost-calculator/SKILL.md` in this repository. For example, clone the repo and add the path to your agent's skill or instruction configuration.
+Or manually point your agent's config to `skills/azure-cost-calculator/SKILL.md` in this repo.
 
 ## Usage
 
-Once installed, just ask your AI agent about Azure costs in natural language. The skill automatically activates when it detects pricing-related questions.
-
-### Example prompts
+Ask about Azure costs in natural language. The skill activates automatically.
 
 ```
 How much does a D4s v5 VM cost per month in East US?
-```
-
-```
 Compare App Service pricing tiers for a production web app
-```
-
-```
-Estimate the monthly cost of a Standard_B2s VM with a P30 managed disk in Australia East in AUD
-```
-
-```
+Estimate a Standard_B2s VM with a P30 managed disk in Australia East in AUD
 What's the cost of a General Purpose SQL Database with 4 vCores in West Europe in EUR?
-```
-
-```
-Budget a Kubernetes cluster with 3 D4s v5 nodes in Canada Central
-```
-
-```
 How much would Azure Cosmos DB with 1000 RU/s and 100 GB storage cost?
 ```
 
-### Sample interaction
+## How It Works
 
-**You:** _How much does a Standard_D4s_v5 VM cost per month in East US?_
+The skill uses service reference files as an index. Each file contains exact API filter values, cost formulas, and traps. The agent locates the right file, runs `Get-AzurePricing.ps1` against the live API, and presents a structured estimate.
 
-**Agent:** Queries the live Azure Retail Prices API and returns:
-
-> **Azure VM Cost Estimate — Standard_D4s_v5 (East US)**
->
-> | Item         | Value           |
-> | ------------ | --------------- |
-> | SKU          | Standard_D4s_v5 |
-> | Region       | eastus          |
-> | OS           | Linux           |
-> | Unit Price   | $0.192 /hour    |
-> | Monthly Cost | **$140.16**     |
->
-> **Assumptions:** Pay-as-you-go pricing, Linux OS, 730 hours/month, no reserved instances.
-
-## Architecture
+- **Deterministic** — same query → same API call → same price. All values from the live API, nothing hardcoded.
+- **Token-efficient** — only SKILL.md and shared.md load on every query. Service files load on demand. Batch mode (3+ services) reads only the first 45 lines per file.
+- **Multi-currency, all regions** — supports USD, AUD, EUR, GBP, JPY, CAD, INR, etc. Works with any Azure region.
 
 ```mermaid
 flowchart LR
     A[User Query] --> B[AI Agent]
     B --> C[SKILL.md]
-    C --> D{Locate Service}
-    D -->|file search| E["services/**/*.md"]
-    D -->|alias index| S["shared.md\n(lightweight)"]
-    D -->|full routing| R["service-routing.md\n(160+ services)"]
-    D -->|not found| F[Explore-AzurePricing.ps1]
-    S --> E
-    R --> E
-    E -->|"≤2 services: full read"| G1["Full Service File"]
-    E -->|"3+ services: lines 1-45"| G2["Partial Read\n(batch mode)"]
-    G1 --> H[Get-AzurePricing.ps1]
-    G2 --> H
-    H --> I[Azure Retail Prices API]
-    I --> H
-    H --> B
-    B --> J[Cost Estimate]
+    C --> D[Service Reference File]
+    D --> E[Get-AzurePricing.ps1]
+    E --> F[Azure Retail Prices API]
+    F --> E
+    E --> B
+    B --> G[Cost Estimate]
 
-    P["pitfalls.md"] -.->|on error| H
-    RI["reserved-instances.md"] -.->|if RI requested| H
-    RG["regions-and-currencies.md"] -.->|non-USD/eastus| H
+    P[pitfalls.md] -.->|on error| E
+    RI[reserved-instances.md] -.->|if RI| E
+    RG[regions-and-currencies.md] -.->|non-USD/eastus| E
 ```
 
-References are loaded on demand — only `SKILL.md` and `shared.md` load on every query. All other references load conditionally, keeping token consumption low for multi-service estimates.
+References load on demand — keeping token consumption low even for 10+ service estimates.
 
-## How It Works
+## Supported Services
 
-The skill uses the **filesystem as an index** — each supported Azure service has a dedicated reference file under `skills/azure-cost-calculator/references/services/` organized into 18 categories. These files contain the exact API filter values, cost formulas, and known traps for each service.
-
-1. **Identifies** the Azure resource type(s) from your question
-2. **Locates** the matching service reference file via file search, the [common alias index](skills/azure-cost-calculator/references/shared.md) (~40 most-searched services), or the [full routing map](skills/azure-cost-calculator/references/service-routing.md) (160+ services)
-3. **Reads** the service file — in full for 1–2 services, or lines 1–45 only in **batch estimation mode** (3+ services) for token efficiency
-4. **Runs** `Get-AzurePricing.ps1` which calls the [Azure Retail Prices REST API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices)
-5. **Presents** a structured estimate with unit price, monthly cost, and stated assumptions
-
-### Token-efficient design
-
-The skill is designed for complex multi-service estimates (10–15+ services) without exhausting the agent's context window:
-
-- **Lazy reference loading** — only `SKILL.md` and `shared.md` load on every query. Troubleshooting ([pitfalls.md](skills/azure-cost-calculator/references/pitfalls.md)), RI pricing ([reserved-instances.md](skills/azure-cost-calculator/references/reserved-instances.md)), region/currency info ([regions-and-currencies.md](skills/azure-cost-calculator/references/regions-and-currencies.md)), and the full routing map ([service-routing.md](skills/azure-cost-calculator/references/service-routing.md)) load only when needed.
-- **Batch estimation mode** — for 3+ services, the agent reads only the first 45 lines of each service file (metadata + primary query pattern), reducing per-service token cost by ~65%.
-- **Alias-first routing** — a compact alias index in `shared.md` resolves common service names without loading the full 140+ service routing map.
-
-For services **not yet documented**, `Explore-AzurePricing.ps1` discovers available filter values directly from the API.
-
-All prices come directly from Microsoft's public API — no hardcoded values.
-
-## Features
-
-- **Live pricing** — always queries the Azure Retail Prices API at runtime
-- **Multi-currency** — supports USD, AUD, EUR, GBP, JPY, CAD, INR, and more
-- **All regions** — works with any Azure region
-- **Comparison mode** — compare SKUs, tiers, or regions side-by-side
-- **Transparent assumptions** — every estimate states region, OS, commitment type, and instance count
-- **Exploration script** — includes `Explore-AzurePricing.ps1` for discovering available SKUs and pricing options
+140+ Azure services are mapped across 18 categories (Compute, Databases, Networking, Storage, Security, Monitoring, Integration, AI + ML, and more). ~25+ services have full reference files with documented query patterns. For services without reference files, `Explore-AzurePricing.ps1` discovers filter values directly from the API.
 
 ## Prerequisites
 
-- **PowerShell 5.1+** (pre-installed on Windows; available on macOS/Linux via [PowerShell Core](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell))
-- **Internet access** to reach `https://prices.azure.com`
-- No Azure subscription or authentication required — the Retail Prices API is public
+- PowerShell 5.1+ (pre-installed on Windows; [install on macOS/Linux](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell))
+- Internet access to `https://prices.azure.com`
+- No Azure subscription or authentication required
 
 ## Contributing
 
-Contributions are welcome! If you'd like to add support for a new Azure service or improve an existing one:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. In short:
 
-1. Fork this repository
-2. Add or update the service reference in `skills/azure-cost-calculator/references/services/<category>/` using [TEMPLATE.md](skills/azure-cost-calculator/references/services/TEMPLATE.md) as a starting point
-3. **45-line rule**: ensure the first query pattern (most common configuration) appears within the first 45 lines — this is required for batch estimation mode
-4. Place the file in the category specified in [service-routing.md](skills/azure-cost-calculator/references/service-routing.md)
-5. If adding a new category, update the category index in [shared.md](skills/azure-cost-calculator/references/shared.md)
-6. Submit a pull request
+- Add service files under `skills/azure-cost-calculator/references/services/<category>/` using the [template](skills/azure-cost-calculator/references/services/TEMPLATE.md)
+- First query pattern must appear within lines 1–45 (required for batch mode)
+- Run the validation script before submitting: `pwsh skills/azure-cost-calculator/scripts/Validate-ServiceReference.ps1`
 
 ## License
 

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -46,6 +46,7 @@ Deterministic Azure cost estimation using the public Retail Prices API. Never gu
 5. **Ask before assuming** — if a required parameter is ambiguous or missing (tier, SKU, quantity, currency, node count, traffic volume), stop and ask the user before proceeding. Do not silently pick a default. The only exceptions are constants defined in service reference files (e.g., mandatory default CU counts) — those are pre-approved defaults.
 6. **Default output format is Json** — do not use Summary (invisible to agents)
 7. **Lazy-load service references** — only read files from `references/services/` that are directly required by the user's query. Never bulk-read all service files. Use the file-search workflow (Step 2) to locate the specific file(s). If the user asks about App Service and SQL Database, search for each and read only those files — not the other 20+.
+8. **Use `pwsh -File`, not `pwsh -Command`** — on Linux/macOS, bash strips OData quotes from inline commands. Always use `pwsh -File scripts/Get-AzurePricing.ps1 ...`.
 
 ## Universal Traps
 

--- a/skills/azure-cost-calculator/references/pitfalls.md
+++ b/skills/azure-cost-calculator/references/pitfalls.md
@@ -4,6 +4,12 @@
 
 Cross-cutting traps that apply across **all** services. These are API-level and script-level behaviours — not specific to any one resource type. For service-specific traps, see each service's reference file in `services/`.
 
+### Cross-Platform Shell Traps
+
+| Trap                                                  | Fix                                                                         |
+| ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Bash/zsh strips OData quotes from `pwsh -Command`** | Use `pwsh -File script.ps1 ...` instead. Scripts handle quoting internally. |
+
 ### API Query Traps
 
 | Trap                                                | Detail                                                                                                                                                                                                                                                                                                                                    | Fix                                                                                                                                                   |

--- a/skills/azure-cost-calculator/references/workflow.md
+++ b/skills/azure-cost-calculator/references/workflow.md
@@ -17,6 +17,10 @@ PowerShell script that queries the Azure Retail Prices REST API (no auth require
 - `-InstanceCount` — Number of instances, default 1
 - `-OutputFormat` — `Json` (default), `Table`, `Summary`
 
+### Cross-Platform Note
+
+> On Linux/macOS, always use `pwsh -File script.ps1 ...` — not `pwsh -Command '...'`. Bash strips OData quotes. See [pitfalls.md](pitfalls.md).
+
 ### Examples
 
 ```powershell


### PR DESCRIPTION
## Changes

### Cross-platform shell trap guidance
On Linux/macOS (including GitHub Actions runners), wrapping \pwsh -Command '...'\ in bash silently strips OData single quotes, causing \Invalid OData parameters supplied\ errors. This was discovered during CI testing.

Added minimal guidance across three files to prevent agents from falling into this trap:

- **SKILL.md** — new Critical Rule #8: \Use pwsh -File, not pwsh -Command\
- **pitfalls.md** — new Cross-Platform Shell Traps table (1 row, ~15 tokens)
- **workflow.md** — one-line cross-platform note before the Examples section

All additions are intentionally minimal to avoid inflating token cost.

### Simplified README
Reduced from **200 lines to ~70 lines** (~65% reduction):

- Replaced 18-row service category table with a single paragraph
- Consolidated 3 install methods into 1 command + 1-line fallback
- Merged Architecture + How It Works + Features into a single section with a simplified mermaid diagram
- Compressed 6 separate example prompts into one code block
- Slimmed Contributing from 6 steps to 3 bullets + link to CONTRIBUTING.md

### Determinism validation
Two independent sub-agents were given the same 3-tier architecture query (App Service + Container Apps + SQL Database). Both produced identical results: **\.01/month** with the same unit prices, queries, and assumptions.