### PR TITLE
Add Azure Database for MySQL service reference

### DIFF
--- a/skills/azure-cost-calculator/references/services/databases/mysql.md
+++ b/skills/azure-cost-calculator/references/services/databases/mysql.md
@@ -23,7 +23,7 @@ ServiceName: Azure Database for MySQL
 ProductName: Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute
 SkuName: vCore
 MeterName: vCore
-InstanceCount: 4    # vCore count
+InstanceCount: 4 # vCore count
 
 ### Storage (100 GB)
 
@@ -31,7 +31,7 @@ ServiceName: Azure Database for MySQL
 ProductName: Azure Database for MySQL Flexible Server Storage
 SkuName: Storage
 MeterName: Storage Data Stored
-Quantity: 100    # storage size in GB
+Quantity: 100 # storage size in GB
 
 ### Compute — Burstable (B4MS)
 
@@ -49,21 +49,21 @@ MeterName: 8 vCore
 
 ## Key Fields
 
-| Parameter | How to determine | Example values |
-|---|---|---|
-| `productName` | Tier + series (exact match) | See Product Names below |
-| `skuName` | Per-vCore series: `'vCore'`; Burstable: SKU name; Edsv5: `Standard_E*` | `'vCore'`, `'Standard_B4ms'` |
-| `meterName` | Per-vCore: `'vCore'`; Burstable: SKU code; Edsv5: `'N vCore'` | `'vCore'`, `'B4MS'`, `'8 vCore'` |
+| Parameter     | How to determine                                                       | Example values                   |
+| ------------- | ---------------------------------------------------------------------- | -------------------------------- |
+| `productName` | Tier + series (exact match)                                            | See Product Names below          |
+| `skuName`     | Per-vCore series: `'vCore'`; Burstable: SKU name; Edsv5: `Standard_E*` | `'vCore'`, `'Standard_B4ms'`     |
+| `meterName`   | Per-vCore: `'vCore'`; Burstable: SKU code; Edsv5: `'N vCore'`          | `'vCore'`, `'B4MS'`, `'8 vCore'` |
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-|---|---|---|---|
-| `vCore` | `vCore` | `1 Hour` | Per-vCore rate — multiply via InstanceCount (GP/BC/MO v5/v6) |
-| `B4MS` | `Standard_B4ms` | `1 Hour` | Fixed Burstable SKU — includes vCPU+RAM |
-| `8 vCore` | `Standard_E8d_v5` | `1 Hour` | Fixed MO Edsv5 size — includes vCPU+RAM |
-| `Storage Data Stored` | `Storage` | `1 GB/Month` | Data storage |
-| `Backup Storage LRS Data Stored` | `Backup Storage LRS` | `1 GB/Month` | Backup storage (LRS redundancy) |
+| Meter                            | skuName              | unitOfMeasure | Notes                                                        |
+| -------------------------------- | -------------------- | ------------- | ------------------------------------------------------------ |
+| `vCore`                          | `vCore`              | `1 Hour`      | Per-vCore rate — multiply via InstanceCount (GP/BC/MO v5/v6) |
+| `B4MS`                           | `Standard_B4ms`      | `1 Hour`      | Fixed Burstable SKU — includes vCPU+RAM                      |
+| `8 vCore`                        | `Standard_E8d_v5`    | `1 Hour`      | Fixed MO Edsv5 size — includes vCPU+RAM                      |
+| `Storage Data Stored`            | `Storage`            | `1 GB/Month`  | Data storage                                                 |
+| `Backup Storage LRS Data Stored` | `Backup Storage LRS` | `1 GB/Month`  | Backup storage (LRS redundancy)                              |
 
 ## Cost Formula
 
@@ -85,14 +85,14 @@ Total = Compute + Storage
 
 ## Product Names
 
-| Config | productName |
-|---|---|
-| GP, Ddsv5 | `Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute` |
-| GP, Dadsv5 | `Azure Database for MySQL Flexible Server General Purpose Dadsv5 Series Compute` |
-| GP, Dv3 | `Azure Database for MySQL Flexible Server General Purpose Dv3 Series Compute` |
-| MO, Edsv5 | `Azure Database for MySQL Flexible Server Memory Optimized Edsv5 Series Compute` |
-| MO, Eadsv5 | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
-| BC, Ev3 | `Azure Database for MySQL Flexible Server Business Critical Ev3 Series Compute` |
-| Burstable, BS | `Azure Database for MySQL Flexible Server Burstable BS Series Compute` |
-| Storage | `Azure Database for MySQL Flexible Server Storage` |
-| Backup | `Azure Database for MySQL Flexible Server Backup Storage` |
+| Config        | productName                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| GP, Ddsv5     | `Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute`   |
+| GP, Dadsv5    | `Azure Database for MySQL Flexible Server General Purpose Dadsv5 Series Compute`  |
+| GP, Dv3       | `Azure Database for MySQL Flexible Server General Purpose Dv3 Series Compute`     |
+| MO, Edsv5     | `Azure Database for MySQL Flexible Server Memory Optimized Edsv5 Series Compute`  |
+| MO, Eadsv5    | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
+| BC, Ev3       | `Azure Database for MySQL Flexible Server Business Critical Ev3 Series Compute`   |
+| Burstable, BS | `Azure Database for MySQL Flexible Server Burstable BS Series Compute`            |
+| Storage       | `Azure Database for MySQL Flexible Server Storage`                                |
+| Backup        | `Azure Database for MySQL Flexible Server Backup Storage`                         |


### PR DESCRIPTION
## Summary

Adds service reference file for **Azure Database for MySQL Flexible Server** (`databases/mysql.md`).

Closes #126

## What's included

- **Compute tiers**: Burstable (fixed SKU), General Purpose (per-vCore), Memory Optimized (per-vCore for v5/v6, per-size for Edsv5), Business Critical
- **Storage**: Separate billing under `Azure Database for MySQL Flexible Server Storage`
- **Backup**: LRS and ZRS options
- **Reserved Instances**: Available for GP/MO/BC tiers (not Burstable)
- **Product Names table**: 9 common product name lookups

## Traps documented

1. **Inflated totals**: ~80 meters across Single Server + all Flexible Server series
2. **Dual vCore meters**: Newer series return both `SkuName: 'vCore'` and `SkuName: '1 vCore'` (identical prices)
3. **RI MonthlyCost**: Script multiplies term price × 730 — must manually calculate `unitPrice ÷ 12` or `÷ 36`

## Validation

- ✅ All 27 checks pass (`Validate-ServiceReference.ps1 -CheckAliasUniqueness`)
- ✅ First query pattern at line 22 (within 45-line rule)
- ✅ 98 lines (under 100-line limit)
- ✅ InstanceCount and Quantity scaling demonstrated

## A/B Testing

Two independent Opus agents were given minimal context and asked to estimate MySQL costs using only the skill reference:

**Agent A** — GP Ddsv5, 8 vCores, 256 GB storage:
| Component | Calculation | Monthly |
|-----------|-------------|---------|
| Compute | \$0.0855 × 730 × 8 | \$499.32 |
| Storage | \$0.115 × 256 | \$29.44 |
| **Total** | | **\$528.76** |

**Agent B** — Burstable B2MS (64 GB) + MO Edsv5 16 vCore (512 GB):
| Component | Calculation | Monthly |
|-----------|-------------|---------|
| Dev Compute | \$0.136 × 730 | \$99.28 |
| Dev Storage | \$0.115 × 64 | \$7.36 |
| Prod Compute | \$1.89 × 730 | \$1,379.70 |
| Prod Storage | \$0.115 × 512 | \$58.88 |
| **Grand Total** | | **\$1,545.22** |

Both agents correctly identified the query patterns, used the right formulas, and produced accurate cost estimates.

## Note on aliases

The routing map lists `Flexible Server` as an alias for both MySQL and PostgreSQL. Dropped it from MySQL to pass alias uniqueness validation — the routing map may need a separate update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for Azure Database for MySQL Flexible Server cost calculation
  * Includes cost components, pricing structures, calculation patterns, and pricing considerations
  * Provides reference tables for meter names, configuration mappings, and cost formulas for various compute and storage options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->