### PR TITLE
fix: phase 3 token reduction across 15 service references

### DIFF
--- a/skills/azure-cost-calculator/references/services/analytics/data-factory.md
+++ b/skills/azure-cost-calculator/references/services/analytics/data-factory.md
@@ -22,29 +22,26 @@ SkuName: Cloud
 MeterName: Cloud Orchestration Activity Run
 Quantity: 10000
 
-### v2 Cloud — data movement hours (use InstanceCount for parallel copy units)
+### v2 Cloud — data movement (per hour; multiply retailPrice × estimated monthly hours)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2
 SkuName: Cloud
 MeterName: Cloud Data Movement
 InstanceCount: 4
-HoursPerMonth: 160
 
-### v2 Data Flow — General Purpose vCores (per hour, min 8 vCores per cluster)
+### v2 Data Flow — General Purpose vCores (per hour; min 8 vCores per cluster)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2 Data Flow - General Purpose
 SkuName: vCore
-HoursPerMonth: 200
 
-### v2 Self Hosted — pipeline activity hours
+### v2 Self Hosted — pipeline activity (per hour)
 
 ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2
 SkuName: Self Hosted
 MeterName: Self Hosted Pipeline Activity
-HoursPerMonth: 160
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/compute/batch.md
+++ b/skills/azure-cost-calculator/references/services/compute/batch.md
@@ -14,37 +14,23 @@ aliases: [HPC Batch, Batch Compute]
 
 ## Query Pattern
 
-### Dedicated pool nodes — price as Virtual Machines (e.g., 4-node D4s v5 pool)
+### Pool nodes — price as Virtual Machines (e.g., 4-node D4s v5 pool)
 
 ServiceName: Virtual Machines
 ArmSkuName: Standard_D4s_v5
 ProductName: Virtual Machines Dsv5 Series
 InstanceCount: 4
 
-### Spot pool nodes (significant discount, may be evicted)
-
-ServiceName: Virtual Machines
-ArmSkuName: Standard_D4s_v5
-ProductName: Virtual Machines Dsv5 Series
-SkuName: D4s v5 Spot
-InstanceCount: 4
-
-### Low Priority pool nodes (classic discount tier, may be evicted)
-
-ServiceName: Virtual Machines
-ArmSkuName: Standard_D4s_v5
-ProductName: Virtual Machines Dsv5 Series
-SkuName: D4s v5 Low Priority
-InstanceCount: 4
+> For **Spot** nodes (up to 90% discount, may be evicted), add `SkuName: {ArmSkuName} Spot` (e.g., `Standard_D4s_v5 Spot`). For **Low Priority** nodes (up to 80% discount), add `SkuName: {ArmSkuName} Low Priority`.
 
 ## Key Fields
 
-| Parameter     | How to determine                               | Example values                                     |
-| ------------- | ---------------------------------------------- | -------------------------------------------------- |
-| `serviceName` | Always `Virtual Machines` (not `Azure Batch`)  | `Virtual Machines`                                 |
-| `armSkuName`  | VM size chosen for the Batch pool              | `Standard_D4s_v5`, `Standard_HB120rs_v3`           |
-| `productName` | Series + OS (Linux omits suffix, Windows adds) | `Virtual Machines Dsv5 Series`, `… Series Windows` |
-| `skuName`     | Size + pricing tier suffix                     | `D4s v5`, `D4s v5 Spot`, `D4s v5 Low Priority`     |
+| Parameter     | How to determine                               | Example values                                                   |
+| ------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| `serviceName` | Always `Virtual Machines` (not `Azure Batch`)  | `Virtual Machines`                                               |
+| `armSkuName`  | VM size chosen for the Batch pool              | `Standard_D4s_v5`, `Standard_HB120rs_v3`                         |
+| `productName` | Series + OS (Linux omits suffix, Windows adds) | `Virtual Machines Dsv5 Series`, `… Series Windows`               |
+| `skuName`     | Size + pricing tier suffix                     | `D4s v5`, `Standard_D4s_v5 Spot`, `Standard_D4s_v5 Low Priority` |
 
 ## Meter Names
 

--- a/skills/azure-cost-calculator/references/services/compute/container-apps.md
+++ b/skills/azure-cost-calculator/references/services/compute/container-apps.md
@@ -12,11 +12,23 @@ aliases: [container apps, ACA]
 
 ## Query Pattern
 
-### {sku}: 'Standard' (Consumption, per-second — UnitPrice shows $0.00) | 'Dedicated' (per-hour, prices correct) | 'Hybrid'
+### Consumption (Standard) — per-second billing (UnitPrice shows $0.00; use Known Rates table)
 
 ServiceName: Azure Container Apps
 ProductName: Azure Container Apps
-SkuName: {sku}
+SkuName: Standard
+
+### Dedicated — per-hour billing (prices correct in API)
+
+ServiceName: Azure Container Apps
+ProductName: Azure Container Apps
+SkuName: Dedicated
+
+### Hybrid — per-hour billing (Arc-enabled environments)
+
+ServiceName: Azure Container Apps
+ProductName: Azure Container Apps
+SkuName: Hybrid
 
 ## Known Consumption Plan Rates
 

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
@@ -12,18 +12,14 @@ aliases: [CosmosDB, Cosmos, documentdb]
 
 ## Query Pattern
 
-### Provisioned throughput (use Quantity for multiples of 100 RU/s)
-
-### Example: 400 RU/s = Quantity 4
+### Provisioned throughput (e.g., 400 RU/s → Quantity: 4)
 
 ServiceName: Azure Cosmos DB
 MeterName: 100 RU/s
 SkuName: RUs
 Quantity: 4
 
-### Autoscale provisioned throughput (use Quantity for multiples of 100 RU/s)
-
-### Example: 10,000 max RU/s = Quantity 100
+### Autoscale provisioned throughput (e.g., 10,000 max RU/s → Quantity: 100)
 
 ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB autoscale

--- a/skills/azure-cost-calculator/references/services/databases/sql-database.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-database.md
@@ -17,11 +17,13 @@ ProductName: SQL Database Single/Elastic Pool General Purpose - Compute Gen5
 SkuName: 2 vCore
 MeterName: vCore
 
-### Storage — for BC: use '...Business Critical - Storage' + 'Business Critical Data Stored'
+### Storage
 
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Storage
 MeterName: General Purpose Data Stored
+
+> For Business Critical: use `ProductName: SQL Database Single/Elastic Pool Business Critical - Storage` and `MeterName: Business Critical Data Stored`.
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/integration/api-management.md
+++ b/skills/azure-cost-calculator/references/services/integration/api-management.md
@@ -20,9 +20,17 @@ ServiceName: API Management
 SkuName: {Tier}
 MeterName: {Tier} Unit
 
-### v2 secondary units: MeterName '{Tier} Secondary Unit'
+### v2 secondary units (Standard v2 / Premium v2)
 
-### Self-hosted gateway (Std v2/Prem v2): MeterName '{Tier} Self-hosted Gateway'
+ServiceName: API Management
+SkuName: {Tier}
+MeterName: {Tier} Secondary Unit
+
+### Self-hosted gateway (Standard v2 / Premium v2)
+
+ServiceName: API Management
+SkuName: {Tier}
+MeterName: {Tier} Self-hosted Gateway
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/integration/logic-apps.md
+++ b/skills/azure-cost-calculator/references/services/integration/logic-apps.md
@@ -16,41 +16,33 @@ aliases: [Workflows, Logic App Standard/Consumption]
 
 ## Query Pattern
 
+All patterns below use `ServiceName: Logic Apps` and `ProductName: Logic Apps` unless noted otherwise.
+
 ### Consumption — standard connector actions (use Quantity for monthly volume)
 
-ServiceName: Logic Apps
-ProductName: Logic Apps
 SkuName: Consumption
 MeterName: Consumption Standard Connector Actions
 Quantity: 10000
 
 ### Consumption — enterprise connector actions
 
-ServiceName: Logic Apps
-ProductName: Logic Apps
 SkuName: Consumption
 MeterName: Consumption Enterprise Connector Actions
 Quantity: 5000
 
 ### Standard — vCPU hours (per-vCPU, use InstanceCount for multiple vCPUs)
 
-ServiceName: Logic Apps
-ProductName: Logic Apps
 SkuName: Standard
 MeterName: Standard vCPU Duration
 InstanceCount: 2
 
 ### Standard — memory (per GiB-hour)
 
-ServiceName: Logic Apps
-ProductName: Logic Apps
 SkuName: Standard
 MeterName: Standard Memory Duration
 
 ### Hybrid — on-premises vCPU hours
 
-ServiceName: Logic Apps
-ProductName: Logic Apps
 SkuName: Hybrid
 MeterName: Hybrid vCPU Duration
 

--- a/skills/azure-cost-calculator/references/services/integration/service-bus.md
+++ b/skills/azure-cost-calculator/references/services/integration/service-bus.md
@@ -16,27 +16,25 @@ aliases: [service bus, messaging, queues, topics]
 
 ## Query Pattern
 
+All patterns below use `ServiceName: Service Bus`.
+
 ### Basic tier — operations only (per 1M)
 
-ServiceName: Service Bus
 SkuName: Basic
 MeterName: Basic Messaging Operations
 
 ### Standard tier — namespace base unit (hourly)
 
-ServiceName: Service Bus
 SkuName: Standard
 MeterName: Standard Base Unit
 
 ### Standard tier — operations (per 1M, first 13M included)
 
-ServiceName: Service Bus
 SkuName: Standard
 MeterName: Standard Messaging Operations
 
 ### Premium — messaging unit (InstanceCount for multi-unit)
 
-ServiceName: Service Bus
 SkuName: Premium
 MeterName: Premium Messaging Unit
 InstanceCount: 2

--- a/skills/azure-cost-calculator/references/services/iot/event-hubs.md
+++ b/skills/azure-cost-calculator/references/services/iot/event-hubs.md
@@ -14,31 +14,31 @@ aliases: [Event Hubs, Kafka on Azure, Event Streaming]
 
 ## Query Pattern
 
+All patterns below use `ServiceName: Event Hubs`.
+
 ### Standard tier — throughput unit (base cost)
 
-ServiceName: Event Hubs
 SkuName: Standard
 MeterName: Standard Throughput Unit
 
 ### Standard tier — ingress events (per 1M events)
 
-ServiceName: Event Hubs
 SkuName: Standard
 MeterName: Standard Ingress Events
 Quantity: 10
 
 ### Premium tier — 3 processing units (use InstanceCount for multi-unit)
 
-ServiceName: Event Hubs
 SkuName: Premium
 MeterName: Premium Processing Unit
 InstanceCount: 3
 
 ### Dedicated tier — capacity unit
 
-ServiceName: Event Hubs
 SkuName: Dedicated
 MeterName: Dedicated Capacity Unit
+
+> For Basic tier, substitute `Basic` in SkuName and MeterName (e.g., `Basic Throughput Unit`, `Basic Ingress Events`).
 
 ## Meter Names
 

--- a/skills/azure-cost-calculator/references/services/iot/iot-hub.md
+++ b/skills/azure-cost-calculator/references/services/iot/iot-hub.md
@@ -14,23 +14,14 @@ aliases: [Device Messaging]
 
 ## Query Pattern
 
-### Standard S1 tier — per unit/month
+All patterns below use `ServiceName: IoT Hub` and `ProductName: IoT Hub` unless noted otherwise.
 
-ServiceName: IoT Hub
-ProductName: IoT Hub
+### Standard S1 tier — per unit/month (use InstanceCount: N for multi-unit)
+
 MeterName: S1 Unit
-
-### Standard S1 — 5 units (use InstanceCount for multi-unit)
-
-ServiceName: IoT Hub
-ProductName: IoT Hub
-MeterName: S1 Unit
-InstanceCount: 5
 
 ### Basic B1 tier
 
-ServiceName: IoT Hub
-ProductName: IoT Hub
 MeterName: B1 Unit
 
 ### IoT Hub Device Provisioning Service — 100K operations (Quantity in 1K units)

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -34,6 +34,14 @@ ServiceName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Retention
 
+### Commitment tier (100+ GB/day) — uses ServiceName: Azure Monitor
+
+ServiceName: Azure Monitor
+SkuName: 100 GB Commitment Tier
+MeterName: 100 GB Commitment Tier Capacity Reservation
+
+> **Trap**: Commitment tier meters have `unitOfMeasure = '1/Day'`. The script's `MonthlyCost` reports the **daily price**. **Always ignore** and manually calculate: `unitPrice × 30`.
+
 ## Key Fields
 
 | Parameter     | How to determine                                | Example values                                                  |
@@ -76,17 +84,9 @@ Retained GB = 5 × 59 = 295 GB
 Monthly retention cost = retentionPrice × 295
 ```
 
-## Commitment Tiers (optional, for high-volume)
+## Commitment Tier Details
 
 For 100+ GB/day, commitment tiers (100, 200, 300, 400, 500, 1000, 2000, 5000) save 15–30% vs pay-as-you-go (e.g., 100 GB/day ≈ 15%, 200 ≈ 20%, 500 ≈ 25%). Overage above the tier is billed at the same discounted effective rate, not PAYG — so slightly over-committing is safe.
-
-### Example: 100 GB/day commitment tier
-
-ServiceName: Azure Monitor
-SkuName: 100 GB Commitment Tier
-MeterName: 100 GB Commitment Tier Capacity Reservation
-
-> **Trap**: Commitment tier meters have `unitOfMeasure = '1/Day'`. The script's `MonthlyCost` reports the **daily price**. **Always ignore** and manually calculate: `unitPrice × 30`.
 
 ## Notes
 

--- a/skills/azure-cost-calculator/references/services/networking/app-gateway.md
+++ b/skills/azure-cost-calculator/references/services/networking/app-gateway.md
@@ -13,49 +13,27 @@ aliases: [app gateway, application gateway, appgw]
 
 ## Query Pattern
 
-### WAF v2 — fixed cost (gateway hours)
+Substitute `{Variant}` with `WAF v2`, `Standard v2`, or `Basic v2` (see Product Names table). WAF v2 and Standard v2 use `Standard` meter prefix; Basic v2 uses `Basic` meter prefix. Run **two queries per variant**:
+
+### {Variant} — fixed cost
 
 ServiceName: Application Gateway
-ProductName: Application Gateway WAF v2
-MeterName: Standard Fixed Cost
+ProductName: Application Gateway {Variant}
+MeterName: {MeterPrefix} Fixed Cost
 
-### WAF v2 — capacity units
-
-ServiceName: Application Gateway
-ProductName: Application Gateway WAF v2
-MeterName: Standard Capacity Units
-
-### Standard v2 — fixed cost
+### {Variant} — capacity units
 
 ServiceName: Application Gateway
-ProductName: Application Gateway Standard v2
-MeterName: Standard Fixed Cost
-
-### Standard v2 — capacity units
-
-ServiceName: Application Gateway
-ProductName: Application Gateway Standard v2
-MeterName: Standard Capacity Units
-
-### Basic v2 — fixed cost
-
-ServiceName: Application Gateway
-ProductName: Application Gateway Basic v2
-MeterName: Basic Fixed Cost
-
-### Basic v2 — capacity units
-
-ServiceName: Application Gateway
-ProductName: Application Gateway Basic v2
-MeterName: Basic Capacity Units
+ProductName: Application Gateway {Variant}
+MeterName: {MeterPrefix} Capacity Units
 
 ## Product Names
 
-| Variant     | productName                       | Fixed Cost Meter      | CU Meter                  |
-| ----------- | --------------------------------- | --------------------- | ------------------------- |
-| WAF v2      | `Application Gateway WAF v2`      | `Standard Fixed Cost` | `Standard Capacity Units` |
-| Standard v2 | `Application Gateway Standard v2` | `Standard Fixed Cost` | `Standard Capacity Units` |
-| Basic v2    | `Application Gateway Basic v2`    | `Basic Fixed Cost`    | `Basic Capacity Units`    |
+| Variant     | productName                       | MeterPrefix | Fixed Cost Meter      | CU Meter                  |
+| ----------- | --------------------------------- | ----------- | --------------------- | ------------------------- |
+| WAF v2      | `Application Gateway WAF v2`      | `Standard`  | `Standard Fixed Cost` | `Standard Capacity Units` |
+| Standard v2 | `Application Gateway Standard v2` | `Standard`  | `Standard Fixed Cost` | `Standard Capacity Units` |
+| Basic v2    | `Application Gateway Basic v2`    | `Basic`     | `Basic Fixed Cost`    | `Basic Capacity Units`    |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/networking/ddos-protection.md
+++ b/skills/azure-cost-calculator/references/services/networking/ddos-protection.md
@@ -12,11 +12,9 @@ aliases: [DDoS, DDoS protection]
 
 ## Query Pattern
 
-### Not applicable — DDoS Protection has no data in the Retail Prices API.
+### Not applicable — use manual fallback table below
 
-### Use the manual fallback table below.
-
-**Not applicable** — no script can query this service. Return the manual estimates below and note the limitation to the user.
+DDoS Protection has no data in the Retail Prices API. Return the manual estimates below and note the limitation to the user.
 
 ## Pricing (manual fallback)
 

--- a/skills/azure-cost-calculator/references/services/networking/front-door.md
+++ b/skills/azure-cost-calculator/references/services/networking/front-door.md
@@ -13,37 +13,31 @@ aliases: [AFD, CDN, Azure CDN, Front Door Premium/Standard]
 
 ## Query Pattern
 
-### Standard profile — base fee (Zone 1 = US/Europe)
+Substitute `{Tier}` with `Standard` or `Premium`.
+
+### {Tier} profile — base fee (Zone 1 = US/Europe)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
-SkuName: Standard
-MeterName: Standard Base Fees
+SkuName: {Tier}
+MeterName: {Tier} Base Fees
 Region: Zone 1
 
-### Premium profile — base fee
+### {Tier} — data transfer out (use Quantity for estimated monthly GB)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
-SkuName: Premium
-MeterName: Premium Base Fees
-Region: Zone 1
-
-### Standard — data transfer out (use Quantity for estimated monthly GB)
-
-ServiceName: Azure Front Door Service
-ProductName: Azure Front Door
-SkuName: Standard
-MeterName: Standard Data Transfer Out
+SkuName: {Tier}
+MeterName: {Tier} Data Transfer Out
 Quantity: 500
 Region: Zone 1
 
-### Standard — requests (per 10K)
+### {Tier} — requests (per 10K)
 
 ServiceName: Azure Front Door Service
 ProductName: Azure Front Door
-SkuName: Standard
-MeterName: Standard Requests
+SkuName: {Tier}
+MeterName: {Tier} Requests
 Region: Zone 1
 
 ## Meter Names

--- a/skills/azure-cost-calculator/references/services/security/key-vault.md
+++ b/skills/azure-cost-calculator/references/services/security/key-vault.md
@@ -17,16 +17,18 @@ aliases: [keyvault, KV, vault]
 ServiceName: Key Vault
 SkuName: Standard
 ProductName: Key Vault
+MeterName: Operations
 
-### Add MeterName 'Operations' or 'Advanced Key Operations' to isolate specific meters
+> For cryptographic operations, use `MeterName: Advanced Key Operations` instead.
 
 ### Premium tier — HSM-backed keys
 
 ServiceName: Key Vault
 SkuName: Premium
 ProductName: Key Vault
+MeterName: Operations
 
-### Add MeterName for specific Premium meters (see table below)
+> For HSM-protected keys, see the Meter Names table for Premium-specific meters.
 
 ## Meter Names
 


### PR DESCRIPTION
## Summary

Phase 3 of the service reference audit (#75): reduce token waste across 15 moderate-severity query pattern files.

Closes #78

## What changed

### Deduplication (shared-fields extraction)
| File | Technique | Token savings |
|------|-----------|--------------|
| logic-apps.md | Extract shared `ServiceName`/`ProductName` to shared-fields line | ~17% |
| service-bus.md | Extract shared `ServiceName` | ~12% |
| event-hubs.md | Extract shared `ServiceName` | ~10% |
| iot-hub.md | Deduplicate `ServiceName`/`ProductName`, remove duplicate S1 pattern | ~24% |

### Pattern consolidation & parameterization
| File | Technique | Token savings |
|------|-----------|--------------|
| batch.md | Consolidate Dedicated/Spot/LP → 1 base + variant note; **fix broken skuName** (`D4s v5 Spot` → `Standard_D4s_v5 Spot`) | ~40% |
| app-gateway.md | Collapse 6 → 2 patterns using `{Variant}` placeholder | ~42% |
| front-door.md | Collapse 4 → 3 patterns using `{Tier}` placeholder | ~21% |

### Non-API field removal
| File | Technique | Token savings |
|------|-----------|--------------|
| data-factory.md | Remove non-API `HoursPerMonth` key from 3 blocks | ~5% |

### Structural consolidation
| File | Technique | Change |
|------|-----------|--------|
| cosmos-db.md | Merge double headings into single with inline examples | -80 chars |
| log-analytics.md | Move commitment tier pattern into Query Pattern section | +240 chars (consolidation) |
| ddos-protection.md | Collapse triple-redundant not-applicable messaging | -67 chars |

### Consistency & determinism improvements
| File | Technique | Change |
|------|-----------|--------|
| container-apps.md | Replace overloaded `{sku}` heading with 3 explicit per-SKU patterns | +267 chars (determinism) |
| key-vault.md | Convert pseudo-pattern comment headings to proper `MeterName` fields | +110 chars |
| api-management.md | Expand inline one-liner variants into full Key: Value blocks | +290 chars |
| sql-database.md | Shorten overloaded storage heading, preserve BC info as blockquote | +71 chars |

## Bug fix

**batch.md**: The previous `skuName` values `D4s v5 Spot` and `D4s v5 Low Priority` returned **zero results** from the Azure Retail Prices API. Fixed to `Standard_D4s_v5 Spot` / `Standard_D4s_v5 Low Priority` (matching `armSkuName` format).

## Testing

- **Validation script**: 225/225 checks PASS across all 15 files
- **Alias uniqueness**: PASS — no collisions
- **API verification**: All query patterns verified against `prices.azure.com` for correct results
- **A/B testing**: Each sub-agent measured before/after char counts to confirm token efficiency
- **Net change**: 87 insertions, 133 deletions (-46 lines)
