### PR TITLE
Add VMSS coverage to Virtual Machines reference

### DIFF
--- a/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
+++ b/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
@@ -52,7 +52,7 @@ Monthly = retailPrice × 730 hours × instanceCount
 ## Notes
 
 - Use the explore script with ServiceName `Virtual Machines` and SearchTerm `{series}` to discover exact `productName` values
-- **VMSS**: Scale-set instances use the same `serviceName` and meters as standalone VMs. There is no orchestration fee — cost is `retailPrice × 730 × instanceCount`. Flexible and Uniform orchestration modes have no pricing difference.
+- **VMSS**: Scale-set instances use the same `serviceName` and VM compute meters as standalone VMs. There is no *additional* VMSS/orchestration meter — you still calculate **compute** as `retailPrice × 730 × instanceCount`, and price managed disks and any attached resources (load balancer, public IP, etc.) separately. Flexible and Uniform orchestration modes have no pricing difference.
 
 ## Azure Hybrid Benefit (AHUB)
 


### PR DESCRIPTION
## Summary

Adds Virtual Machine Scale Sets (VMSS) coverage to the existing Virtual Machines service reference. Closes #142.

## Changes

- **Aliases**: Added `VMSS`, `VM Scale Sets`, `scale set` to frontmatter (aligns with `service-routing.md` line 22)
- **VMSS Note**: Added a concise note confirming VMSS instances use the same `serviceName`/meters, no orchestration fee, and Flexible/Uniform modes have no pricing difference

## Why not a separate file?

API research confirmed VMSS has **zero dedicated meters** in the Azure Retail Prices API — all queries return under `serviceName eq 'Virtual Machines'` with identical per-hour rates. Creating a separate file would be a no-meter companion reference with no unique pricing data, adding maintenance burden for no value.

## Validation

- `Validate-ServiceReference.ps1` passes all 27 checks including alias uniqueness
- File is 89 lines (under 100-line limit)

## A/B Testing Results

Two independent agents were given identical VMSS architectures (e-commerce autoscaling + HPC Spot) and tasked with producing API queries using only the updated reference file:

| Metric | E-commerce Scenario | HPC Spot Scenario |
|--------|-------------------|-------------------|
| **Query determinism** | ✅ Both agents produced identical queries | ✅ Identical queries |
| **Reasoning steps** | A: 9, B: 8 | A: 8, B: 7 |
| **Assumptions needed** | A: 2, B: 1 | A: 3, B: 2 |
| **VMSS coverage rating** | Both: 3/5 | A: 2/5, B: 3/5 |

**Key finding**: The VMSS note provides sufficient guidance for agents to produce correct, deterministic queries. Identified gaps (autoscaling modeling, ephemeral disks, Spot query templates) are pre-existing VM reference limitations, not VMSS-specific issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Azure Virtual Machines documentation search aliases to include VMSS, VM Scale Sets, and "scale set" so related guidance is easier to find.
  * Minor metadata update for improved discoverability of VM-related topics across the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->