### PR TITLE
Add Azure OpenAI service reference

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/openai.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai.md
@@ -24,12 +24,12 @@ aliases: [OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4]
 ```
 
 ```powershell
-# Step 2: Query a specific model — substitute discovered skuName values
+# Step 2: Query a specific model — use exact productName and skuName from discovery
 # Example: chat model input tokens, Global deployment, 10M tokens
 .\Get-AzurePricing.ps1 `
     -ServiceName 'Foundry Models' `
-    -ProductName '{Azure OpenAI GPT*}' `
-    -SkuName '{model} Inpt Glbl' `
+    -ProductName 'Azure OpenAI GPT5' `
+    -SkuName 'GPT 5 Mini Inpt Glbl' `
     -Quantity 10
 ```
 
@@ -46,9 +46,9 @@ aliases: [OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4]
 
 | Parameter     | How to determine                               | Stable pattern                                                      |
 | ------------- | ---------------------------------------------- | ------------------------------------------------------------------- |
-| `serviceName` | Always `Foundry Models`                        | `Foundry Models`                                                    |
-| `productName` | Model family — discover via Explore            | `Azure OpenAI GPT*`, `Azure OpenAI Embedding`, `Azure OpenAI Media` |
-| `skuName`     | `{model} {Inpt\|outpt\|inp\|out} {deployment}` | Deployment: `Glbl`, `DZone`/`Dz`/`DZ`, `regnl`                      |
+| `serviceName` | Always `Foundry Models`                        | `Foundry Models`                                                     |
+| `productName` | Model family — use exact value from discovery  | `Azure OpenAI GPT5`, `Azure OpenAI Embedding`, `Azure OpenAI Media`  |
+| `skuName`     | `{model} {Inpt/outpt/inp/out} {deployment}`   | Deployment: `Glbl`, `DZone`/`Dz`/`DZ`, `regnl`                      |
 | `meterName`   | skuName + ` 1M Tokens` or ` Tokens`            | Unit varies: `1M` (large models) or `1K` (small/embedding)          |
 
 ## SKU Naming Conventions


### PR DESCRIPTION
## Summary

- Adds service reference for Azure OpenAI Service at `services/ai-ml/openai.md` (closes #31)
- Uses **discovery-first pattern**: agents discover current model names via `Explore-AzurePricing.ps1` before querying, making the reference resilient to model generation changes (GPT-5 today → GPT-6 tomorrow)
- Documents stable SKU naming conventions (deployment types, direction tokens, batch/cached/codex prefixes) rather than hardcoding volatile model-specific meter names
- Key API finding: `serviceName` is `Foundry Models` (AI Foundry rebrand), NOT `Azure OpenAI Service`

### A/B Test Results (12-service AML platform, UK South, GBP)

| Metric | Agent A | Agent B |
|--------|---------|---------|
| Total cost | £7,379.72 | £7,368.10 |
| Variance | 0.16% | |
| Tool calls | 47 | 47 |
| Tokens | 54.9K | 56.3K |
| OpenAI match | 3/3 exact | 3/3 exact |

10/12 services exact match. Variance from VNet peering direction interpretation and Monitor alert free-tier handling — unrelated to the OpenAI reference.

## Test plan

- [x] `Validate-ServiceReference.ps1 -CheckAliasUniqueness` passes
- [x] First query pattern within lines 1–45
- [x] File under 100 lines (81 lines)
- [x] A/B tested with Sonnet 4.5 agents on regulated architecture scenario
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)