### PR TITLE
fix: correct inverted heading hierarchy across all service references

### DIFF
--- a/skills/azure-cost-calculator/references/services/TEMPLATE.md
+++ b/skills/azure-cost-calculator/references/services/TEMPLATE.md
@@ -108,7 +108,7 @@ aliases: [{ comma-separated common names, abbreviations, and synonyms }]
 
 ## Query Pattern
 
-# {Description of what this query returns}
+### {Description of what this query returns}
 
 ServiceName: {serviceName}
 SkuName: {skuName}

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
@@ -14,20 +14,20 @@ aliases: [Azure ML, AML, ML Workspace, Machine Learning Studio]
 
 ## Query Pattern
 
-# Managed online endpoint — e.g., NC4asT4 v3 GPU instance (2 endpoints)
+### Managed online endpoint — e.g., NC4asT4 v3 GPU instance (2 endpoints)
 
 ServiceName: Azure Machine Learning
 ProductName: Managed Model Hosting Service
 SkuName: NC4asT4 v3
 InstanceCount: 2
 
-# ML service surcharge — Standard GPU
+### ML service surcharge — Standard GPU
 
 ServiceName: Azure Machine Learning
 ProductName: Machine Learning service
 MeterName: Standard GPU Surcharge
 
-# Safety evaluation tokens (input) — 100K tokens
+### Safety evaluation tokens (input) — 100K tokens
 
 ServiceName: Azure Machine Learning
 ProductName: Machine Learning service

--- a/skills/azure-cost-calculator/references/services/ai-ml/openai.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai.md
@@ -18,20 +18,20 @@ aliases: [OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4]
 
 ## Query Pattern
 
-# Step 1: Discover current OpenAI models and SKU names
+### Step 1: Discover current OpenAI models and SKU names
 
 Use the explore script with SearchTerm Azure OpenAI and Top 20
 
-# Step 2: Query a specific model — use exact productName and skuName from discovery
+### Step 2: Query a specific model — use exact productName and skuName from discovery
 
-# Example: chat model input tokens, Global deployment, 10M tokens
+### Example: chat model input tokens, Global deployment, 10M tokens
 
 ServiceName: Foundry Models
 ProductName: Azure OpenAI GPT5
 SkuName: GPT 5 Mini Inpt Glbl
 Quantity: 10
 
-# Embeddings — substitute discovered embedding skuName, 50M tokens (50K × 1K)
+### Embeddings — substitute discovered embedding skuName, 50M tokens (50K × 1K)
 
 ServiceName: Foundry Models
 ProductName: Azure OpenAI Embedding

--- a/skills/azure-cost-calculator/references/services/analytics/data-factory.md
+++ b/skills/azure-cost-calculator/references/services/analytics/data-factory.md
@@ -14,7 +14,7 @@ aliases: [ADF, ETL, Data Pipeline]
 
 ## Query Pattern
 
-# v2 Cloud — orchestration activity runs (per 1K runs, use Quantity for monthly volume)
+### v2 Cloud — orchestration activity runs (per 1K runs, use Quantity for monthly volume)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2
@@ -22,7 +22,7 @@ SkuName: Cloud
 MeterName: Cloud Orchestration Activity Run
 Quantity: 10000
 
-# v2 Cloud — data movement hours (use InstanceCount for parallel copy units)
+### v2 Cloud — data movement hours (use InstanceCount for parallel copy units)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2
@@ -31,14 +31,14 @@ MeterName: Cloud Data Movement
 InstanceCount: 4
 HoursPerMonth: 160
 
-# v2 Data Flow — General Purpose vCores (per hour, min 8 vCores per cluster)
+### v2 Data Flow — General Purpose vCores (per hour, min 8 vCores per cluster)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2 Data Flow - General Purpose
 SkuName: vCore
 HoursPerMonth: 200
 
-# v2 Self Hosted — pipeline activity hours
+### v2 Self Hosted — pipeline activity hours
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2

--- a/skills/azure-cost-calculator/references/services/analytics/databricks.md
+++ b/skills/azure-cost-calculator/references/services/analytics/databricks.md
@@ -14,20 +14,20 @@ aliases: [DBX, Spark on Azure]
 
 ## Query Pattern
 
-# Premium Jobs Compute — e.g., 10 DBUs running full month
+### Premium Jobs Compute — e.g., 10 DBUs running full month
 
 ServiceName: Azure Databricks
 ProductName: Azure Databricks
 SkuName: Premium Jobs Compute
 Quantity: 10
 
-# Premium All-purpose Compute — interactive clusters
+### Premium All-purpose Compute — interactive clusters
 
 ServiceName: Azure Databricks
 ProductName: Azure Databricks
 SkuName: Premium All-purpose Compute
 
-# Premium Serverless SQL — serverless SQL warehouse
+### Premium Serverless SQL — serverless SQL warehouse
 
 ServiceName: Azure Databricks
 ProductName: Azure Databricks Regional

--- a/skills/azure-cost-calculator/references/services/compute/aks.md
+++ b/skills/azure-cost-calculator/references/services/compute/aks.md
@@ -12,19 +12,19 @@ aliases: [AKS, kubernetes, k8s]
 
 ## Query Pattern
 
-# AKS management fee — Standard tier (filter to Uptime SLA only)
+### AKS management fee — Standard tier (filter to Uptime SLA only)
 
 ServiceName: Azure Kubernetes Service
 SkuName: Standard
 MeterName: Standard Uptime SLA
 
-# AKS management fee — Standard LTS (only if user needs Long Term Support)
+### AKS management fee — Standard LTS (only if user needs Long Term Support)
 
 ServiceName: Azure Kubernetes Service
 SkuName: Standard
 MeterName: Standard Long Term Support
 
-# Node VMs - query as Virtual Machines
+### Node VMs - query as Virtual Machines
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5

--- a/skills/azure-cost-calculator/references/services/compute/app-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/app-service.md
@@ -10,13 +10,13 @@ aliases: [app service, web app, webapp]
 
 ## Query Pattern
 
-# Linux
+### Linux
 
 ServiceName: Azure App Service
 SkuName: P1 v3
 ProductName: Azure App Service Premium v3 Plan - Linux
 
-# Windows
+### Windows
 
 ServiceName: Azure App Service
 SkuName: P1 v3

--- a/skills/azure-cost-calculator/references/services/compute/batch.md
+++ b/skills/azure-cost-calculator/references/services/compute/batch.md
@@ -14,14 +14,14 @@ aliases: [HPC Batch, Batch Compute]
 
 ## Query Pattern
 
-# Dedicated pool nodes — price as Virtual Machines (e.g., 4-node D4s v5 pool)
+### Dedicated pool nodes — price as Virtual Machines (e.g., 4-node D4s v5 pool)
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5
 ProductName: Virtual Machines Dsv5 Series
 InstanceCount: 4
 
-# Spot pool nodes (significant discount, may be evicted)
+### Spot pool nodes (significant discount, may be evicted)
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5
@@ -29,7 +29,7 @@ ProductName: Virtual Machines Dsv5 Series
 SkuName: D4s v5 Spot
 InstanceCount: 4
 
-# Low Priority pool nodes (classic discount tier, may be evicted)
+### Low Priority pool nodes (classic discount tier, may be evicted)
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5

--- a/skills/azure-cost-calculator/references/services/compute/container-apps.md
+++ b/skills/azure-cost-calculator/references/services/compute/container-apps.md
@@ -12,7 +12,7 @@ aliases: [container apps, ACA]
 
 ## Query Pattern
 
-# $sku: 'Standard' (Consumption, per-second — UnitPrice shows $0.00) | 'Dedicated' (per-hour, prices correct) | 'Hybrid'
+### $sku: 'Standard' (Consumption, per-second — UnitPrice shows $0.00) | 'Dedicated' (per-hour, prices correct) | 'Hybrid'
 
 ServiceName: Azure Container Apps
 ProductName: Azure Container Apps

--- a/skills/azure-cost-calculator/references/services/compute/functions.md
+++ b/skills/azure-cost-calculator/references/services/compute/functions.md
@@ -13,13 +13,13 @@ aliases: [azure functions, serverless, function app]
 
 ## Query Pattern
 
-# Consumption plan meters
+### Consumption plan meters
 
 ServiceName: Functions
 SkuName: Standard
 ProductName: Functions
 
-# Premium plan meters
+### Premium plan meters
 
 ServiceName: Functions
 SkuName: Premium

--- a/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
+++ b/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
@@ -12,13 +12,13 @@ aliases: [VMs, virtual machine, VM]
 
 ## Query Pattern
 
-# Recommended: Filter to Linux standard only using ProductName
+### Recommended: Filter to Linux standard only using ProductName
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D2s_v5
 ProductName: Virtual Machines Dsv5 Series
 
-# Windows standard only
+### Windows standard only
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D2s_v5
@@ -54,7 +54,7 @@ Monthly = retailPrice × 730 hours × instanceCount
 
 ## Reserved Instance Pricing
 
-# RI for Linux D2s v5 (returns both 1-Year and 3-Year terms)
+### RI for Linux D2s v5 (returns both 1-Year and 3-Year terms)
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D2s_v5

--- a/skills/azure-cost-calculator/references/services/containers/container-instances.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-instances.md
@@ -25,7 +25,7 @@ aliases:
 
 ## Query Pattern
 
-# Standard Linux — vCPU and memory (most common)
+### Standard Linux — vCPU and memory (most common)
 
 ServiceName: Container Instances
 ProductName: Container Instances
@@ -37,20 +37,20 @@ ProductName: Container Instances
 SkuName: Standard
 MeterName: Standard Memory Duration
 
-# Windows surcharge — add to Linux cost above
+### Windows surcharge — add to Linux cost above
 
 ServiceName: Container Instances
 ProductName: Container Instances
 SkuName: Standard
 MeterName: Standard Windows Software Duration
 
-# Spot containers (up to 70% discount, may be evicted)
+### Spot containers (up to 70% discount, may be evicted)
 
 ServiceName: Container Instances
 ProductName: Container Instances
 SkuName: Standard Spot
 
-# GPU containers — substitute $gpu: K80, P100, V100
+### GPU containers — substitute $gpu: K80, P100, V100
 
 ServiceName: Container Instances
 ProductName: Container Instances with GPU

--- a/skills/azure-cost-calculator/references/services/containers/container-registry.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-registry.md
@@ -17,12 +17,12 @@ aliases: [ACR, container registry]
 
 Substitute `{Tier}` with `Basic`, `Standard`, or `Premium`:
 
-# {Tier} registry unit (daily cost)
+### {Tier} registry unit (daily cost)
 ServiceName: Container Registry
 ProductName: Container Registry
 MeterName: {Tier} Registry Unit
 
-# Data stored (excess beyond included quota)
+### Data stored (excess beyond included quota)
 ServiceName: Container Registry
 ProductName: Container Registry
 MeterName: Data Stored

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
@@ -12,18 +12,18 @@ aliases: [CosmosDB, Cosmos, documentdb]
 
 ## Query Pattern
 
-# Provisioned throughput (use Quantity for multiples of 100 RU/s)
+### Provisioned throughput (use Quantity for multiples of 100 RU/s)
 
-# Example: 400 RU/s = Quantity 4
+### Example: 400 RU/s = Quantity 4
 
 ServiceName: Azure Cosmos DB
 MeterName: 100 RU/s
 SkuName: RUs
 Quantity: 4
 
-# Autoscale provisioned throughput (use Quantity for multiples of 100 RU/s)
+### Autoscale provisioned throughput (use Quantity for multiples of 100 RU/s)
 
-# Example: 10,000 max RU/s = Quantity 100
+### Example: 10,000 max RU/s = Quantity 100
 
 ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB autoscale
@@ -31,7 +31,7 @@ MeterName: AP1 100 RUs
 SkuName: AP1
 Quantity: 100
 
-# Storage (transactional)
+### Storage (transactional)
 
 ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB

--- a/skills/azure-cost-calculator/references/services/databases/postgresql-flexible.md
+++ b/skills/azure-cost-calculator/references/services/databases/postgresql-flexible.md
@@ -12,14 +12,14 @@ aliases: [PostgreSQL, postgres, flexible server]
 
 ## Query Pattern
 
-# Compute cost (General Purpose, Ddsv5 series, 4 vCore)
+### Compute cost (General Purpose, Ddsv5 series, 4 vCore)
 
 ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute
 SkuName: 4 vCore
 MeterName: vCore
 
-# Storage cost
+### Storage cost
 
 ServiceName: Azure Database for PostgreSQL
 ProductName: Az DB for PostgreSQL Flexible Server Storage

--- a/skills/azure-cost-calculator/references/services/databases/redis-cache.md
+++ b/skills/azure-cost-calculator/references/services/databases/redis-cache.md
@@ -37,19 +37,19 @@ Format: `{tier_prefix}{size} Cache Instance`
 
 ### Recommended Query Pattern (with productName filter)
 
-# Basic C1
+### Basic C1
 
 ServiceName: Redis Cache
 ProductName: Azure Redis Cache Basic
 MeterName: C1 Cache
 
-# Standard C1
+### Standard C1
 
 ServiceName: Redis Cache
 ProductName: Azure Redis Cache Standard
 MeterName: C1 Cache Instance
 
-# Premium P1
+### Premium P1
 
 ServiceName: Redis Cache
 ProductName: Azure Redis Cache Premium
@@ -65,7 +65,7 @@ Monthly = retailPrice × 730 hours × shardCount × (1 + replicas)
 
 RIs available for **Premium only** (P1-P5). Returns both 1-Year and 3-Year terms. Divide `retailPrice` by 12 (1-Year) or 36 (3-Year) for monthly cost.
 
-# RI for Premium — substitute {Size} with P1-P5
+### RI for Premium — substitute {Size} with P1-P5
 
 ServiceName: Redis Cache
 MeterName: {Size} Cache Instance

--- a/skills/azure-cost-calculator/references/services/databases/sql-database.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-database.md
@@ -10,14 +10,14 @@ aliases: [SQL DB, Azure SQL, sql]
 
 ## Query Pattern
 
-# vCore compute (e.g., 2 vCore GP; swap productName for Business Critical)
+### vCore compute (e.g., 2 vCore GP; swap productName for Business Critical)
 
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Compute Gen5
 SkuName: 2 vCore
 MeterName: vCore
 
-# Storage — for BC: use '...Business Critical - Storage' + 'Business Critical Data Stored'
+### Storage — for BC: use '...Business Critical - Storage' + 'Business Critical Data Stored'
 
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Storage
@@ -53,9 +53,9 @@ Total = Compute + Storage (unitPrice reflects total for selected vCore count)
 
 ## Reserved Instance Pricing
 
-# RI compute only (swap productName for BC). Returns 1-Year + 3-Year terms.
+### RI compute only (swap productName for BC). Returns 1-Year + 3-Year terms.
 
-# Omit SkuName for RI — unitPrice is per-vCore; multiply by your vCore count.
+### Omit SkuName for RI — unitPrice is per-vCore; multiply by your vCore count.
 
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Compute Gen5

--- a/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
@@ -14,14 +14,14 @@ aliases: [SQL MI, Azure SQL MI, Managed Instance]
 
 ## Query Pattern
 
-# vCore compute (e.g., 8 vCore GP Gen5; swap productName for tier/series)
+### vCore compute (e.g., 8 vCore GP Gen5; swap productName for tier/series)
 
 ServiceName: SQL Managed Instance
 ProductName: SQL Managed Instance General Purpose - Compute Gen5
 SkuName: 8 vCore
 MeterName: vCore
 
-# Storage (General Purpose) — use Quantity for provisioned GB
+### Storage (General Purpose) — use Quantity for provisioned GB
 
 ServiceName: SQL Managed Instance
 ProductName: SQL Managed Instance General Purpose - Storage
@@ -66,9 +66,9 @@ Total = Monthly Compute + Monthly Storage
 
 ## Reserved Instance Pricing
 
-# RI compute (swap productName for BC). Returns 1-Year + 3-Year terms.
+### RI compute (swap productName for BC). Returns 1-Year + 3-Year terms.
 
-# Omit SkuName for RI — unitPrice is per-vCore; multiply by your vCore count.
+### Omit SkuName for RI — unitPrice is per-vCore; multiply by your vCore count.
 
 ServiceName: SQL Managed Instance
 ProductName: SQL Managed Instance General Purpose - Compute Gen5

--- a/skills/azure-cost-calculator/references/services/integration/api-management.md
+++ b/skills/azure-cost-calculator/references/services/integration/api-management.md
@@ -14,15 +14,15 @@ aliases: [APIM, API gateway, API management]
 
 ## Query Pattern
 
-# All tiers — substitute {Tier} from Meter Names table
+### All tiers — substitute {Tier} from Meter Names table
 
 ServiceName: API Management
 SkuName: {Tier}
 MeterName: {Tier} Unit
 
-# v2 secondary units: MeterName '{Tier} Secondary Unit'
+### v2 secondary units: MeterName '{Tier} Secondary Unit'
 
-# Self-hosted gateway (Std v2/Prem v2): MeterName '{Tier} Self-hosted Gateway'
+### Self-hosted gateway (Std v2/Prem v2): MeterName '{Tier} Self-hosted Gateway'
 
 ## Key Fields
 
@@ -53,9 +53,9 @@ MeterName: {Tier} Unit
 ## Cost Formula
 
 ```
-# Hourly tiers: Monthly = retailPrice × 730 × unitCount
-# Consumption:  Monthly = retailPrice × (apiCalls / 10,000)  [first 1M calls/month free]
-# Add-ons:      Monthly += componentPrice × 730 × count  (secondary units, gateways, workspace packs)
+### Hourly tiers: Monthly = retailPrice × 730 × unitCount
+### Consumption:  Monthly = retailPrice × (apiCalls / 10,000)  [first 1M calls/month free]
+### Add-ons:      Monthly += componentPrice × 730 × count  (secondary units, gateways, workspace packs)
 ```
 
 ## Common SKUs

--- a/skills/azure-cost-calculator/references/services/integration/logic-apps.md
+++ b/skills/azure-cost-calculator/references/services/integration/logic-apps.md
@@ -16,7 +16,7 @@ aliases: [Workflows, Logic App Standard/Consumption]
 
 ## Query Pattern
 
-# Consumption — standard connector actions (use Quantity for monthly volume)
+### Consumption — standard connector actions (use Quantity for monthly volume)
 
 ServiceName: Logic Apps
 ProductName: Logic Apps
@@ -24,7 +24,7 @@ SkuName: Consumption
 MeterName: Consumption Standard Connector Actions
 Quantity: 10000
 
-# Consumption — enterprise connector actions
+### Consumption — enterprise connector actions
 
 ServiceName: Logic Apps
 ProductName: Logic Apps
@@ -32,7 +32,7 @@ SkuName: Consumption
 MeterName: Consumption Enterprise Connector Actions
 Quantity: 5000
 
-# Standard — vCPU hours (per-vCPU, use InstanceCount for multiple vCPUs)
+### Standard — vCPU hours (per-vCPU, use InstanceCount for multiple vCPUs)
 
 ServiceName: Logic Apps
 ProductName: Logic Apps
@@ -40,21 +40,21 @@ SkuName: Standard
 MeterName: Standard vCPU Duration
 InstanceCount: 2
 
-# Standard — memory (per GiB-hour)
+### Standard — memory (per GiB-hour)
 
 ServiceName: Logic Apps
 ProductName: Logic Apps
 SkuName: Standard
 MeterName: Standard Memory Duration
 
-# Hybrid — on-premises vCPU hours
+### Hybrid — on-premises vCPU hours
 
 ServiceName: Logic Apps
 ProductName: Logic Apps
 SkuName: Hybrid
 MeterName: Hybrid vCPU Duration
 
-# Integration Account (add-on for B2B) — substitute tier: Basic, Standard, Premium
+### Integration Account (add-on for B2B) — substitute tier: Basic, Standard, Premium
 
 ServiceName: Logic Apps
 ProductName: Logic Apps Integration Account

--- a/skills/azure-cost-calculator/references/services/integration/service-bus.md
+++ b/skills/azure-cost-calculator/references/services/integration/service-bus.md
@@ -16,25 +16,25 @@ aliases: [service bus, messaging, queues, topics]
 
 ## Query Pattern
 
-# Basic tier — operations only (per 1M)
+### Basic tier — operations only (per 1M)
 
 ServiceName: Service Bus
 SkuName: Basic
 MeterName: Basic Messaging Operations
 
-# Standard tier — namespace base unit (hourly)
+### Standard tier — namespace base unit (hourly)
 
 ServiceName: Service Bus
 SkuName: Standard
 MeterName: Standard Base Unit
 
-# Standard tier — operations (per 1M, first 13M included)
+### Standard tier — operations (per 1M, first 13M included)
 
 ServiceName: Service Bus
 SkuName: Standard
 MeterName: Standard Messaging Operations
 
-# Premium — messaging unit (InstanceCount for multi-unit)
+### Premium — messaging unit (InstanceCount for multi-unit)
 
 ServiceName: Service Bus
 SkuName: Premium

--- a/skills/azure-cost-calculator/references/services/iot/event-grid.md
+++ b/skills/azure-cost-calculator/references/services/iot/event-grid.md
@@ -14,25 +14,25 @@ aliases: [Event Routing, Event-driven]
 
 ## Query Pattern
 
-# Standard operations — event delivery (per 100K), 10 units = 1M operations
+### Standard operations — event delivery (per 100K), 10 units = 1M operations
 
 ServiceName: Event Grid
 MeterName: Standard Operations
 Quantity: 10
 
-# Namespace topic event operations (per 1M events)
+### Namespace topic event operations (per 1M events)
 
 ServiceName: Event Grid
 MeterName: Standard Event Operations
 Quantity: 5
 
-# MQTT messaging operations (per 1M)
+### MQTT messaging operations (per 1M)
 
 ServiceName: Event Grid
 MeterName: Standard MQTT Operations
 Quantity: 5
 
-# MQTT throughput unit (hourly, for namespace topics)
+### MQTT throughput unit (hourly, for namespace topics)
 
 ServiceName: Event Grid
 MeterName: Standard Throughput Unit

--- a/skills/azure-cost-calculator/references/services/iot/event-hubs.md
+++ b/skills/azure-cost-calculator/references/services/iot/event-hubs.md
@@ -14,27 +14,27 @@ aliases: [Event Hubs, Kafka on Azure, Event Streaming]
 
 ## Query Pattern
 
-# Standard tier — throughput unit (base cost)
+### Standard tier — throughput unit (base cost)
 
 ServiceName: Event Hubs
 SkuName: Standard
 MeterName: Standard Throughput Unit
 
-# Standard tier — ingress events (per 1M events)
+### Standard tier — ingress events (per 1M events)
 
 ServiceName: Event Hubs
 SkuName: Standard
 MeterName: Standard Ingress Events
 Quantity: 10
 
-# Premium tier — 3 processing units (use InstanceCount for multi-unit)
+### Premium tier — 3 processing units (use InstanceCount for multi-unit)
 
 ServiceName: Event Hubs
 SkuName: Premium
 MeterName: Premium Processing Unit
 InstanceCount: 3
 
-# Dedicated tier — capacity unit
+### Dedicated tier — capacity unit
 
 ServiceName: Event Hubs
 SkuName: Dedicated

--- a/skills/azure-cost-calculator/references/services/iot/iot-hub.md
+++ b/skills/azure-cost-calculator/references/services/iot/iot-hub.md
@@ -14,26 +14,26 @@ aliases: [Device Messaging]
 
 ## Query Pattern
 
-# Standard S1 tier — per unit/month
+### Standard S1 tier — per unit/month
 
 ServiceName: IoT Hub
 ProductName: IoT Hub
 MeterName: S1 Unit
 
-# Standard S1 — 5 units (use InstanceCount for multi-unit)
+### Standard S1 — 5 units (use InstanceCount for multi-unit)
 
 ServiceName: IoT Hub
 ProductName: IoT Hub
 MeterName: S1 Unit
 InstanceCount: 5
 
-# Basic B1 tier
+### Basic B1 tier
 
 ServiceName: IoT Hub
 ProductName: IoT Hub
 MeterName: B1 Unit
 
-# IoT Hub Device Provisioning Service — 100K operations (Quantity in 1K units)
+### IoT Hub Device Provisioning Service — 100K operations (Quantity in 1K units)
 
 ServiceName: IoT Hub
 ProductName: IoT Hub Device Provisioning

--- a/skills/azure-cost-calculator/references/services/management/management-groups.md
+++ b/skills/azure-cost-calculator/references/services/management/management-groups.md
@@ -14,11 +14,11 @@ aliases: [Management Group, Azure Management Groups, Subscription Organization]
 
 ## Query Pattern
 
-# No pricing meters exist — included for validation only
-# Management Groups is a free governance service
+### No pricing meters exist — included for validation only
+### Management Groups is a free governance service
 ServiceName: Management Groups
 Quantity: 1
-# Expected: 0 results — this service has no retail meter
+### Expected: 0 results — this service has no retail meter
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/management/site-recovery.md
+++ b/skills/azure-cost-calculator/references/services/management/site-recovery.md
@@ -14,14 +14,14 @@ aliases: [ASR, Disaster Recovery, DR]
 
 ## Query Pattern
 
-# Azure-to-Azure replication — 10 protected VMs
+### Azure-to-Azure replication — 10 protected VMs
 
 ServiceName: Azure Site Recovery
 SkuName: Azure
 MeterName: VM Replicated to Azure
 InstanceCount: 10
 
-# System Center (on-premises VMM) replication — 5 protected VMs
+### System Center (on-premises VMM) replication — 5 protected VMs
 
 ServiceName: Azure Site Recovery
 SkuName: System Center

--- a/skills/azure-cost-calculator/references/services/monitoring/app-insights.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/app-insights.md
@@ -22,13 +22,13 @@ aliases:
 
 ## Query Pattern
 
-# Application Insights data ingestion (via Log Analytics workspace)
+### Application Insights data ingestion (via Log Analytics workspace)
 
 ServiceName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Analyzed
 
-# Application Insights data retention (via Log Analytics workspace)
+### Application Insights data retention (via Log Analytics workspace)
 
 ServiceName: Log Analytics
 SkuName: Analytics Logs

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -22,13 +22,13 @@ aliases:
 
 ## Query Pattern
 
-# Log Analytics — pay-as-you-go ingestion (per GB)
+### Log Analytics — pay-as-you-go ingestion (per GB)
 
 ServiceName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Analyzed
 
-# Log Analytics — data retention (beyond 31 days free)
+### Log Analytics — data retention (beyond 31 days free)
 
 ServiceName: Log Analytics
 SkuName: Analytics Logs
@@ -80,7 +80,7 @@ Monthly retention cost = retentionPrice × 295
 
 For 100+ GB/day, commitment tiers (100, 200, 300, 400, 500, 1000, 2000, 5000) save 15–30% vs pay-as-you-go (e.g., 100 GB/day ≈ 15%, 200 ≈ 20%, 500 ≈ 25%). Overage above the tier is billed at the same discounted effective rate, not PAYG — so slightly over-committing is safe.
 
-# Example: 100 GB/day commitment tier
+### Example: 100 GB/day commitment tier
 
 ServiceName: Azure Monitor
 SkuName: 100 GB Commitment Tier

--- a/skills/azure-cost-calculator/references/services/monitoring/monitor.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/monitor.md
@@ -14,7 +14,7 @@ aliases: [Azure Monitor Metrics, Metrics, Alerts, Diagnostics, Platform Metrics]
 
 ## Query Pattern
 
-# Azure Monitor — custom metrics
+### Azure Monitor — custom metrics
 
 ServiceName: Azure Monitor
 MeterName: Monitored Time Series

--- a/skills/azure-cost-calculator/references/services/networking/app-gateway.md
+++ b/skills/azure-cost-calculator/references/services/networking/app-gateway.md
@@ -13,37 +13,37 @@ aliases: [app gateway, application gateway, appgw]
 
 ## Query Pattern
 
-# WAF v2 — fixed cost (gateway hours)
+### WAF v2 — fixed cost (gateway hours)
 
 ServiceName: Application Gateway
 ProductName: Application Gateway WAF v2
 MeterName: Standard Fixed Cost
 
-# WAF v2 — capacity units
+### WAF v2 — capacity units
 
 ServiceName: Application Gateway
 ProductName: Application Gateway WAF v2
 MeterName: Standard Capacity Units
 
-# Standard v2 — fixed cost
+### Standard v2 — fixed cost
 
 ServiceName: Application Gateway
 ProductName: Application Gateway Standard v2
 MeterName: Standard Fixed Cost
 
-# Standard v2 — capacity units
+### Standard v2 — capacity units
 
 ServiceName: Application Gateway
 ProductName: Application Gateway Standard v2
 MeterName: Standard Capacity Units
 
-# Basic v2 — fixed cost
+### Basic v2 — fixed cost
 
 ServiceName: Application Gateway
 ProductName: Application Gateway Basic v2
 MeterName: Basic Fixed Cost
 
-# Basic v2 — capacity units
+### Basic v2 — capacity units
 
 ServiceName: Application Gateway
 ProductName: Application Gateway Basic v2

--- a/skills/azure-cost-calculator/references/services/networking/azure-firewall.md
+++ b/skills/azure-cost-calculator/references/services/networking/azure-firewall.md
@@ -15,14 +15,14 @@ aliases: [firewall]
 
 Substitute `{Tier}` with `Standard`, `Premium`, or `Basic` (see Meter Names table). Run **two queries per tier**:
 
-# {Tier} — fixed deployment cost
+### {Tier} — fixed deployment cost
 
 ServiceName: Azure Firewall
 ProductName: Azure Firewall
 SkuName: {Tier}
 MeterName: {Tier} Deployment
 
-# {Tier} — data processing
+### {Tier} — data processing
 
 ServiceName: Azure Firewall
 ProductName: Azure Firewall

--- a/skills/azure-cost-calculator/references/services/networking/content-delivery-network.md
+++ b/skills/azure-cost-calculator/references/services/networking/content-delivery-network.md
@@ -16,7 +16,7 @@ aliases: [CDN Classic, Azure CDN Classic, Content Delivery]
 
 ## Query Pattern
 
-# Standard Microsoft — data transfer (Zone 1, most common)
+### Standard Microsoft — data transfer (Zone 1, most common)
 
 ServiceName: Content Delivery Network
 ProductName: Azure CDN from Microsoft
@@ -24,7 +24,7 @@ SkuName: Standard
 MeterName: Standard Data Transfer
 Region: Zone 1
 
-# Standard Microsoft — request pricing (per 1M requests)
+### Standard Microsoft — request pricing (per 1M requests)
 
 ServiceName: Content Delivery Network
 ProductName: Azure CDN from Microsoft
@@ -32,7 +32,7 @@ SkuName: Standard
 MeterName: Standard Requests
 Region: Zone 1
 
-# Premium Verizon — data transfer with volume estimate
+### Premium Verizon — data transfer with volume estimate
 
 ServiceName: Content Delivery Network
 ProductName: Azure CDN from Verizon

--- a/skills/azure-cost-calculator/references/services/networking/ddos-protection.md
+++ b/skills/azure-cost-calculator/references/services/networking/ddos-protection.md
@@ -12,9 +12,9 @@ aliases: [DDoS, DDoS protection]
 
 ## Query Pattern
 
-# Not applicable — DDoS Protection has no data in the Retail Prices API.
+### Not applicable — DDoS Protection has no data in the Retail Prices API.
 
-# Use the manual fallback table below.
+### Use the manual fallback table below.
 
 **Not applicable** — no script can query this service. Return the manual estimates below and note the limitation to the user.
 

--- a/skills/azure-cost-calculator/references/services/networking/express-route.md
+++ b/skills/azure-cost-calculator/references/services/networking/express-route.md
@@ -13,35 +13,35 @@ aliases: [ER, Dedicated Circuit]
 
 ## Query Pattern
 
-# Gateway — zone-redundant (most common) — use InstanceCount for multiple gateways
+### Gateway — zone-redundant (most common) — use InstanceCount for multiple gateways
 
 ServiceName: ExpressRoute
 ProductName: ExpressRoute Gateway
 MeterName: ErGw2AZ Gateway
 InstanceCount: 1
 
-# Circuit — Standard Metered 1 Gbps (flat monthly fee, Zone 1 = US/Europe)
+### Circuit — Standard Metered 1 Gbps (flat monthly fee, Zone 1 = US/Europe)
 
 ServiceName: ExpressRoute
 ProductName: ExpressRoute
 MeterName: Standard Metered Data 1 Gbps Circuit
 Region: Zone 1
 
-# Circuit — Standard Unlimited 1 Gbps
+### Circuit — Standard Unlimited 1 Gbps
 
 ServiceName: ExpressRoute
 ProductName: ExpressRoute
 MeterName: Standard Unlimited Data 1 Gbps Circuit
 Region: Zone 1
 
-# Circuit — Premium Metered 1 Gbps (adds global reach)
+### Circuit — Premium Metered 1 Gbps (adds global reach)
 
 ServiceName: ExpressRoute
 ProductName: ExpressRoute
 MeterName: Premium Metered Data 1 Gbps Circuit
 Region: Zone 1
 
-# Metered outbound data (per-GB egress on Metered circuits)
+### Metered outbound data (per-GB egress on Metered circuits)
 
 ServiceName: ExpressRoute
 ProductName: ExpressRoute

--- a/skills/azure-cost-calculator/references/services/networking/front-door.md
+++ b/skills/azure-cost-calculator/references/services/networking/front-door.md
@@ -13,7 +13,7 @@ aliases: [AFD, CDN, Azure CDN, Front Door Premium/Standard]
 
 ## Query Pattern
 
-# Standard profile — base fee (Zone 1 = US/Europe)
+### Standard profile — base fee (Zone 1 = US/Europe)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
@@ -21,7 +21,7 @@ SkuName: Standard
 MeterName: Standard Base Fees
 Region: Zone 1
 
-# Premium profile — base fee
+### Premium profile — base fee
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
@@ -29,7 +29,7 @@ SkuName: Premium
 MeterName: Premium Base Fees
 Region: Zone 1
 
-# Standard — data transfer out (use Quantity for estimated monthly GB)
+### Standard — data transfer out (use Quantity for estimated monthly GB)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
@@ -38,7 +38,7 @@ MeterName: Standard Data Transfer Out
 Quantity: 500
 Region: Zone 1
 
-# Standard — requests (per 10K)
+### Standard — requests (per 10K)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door

--- a/skills/azure-cost-calculator/references/services/networking/private-dns.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-dns.md
@@ -13,12 +13,12 @@ aliases: [private DNS, DNS zones]
 
 ## Query Pattern
 
-# Private Zone hosting cost
+### Private Zone hosting cost
 
 API: https://prices.azure.com/api/retail/prices?$filter=serviceName eq 'Azure DNS' and productName eq 'Azure DNS' and meterName eq 'Private Zone'
 Fields: meterName, unitPrice, unitOfMeasure, currencyCode, armRegionName
 
-# Private DNS queries
+### Private DNS queries
 
 API: https://prices.azure.com/api/retail/prices?$filter=serviceName eq 'Azure DNS' and productName eq 'Azure DNS' and meterName eq 'Private Queries'
 Fields: meterName, unitPrice, unitOfMeasure, currencyCode, armRegionName

--- a/skills/azure-cost-calculator/references/services/networking/private-link.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-link.md
@@ -12,17 +12,17 @@ aliases: [private link, private endpoint, PL]
 
 ## Query Pattern
 
-# Private Endpoint hourly cost
+### Private Endpoint hourly cost
 
 API: https://prices.azure.com/api/retail/prices?$filter=serviceName eq 'Virtual Network' and productName eq 'Virtual Network Private Link' and meterName eq 'Standard Private Endpoint'
 Fields: meterName, unitPrice, unitOfMeasure, currencyCode, armRegionName
 
-# Data Processed — Ingress
+### Data Processed — Ingress
 
 API: https://prices.azure.com/api/retail/prices?$filter=serviceName eq 'Virtual Network' and productName eq 'Virtual Network Private Link' and meterName eq 'Standard Data Processed - Ingress'
 Fields: meterName, unitPrice, unitOfMeasure, currencyCode, armRegionName
 
-# Data Processed — Egress
+### Data Processed — Egress
 
 API: https://prices.azure.com/api/retail/prices?$filter=serviceName eq 'Virtual Network' and productName eq 'Virtual Network Private Link' and meterName eq 'Standard Data Processed - Egress'
 Fields: meterName, unitPrice, unitOfMeasure, currencyCode, armRegionName

--- a/skills/azure-cost-calculator/references/services/security/key-vault.md
+++ b/skills/azure-cost-calculator/references/services/security/key-vault.md
@@ -12,21 +12,21 @@ aliases: [keyvault, KV, vault]
 
 ## Query Pattern
 
-# Standard tier — filter by productName to exclude Dedicated HSM
+### Standard tier — filter by productName to exclude Dedicated HSM
 
 ServiceName: Key Vault
 SkuName: Standard
 ProductName: Key Vault
 
-# Add MeterName 'Operations' or 'Advanced Key Operations' to isolate specific meters
+### Add MeterName 'Operations' or 'Advanced Key Operations' to isolate specific meters
 
-# Premium tier — HSM-backed keys
+### Premium tier — HSM-backed keys
 
 ServiceName: Key Vault
 SkuName: Premium
 ProductName: Key Vault
 
-# Add MeterName for specific Premium meters (see table below)
+### Add MeterName for specific Premium meters (see table below)
 
 ## Meter Names
 
@@ -48,7 +48,7 @@ ProductName: Key Vault
 
 ```
 Monthly = (operations/10000 × ops_price) + (advancedOps/10000 × advOps_price)
-# Premium: add per-key HSM charges (RSA 2048 + Advanced Key at applicable tier)
+### Premium: add per-key HSM charges (RSA 2048 + Advanced Key at applicable tier)
 ```
 
 ## Notes

--- a/skills/azure-cost-calculator/references/services/storage/backup.md
+++ b/skills/azure-cost-calculator/references/services/storage/backup.md
@@ -12,21 +12,21 @@ aliases: [Recovery Services Vault, MARS Agent, VM Backup]
 
 ## Query Pattern
 
-# Azure VM backup — 10 protected VMs
+### Azure VM backup — 10 protected VMs
 
 ServiceName: Backup
 SkuName: Azure VM
 MeterName: Azure VM Protected Instances
 InstanceCount: 10
 
-# Backup storage — 500 GB LRS
+### Backup storage — 500 GB LRS
 
 ServiceName: Backup
 SkuName: Standard
 MeterName: LRS Data Stored
 Quantity: 500
 
-# SQL Server in Azure VM backup
+### SQL Server in Azure VM backup
 
 ServiceName: Backup
 SkuName: SQL Server in Azure VM

--- a/skills/azure-cost-calculator/references/services/storage/managed-disks.md
+++ b/skills/azure-cost-calculator/references/services/storage/managed-disks.md
@@ -22,27 +22,27 @@ aliases: [managed disks, disks, disk storage]
 
 ## Query Pattern
 
-# Fixed-size disks — substitute {Prefix}, {Size}, {productName} from Disk Types table
+### Fixed-size disks — substitute {Prefix}, {Size}, {productName} from Disk Types table
 
 ServiceName: Storage
 SkuName: {Prefix}{Size} LRS
 ProductName: {productName}
 
-# Add MeterName {Prefix}{Size} LRS Disk to isolate disk cost from mount fee
+### Add MeterName {Prefix}{Size} LRS Disk to isolate disk cost from mount fee
 
-# ZRS: SkuName {Prefix}{Size} ZRS (Premium/Standard SSD only, ~50% more). HDD is LRS only.
+### ZRS: SkuName {Prefix}{Size} ZRS (Premium/Standard SSD only, ~50% more). HDD is LRS only.
 
-# Provisioned disks (Ultra / Premium SSD v2) — query each meter separately:
+### Provisioned disks (Ultra / Premium SSD v2) — query each meter separately:
 
-# MeterName {sku} LRS Provisioned Capacity
+### MeterName {sku} LRS Provisioned Capacity
 
-# MeterName {sku} LRS Provisioned IOPS
+### MeterName {sku} LRS Provisioned IOPS
 
-# MeterName {sku} LRS Provisioned Throughput (MBps)
+### MeterName {sku} LRS Provisioned Throughput (MBps)
 
-# Ultra: SkuName Ultra LRS, ProductName Ultra Disks
+### Ultra: SkuName Ultra LRS, ProductName Ultra Disks
 
-# PremiumV2: SkuName Premium LRS, ProductName Azure Premium SSD v2 (includes 3K IOPS + 125 MBps free)
+### PremiumV2: SkuName Premium LRS, ProductName Azure Premium SSD v2 (includes 3K IOPS + 125 MBps free)
 
 > Standard SSD/HDD return an additional `Disk Operations` meter (per 10K IO). Premium SSD does NOT — IOPS included in price.
 

--- a/skills/azure-cost-calculator/references/services/storage/storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage.md
@@ -17,14 +17,14 @@ aliases:
 
 Template: `ServiceName: Storage`, `SkuName: <Tier> <Redundancy>`, `ProductName: <see Product Names>`, `MeterName: <see Meter Names>`
 
-# LRS/GRS storage (productName: Blob Storage)
+### LRS/GRS storage (productName: Blob Storage)
 
 ServiceName: Storage
 SkuName: Hot LRS
 ProductName: Blob Storage
 MeterName: Hot LRS Data Stored
 
-# ZRS/GZRS storage (productName: General Block Blob v2)
+### ZRS/GZRS storage (productName: General Block Blob v2)
 
 ServiceName: Storage
 SkuName: Hot ZRS

--- a/skills/azure-cost-calculator/references/services/web/cognitive-search.md
+++ b/skills/azure-cost-calculator/references/services/web/cognitive-search.md
@@ -14,20 +14,20 @@ aliases: [Azure AI Search, Search Service, Full-text Search]
 
 ## Query Pattern
 
-# Standard S1 — 1 search unit (swap SkuName/MeterName for other tiers)
+### Standard S1 — 1 search unit (swap SkuName/MeterName for other tiers)
 
 ServiceName: Azure Cognitive Search
 SkuName: Standard S1
 MeterName: Standard S1 Unit
 
-# Standard S1 — 3 search units (use InstanceCount for multi-SU deployments)
+### Standard S1 — 3 search units (use InstanceCount for multi-SU deployments)
 
 ServiceName: Azure Cognitive Search
 SkuName: Standard S1
 MeterName: Standard S1 Unit
 InstanceCount: 3
 
-# Semantic Ranker add-on — use Quantity 30 (billed per day, not per hour)
+### Semantic Ranker add-on — use Quantity 30 (billed per day, not per hour)
 
 ServiceName: Azure Cognitive Search
 SkuName: Semantic Ranker

--- a/skills/azure-cost-calculator/references/services/web/static-web-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/static-web-apps.md
@@ -16,14 +16,14 @@ aliases: [SWA, JAMstack]
 
 ## Query Pattern
 
-# Standard plan — per-app monthly fee (use Region eastus2; eastus has no data)
+### Standard plan — per-app monthly fee (use Region eastus2; eastus has no data)
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps
 MeterName: Standard App
 Region: eastus2
 
-# Bandwidth — pass Quantity with total GB to see per-tier unit prices
+### Bandwidth — pass Quantity with total GB to see per-tier unit prices
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps
@@ -33,7 +33,7 @@ Region: eastus2
 
 > **Trap (Bandwidth tiered pricing)**: The script returns two rows — one at $0.00 (`tierMinimumUnits=0`, first 100 GB) and one at $0.20 (`tierMinimumUnits=100`, overage). The script multiplies `Quantity` × `unitPrice` per row without subtracting the free tier. Ignore `totalMonthlyCost` — manually calculate overage: `max(0, totalGB - 100) × overage_retailPrice`.
 
-# Azure Front Door add-on (enterprise-grade edge, hourly)
+### Azure Front Door add-on (enterprise-grade edge, hourly)
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps


### PR DESCRIPTION
## Problem

Service reference files use `# ` (H1) headers for query pattern labels, cost formula sub-items, and other sub-entries that appear **inside** `## ` (H2) sections. This creates an inverted heading hierarchy where H1 (the highest level) is nested under H2 (a lower level).

### Example (container-registry.md)

```markdown
## Query Pattern          <- H2

# {Tier} registry unit    <- H1 (should be H3)
ServiceName: Container Registry
...
```

The document title is correctly `# Container Registry (ACR)` (H1), but the query labels underneath `## Query Pattern` are also H1 — making them **peers of (or higher than) the document title** in the Markdown outline.

### Expected hierarchy

```
# Service Title           <- H1 (document title, exactly one per file)
  ## Query Pattern        <- H2 (section)
    ### Query label       <- H3 (sub-entry under section)
  ## Meter Names          <- H2
  ## Cost Formula         <- H2
    ### Formula variant   <- H3
  ## Notes                <- H2
```

## Scope

The TEMPLATE.md itself introduces the bug on line 111, and every service reference file derived from it inherits the issue.

### Audit results

| Metric | Count |
|--------|-------|
| **Files affected** | 43 (including TEMPLATE.md) |
| **Total misplaced H1 headers** | 145 |

### Breakdown by parent H2 section

| Section | Misplaced H1 count |
|---------|-----------|
| `## Query Pattern` | 131 |
| `## Reserved Instance Pricing` | 6 |
| `## Cost Formula` | 4 |
| `## Product Names` | 3 |
| `## Commitment Tiers` | 1 |

### All affected files

**ai-ml/** (2 files, 7 misplaced H1s)
- `machine-learning.md` — 3 under Query Pattern
- `openai.md` — 4 under Query Pattern

**analytics/** (2 files, 7 misplaced H1s)
- `data-factory.md` — 4 under Query Pattern
- `databricks.md` — 3 under Query Pattern

**compute/** (6 files, 14 misplaced H1s)
- `aks.md` — 3 under Query Pattern
- `app-service.md` — 2 under Query Pattern
- `batch.md` — 3 under Query Pattern
- `container-apps.md` — 1 under Query Pattern
- `functions.md` — 2 under Query Pattern
- `virtual-machines.md` — 2 under Query Pattern + 1 under Reserved Instance Pricing

**containers/** (2 files, 6 misplaced H1s)
- `container-instances.md` — 4 under Query Pattern
- `container-registry.md` — 2 under Query Pattern

**databases/** (5 files, 18 misplaced H1s)
- `cosmos-db.md` — 5 under Query Pattern
- `postgresql-flexible.md` — 2 under Query Pattern
- `redis-cache.md` — 3 under Product Names + 1 under Reserved Instance Pricing
- `sql-database.md` — 2 under Query Pattern + 2 under Reserved Instance Pricing
- `sql-managed-instance.md` — 2 under Query Pattern + 2 under Reserved Instance Pricing

**integration/** (3 files, 16 misplaced H1s)
- `api-management.md` — 3 under Query Pattern + 3 under Cost Formula
- `logic-apps.md` — 6 under Query Pattern
- `service-bus.md` — 4 under Query Pattern

**iot/** (3 files, 12 misplaced H1s)
- `event-grid.md` — 4 under Query Pattern
- `event-hubs.md` — 4 under Query Pattern
- `iot-hub.md` — 4 under Query Pattern

**management/** (2 files, 5 misplaced H1s)
- `management-groups.md` — 3 under Query Pattern
- `site-recovery.md` — 2 under Query Pattern

**monitoring/** (3 files, 5 misplaced H1s)
- `app-insights.md` — 2 under Query Pattern
- `log-analytics.md` — 2 under Query Pattern + 1 under Commitment Tiers
- `monitor.md` — 1 under Query Pattern

**networking/** (8 files, 23 misplaced H1s)
- `app-gateway.md` — 6 under Query Pattern
- `azure-firewall.md` — 2 under Query Pattern
- `content-delivery-network.md` — 3 under Query Pattern
- `ddos-protection.md` — 2 under Query Pattern
- `express-route.md` — 5 under Query Pattern
- `front-door.md` — 4 under Query Pattern
- `private-dns.md` — 2 under Query Pattern
- `private-link.md` — 3 under Query Pattern

**security/** (1 file, 5 misplaced H1s)
- `key-vault.md` — 4 under Query Pattern + 1 under Cost Formula

**storage/** (3 files, 14 misplaced H1s)
- `backup.md` — 3 under Query Pattern
- `managed-disks.md` — 9 under Query Pattern
- `storage.md` — 2 under Query Pattern

**web/** (2 files, 6 misplaced H1s)
- `cognitive-search.md` — 3 under Query Pattern
- `static-web-apps.md` — 3 under Query Pattern

**Not affected:** `load-balancer.md`, `defender-for-cloud.md` (no sub-level H1 headers)

## Root cause

`TEMPLATE.md` line 111 defines the query pattern label format as `# {Description}` (H1). All service files followed the template.

## Proposed fix

1. Update `TEMPLATE.md` line 111: change `# {Description...}` to `### {Description...}`
2. Update all 42 service reference files: change every non-title `# ` to `### `
3. Update `Validate-ServiceReference.ps1` if it checks heading levels
4. Verify the `## Query Pattern` -> `### label` -> `Key: Value` structure renders correctly and does not break any tooling that parses these files (e.g., batch estimation mode reading lines 1-45)

## Impact

- Markdown renderers (GitHub, VS Code preview) show these as page-level headings, breaking the document outline
- AI agents parsing these files may incorrectly interpret heading hierarchy
- Table of contents / outline views show a nonsensical structure
