### PR TITLE
fix: standardize query pattern conventions across 8 service references

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/openai.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai.md
@@ -18,25 +18,24 @@ aliases: [OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4]
 
 ## Query Pattern
 
-### Step 1: Discover current OpenAI models and SKU names
+### Discover available models (always run first — model names change frequently)
 
-Use the explore script with SearchTerm Azure OpenAI and Top 20
+SearchTerm: Azure OpenAI
+Top: 20
 
-### Step 2: Query a specific model — use exact productName and skuName from discovery
-
-### Example: chat model input tokens, Global deployment, 10M tokens
+### Chat / completion model — substitute discovered values
 
 ServiceName: Foundry Models
-ProductName: Azure OpenAI GPT5
-SkuName: GPT 5 Mini Inpt Glbl
-Quantity: 10
+ProductName: {productName from discovery}
+SkuName: {model} {direction} {deployment}
+Quantity: {tokenCount in units matching unitOfMeasure}
 
-### Embeddings — substitute discovered embedding skuName, 50M tokens (50K × 1K)
+### Embeddings — substitute discovered embedding skuName
 
 ServiceName: Foundry Models
 ProductName: Azure OpenAI Embedding
-SkuName: {embedding model} DZ
-Quantity: 50000
+SkuName: {embedding model} {deployment}
+Quantity: {tokenCount in units matching unitOfMeasure}
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/compute/aks.md
+++ b/skills/azure-cost-calculator/references/services/compute/aks.md
@@ -8,7 +8,7 @@ aliases: [AKS, kubernetes, k8s]
 
 **Primary cost**: AKS management fee + VM node costs (priced separately as VMs)
 
-> **Trap**: Querying with just `-SkuName 'Standard'` returns **two** meters: `Standard Uptime SLA` ($0.1429/hr) and `Standard Long Term Support` ($0.8573/hr). The `summary.totalMonthlyCost` sums both, inflating the estimate ~7× (~$730/mo instead of ~$104/mo). Always filter with `-MeterName 'Standard Uptime SLA'` unless the user specifically needs LTS Kubernetes version support.
+> **Trap**: Querying with just `-SkuName 'Standard'` returns **two** meters: `Standard Uptime SLA` ($0.10/hr) and `Standard Long Term Support` ($0.60/hr). The `summary.totalMonthlyCost` sums both, inflating the estimate ~7× (~$511/mo instead of ~$73/mo). Always filter with `-MeterName 'Standard Uptime SLA'` unless the user specifically needs LTS Kubernetes version support.
 
 ## Query Pattern
 
@@ -28,7 +28,6 @@ MeterName: Standard Long Term Support
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5
-Quantity: 1
 InstanceCount: 3
 
 ## Meter Names

--- a/skills/azure-cost-calculator/references/services/compute/container-apps.md
+++ b/skills/azure-cost-calculator/references/services/compute/container-apps.md
@@ -12,11 +12,11 @@ aliases: [container apps, ACA]
 
 ## Query Pattern
 
-### $sku: 'Standard' (Consumption, per-second — UnitPrice shows $0.00) | 'Dedicated' (per-hour, prices correct) | 'Hybrid'
+### {sku}: 'Standard' (Consumption, per-second — UnitPrice shows $0.00) | 'Dedicated' (per-hour, prices correct) | 'Hybrid'
 
 ServiceName: Azure Container Apps
 ProductName: Azure Container Apps
-SkuName: $sku
+SkuName: {sku}
 
 ## Known Consumption Plan Rates
 

--- a/skills/azure-cost-calculator/references/services/containers/container-instances.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-instances.md
@@ -50,11 +50,11 @@ ServiceName: Container Instances
 ProductName: Container Instances
 SkuName: Standard Spot
 
-### GPU containers — substitute $gpu: K80, P100, V100
+### GPU containers — substitute {gpu}: K80, P100, V100
 
 ServiceName: Container Instances
 ProductName: Container Instances with GPU
-SkuName: $gpu
+SkuName: {gpu}
 
 ## Meter Names
 
@@ -70,8 +70,8 @@ SkuName: $gpu
 | `K80 vGPU Duration`                           | `K80`                         | `100 Seconds`    | GPU meter              |
 | `P100 vGPU Duration`                          | `P100`                        | `100 Seconds`    | GPU meter              |
 | `V100 vGPU Duration`                          | `V100`                        | `100 Seconds`    | GPU meter              |
-| `$gpu vCPU Duration`                          | `$gpu`                        | `100 Seconds`    | GPU compute (per vCPU) |
-| `$gpu Memory Duration`                        | `$gpu`                        | `100 GB Seconds` | GPU memory (per GiB)   |
+| `vCPU Duration`                               | `{gpu}`                       | `100 Seconds`    | GPU compute (per vCPU) |
+| `Memory Duration`                             | `{gpu}`                       | `100 GB Seconds` | GPU memory (per GiB)   |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/security/defender-for-cloud.md
+++ b/skills/azure-cost-calculator/references/services/security/defender-for-cloud.md
@@ -4,7 +4,6 @@ category: security
 aliases: [defender, security center, MDC]
 ---
 
-```markdown
 # Microsoft Defender for Cloud
 
 **Multiple sub-products** — query each separately by its own productName/skuName/meterName.
@@ -19,9 +18,9 @@ aliases: [defender, security center, MDC]
 All sub-products use the same pattern — substitute values from the Meter Names table:
 
 ServiceName: Microsoft Defender for Cloud
-ProductName: <productName from table>
-SkuName: <skuName from table>
-MeterName: <meterName from table>
+ProductName: {productName}
+SkuName: {skuName}
+MeterName: {meterName}
 
 ## Meter Names
 
@@ -63,4 +62,3 @@ MeterName: <meterName from table>
 **Counting example**: Architecture with 2 VMs, 1 AKS (3 nodes), 2 Storage accounts, 1 PostgreSQL, 1 Key Vault, 1 Container Registry, 1 Load Balancer → billable = 2 + 3 + 2 + 1 = **8 resources** (Key Vault, ACR, LB excluded). Cost = `$5.11 × 8 = $40.88/mo`.
 
 **Formula**: `$5.11 × billableResourceCount` — count only eligible types above; use Azure Resource Graph to enumerate.
-```

--- a/skills/azure-cost-calculator/references/services/storage/storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage.md
@@ -15,7 +15,7 @@ aliases:
 
 ## Query Pattern
 
-Template: `ServiceName: Storage`, `SkuName: <Tier> <Redundancy>`, `ProductName: <see Product Names>`, `MeterName: <see Meter Names>`
+Template: `ServiceName: Storage`, `SkuName: {Tier} {Redundancy}`, `ProductName: {see Product Names}`, `MeterName: {see Meter Names}`
 
 ### LRS/GRS storage (productName: Blob Storage)
 
@@ -53,7 +53,7 @@ MeterName: Hot ZRS Data Stored
 | `Hot LRS Write Operations`  | `Hot LRS`     | `Blob Storage`          | `10K`         | Redundancy-specific              |
 | `Hot GZRS Write Operations` | `Hot GZRS`    | `General Block Blob v2` | `10K`         | Shared by GZRS & RA-GZRS         |
 
-Meter pattern: `<Tier> <Redundancy> Data Stored`, `<Tier> Read Operations`, `<Tier> <Redundancy> Write Operations`
+Meter pattern: `{Tier} {Redundancy} Data Stored`, `{Tier} Read Operations`, `{Tier} {Redundancy} Write Operations`
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/web/cognitive-search.md
+++ b/skills/azure-cost-calculator/references/services/web/cognitive-search.md
@@ -12,20 +12,16 @@ aliases: [Azure AI Search, Search Service, Full-text Search]
 
 > **Trap (CC variants)**: Each tier has a customer-controlled encryption variant (e.g., `Standard S1 CC`). These are separate SKUs with higher prices — do not confuse with the standard tier.
 
+> **Trap (Semantic Ranker MonthlyCost)**: The Semantic Ranker meter uses `1/Day` units. Without `Quantity 30`, the script's `MonthlyCost` reports only the **daily** price (~$16). Always use `Quantity 30` and ignore the script's `MonthlyCost` for this meter. For Semantic Ranker, always check `unitOfMeasure`. If `1/Day`, multiply `unitPrice × 30` for monthly cost.
+
 ## Query Pattern
 
-### Standard S1 — 1 search unit (swap SkuName/MeterName for other tiers)
+### {SkuName} tier — use InstanceCount for multi-SU deployments
 
 ServiceName: Azure Cognitive Search
-SkuName: Standard S1
-MeterName: Standard S1 Unit
-
-### Standard S1 — 3 search units (use InstanceCount for multi-SU deployments)
-
-ServiceName: Azure Cognitive Search
-SkuName: Standard S1
-MeterName: Standard S1 Unit
-InstanceCount: 3
+SkuName: {SkuName}
+MeterName: {SkuName} Unit
+InstanceCount: {searchUnits}
 
 ### Semantic Ranker add-on — use Quantity 30 (billed per day, not per hour)
 
@@ -33,10 +29,6 @@ ServiceName: Azure Cognitive Search
 SkuName: Semantic Ranker
 MeterName: Semantic Ranker Unit
 Quantity: 30
-
-> **Trap (Semantic Ranker MonthlyCost)**: The Semantic Ranker meter uses `1/Day` units. Without `Quantity 30`, the script's `MonthlyCost` reports only the **daily** price (~$16). Always use `Quantity 30` and ignore the script's `MonthlyCost` for this meter.
->
-> **Agent instruction**: For Semantic Ranker, always check `unitOfMeasure`. If `1/Day`, multiply `unitPrice × 30` for monthly cost. Never trust the script's `MonthlyCost` for daily-billed meters.
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/web/static-web-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/static-web-apps.md
@@ -14,6 +14,8 @@ aliases: [SWA, JAMstack]
 
 > **Trap (Inflated totals)**: Omitting `MeterName` returns app + AFD + bandwidth meters summed together (~$26.72). Always filter by `MeterName` to get individual component costs.
 
+> **Trap (Bandwidth tiered pricing)**: The script returns two rows — one at $0.00 (`tierMinimumUnits=0`, first 100 GB) and one at $0.20 (`tierMinimumUnits=100`, overage). The script multiplies `Quantity` × `unitPrice` per row without subtracting the free tier. Ignore `totalMonthlyCost` — manually calculate overage: `max(0, totalGB - 100) × overage_retailPrice`.
+
 ## Query Pattern
 
 ### Standard plan — per-app monthly fee (use Region eastus2; eastus has no data)
@@ -30,8 +32,6 @@ ProductName: Static Web Apps
 MeterName: Standard Bandwidth Usage
 Quantity: 500
 Region: eastus2
-
-> **Trap (Bandwidth tiered pricing)**: The script returns two rows — one at $0.00 (`tierMinimumUnits=0`, first 100 GB) and one at $0.20 (`tierMinimumUnits=100`, overage). The script multiplies `Quantity` × `unitPrice` per row without subtracting the free tier. Ignore `totalMonthlyCost` — manually calculate overage: `max(0, totalGB - 100) × overage_retailPrice`.
 
 ### Azure Front Door add-on (enterprise-grade edge, hourly)
 


### PR DESCRIPTION
## Summary

Phase 2 of #75 — Closes #77

Standardizes query pattern conventions across 8 service reference files to ensure determinism, token efficiency, and cross-template alignment.

## Changes by file

| File | Changes |
|------|---------|
| **container-apps.md** | `$sku` → `{sku}` in heading and SkuName |
| **container-instances.md** | `$gpu` → `{gpu}` in heading, SkuName, meter table; fixed GPU meter names — verified against live API |
| **storage.md** | `<Tier>/<Redundancy>` → `{Tier}/{Redundancy}` in template and meter pattern lines |
| **defender-for-cloud.md** | `<productName>/<skuName>/<meterName>` → `{productName}/{skuName}/{meterName}`; removed stray code fence wrapping entire body |
| **aks.md** | Removed redundant `Quantity: 1`; updated stale trap prices ($0.1429→$0.10/hr, $0.8573→$0.60/hr) — verified against live API |
| **openai.md** | Converted prose Step 1/Step 2 to declarative SearchTerm/Top discovery + parameterized templates; removed hardcoded model names for future-proofing |
| **static-web-apps.md** | Moved bandwidth tiered pricing trap above Query Pattern (was between pattern blocks) |
| **cognitive-search.md** | Moved Semantic Ranker trap above Query Pattern; merged duplicate agent instruction; replaced redundant dual S1 patterns with single parameterized `{SkuName}` template |

## Acceptance criteria (#77)

- [x] All placeholders use `{variable}` — no `$var` or `<var>` remaining
- [x] No `InstanceCount: 1` or `Quantity: 1` defaults (scripts default to 1)
- [x] `openai.md` uses declarative Key:Value format, not prose
- [x] No trap blockquotes between query pattern blocks

## Bonus fixes (found during API verification)

- **container-instances.md**: GPU meter names were factually wrong — API returns `vCPU Duration` and `Memory Duration`, not `$gpu vCPU Duration`/`$gpu Memory Duration`
- **aks.md**: Trap prices were stale ($0.1429 is now $0.10/hr, $0.8573 is now $0.60/hr)
- **defender-for-cloud.md**: Entire body was wrapped in a stray markdown code fence

## Validation

All 8 files pass `Validate-ServiceReference.ps1` — **120/120 checks passed**, including:
- YAML front matter, required sections, 45-line rule
- Trap format, scaling parameters, alias uniqueness
- No verified dates, no case-sensitive headers

## Impact

- **Net -12 lines** (30 insertions, 42 deletions) — more concise
- **Token efficiency**: Parameterized templates reduce per-query token cost
- **Determinism**: Consistent `{variable}` syntax eliminates ambiguity for agents
- **Future-proofing**: OpenAI patterns no longer hardcode model names that change frequently
