### PR TITLE
fix: remove stray markdown fencing from 3 service reference files

### DIFF
--- a/skills/azure-cost-calculator/references/services/containers/container-registry.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-registry.md
@@ -4,7 +4,6 @@ category: containers
 aliases: [ACR, container registry]
 ---
 
-````markdown
 # Container Registry (ACR)
 
 **Primary cost**: Registry unit (daily) + excess storage (per-GB/month)
@@ -61,4 +60,3 @@ Monthly = registryUnitPrice × 30 + storagePrice × max(0, totalGB - includedGB)
 - Premium tier is required for geo-replication, content trust, and private endpoints
 - Build tasks (ACR Tasks) have separate compute-based pricing not covered here
 - Networking: Premium supports private link; Basic/Standard are public only
-````

--- a/skills/azure-cost-calculator/references/services/networking/private-dns.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-dns.md
@@ -4,7 +4,6 @@ category: networking
 aliases: [private DNS, DNS zones]
 ---
 
-````markdown
 # Private DNS Zones
 
 **Primary cost**: Zone hosting (per-zone/month) + DNS queries
@@ -67,4 +66,3 @@ Total: $7.00/month (USD)
 - Private DNS zones are commonly paired with Private Endpoints (one zone per service type)
 - Typical private endpoint zones: `privatelink.database.windows.net`, `privatelink.blob.core.windows.net`, etc.
 - Query volume is usually very low — the zone hosting fee dominates for most deployments
-````

--- a/skills/azure-cost-calculator/references/services/networking/private-link.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-link.md
@@ -4,7 +4,6 @@ category: networking
 aliases: [private link, private endpoint, PL]
 ---
 
-````markdown
 # Private Link / Private Endpoints
 
 **Multiple meters**: Endpoint hours (per-endpoint) + data processed (ingress/egress per-GB)
@@ -64,4 +63,3 @@ Total: ~$22.90/month (USD)
 - Private endpoints are per-resource (e.g., one for SQL, one for Storage, one for Key Vault)
 - Data processing charges are typically negligible compared to endpoint hours for moderate usage
 - Each private endpoint consumes an IP address from the VNet subnet
-````


### PR DESCRIPTION
## Summary

Remove stray ````markdown`` / `````` fencing from 3 service reference files that was accidentally copied from TEMPLATE.md.

## Affected files

- `services/networking/private-link.md`
- `services/networking/private-dns.md`
- `services/containers/container-registry.md`

## What changed

Removed the opening ````markdown`` (line 7, after YAML frontmatter) and closing `````` (last line) in each file. No content changes — only the fencing wrappers were removed.

## Validation

- `Validate-ServiceReference.ps1` passes on all 3 files and all other service files
- Alias uniqueness check passes

Fixes #71