### PR TITLE
Add Azure Migrate service reference

### DIFF
--- a/skills/azure-cost-calculator/references/services/management/azure-migrate.md
+++ b/skills/azure-cost-calculator/references/services/management/azure-migrate.md
@@ -47,7 +47,7 @@ Migration project costs come from dependent services:
 ## Notes
 
 - Azure Migrate hub (discovery, assessment, business case) is **completely free**
-- Server replication uses Azure Site Recovery — first **180 days free** per instance, then standard ASR rates
+- Server replication uses Azure Site Recovery — first **180 days free** per instance (migration-specific benefit via Azure Migrate; standalone ASR for disaster recovery offers only 31 days free), then standard ASR rates
 - Database Migration Service Standard tier (offline) is **always free**; Premium tier (online) has vCore billing after 180 days
 - Storage consumed during replication and network egress are billed under their respective services regardless of free periods
 - Third-party ISV tools (Carbonite, Cloudamize, etc.) have separate vendor licensing outside Azure billing

--- a/skills/azure-cost-calculator/references/services/management/site-recovery.md
+++ b/skills/azure-cost-calculator/references/services/management/site-recovery.md
@@ -59,7 +59,7 @@ System Center target:  retailPrice (System Center SKU) × VM count
 
 ## Notes
 
-- First 31 days of protection for each new instance are free (not reflected in API)
+- First 31 days of protection for each new instance are free (not reflected in API). When ASR is used via Azure Migrate for server migration, a longer **180-day** free period applies — see the Azure Migrate reference
 - The ASR license fee is per-instance; VM size and disk count do not affect the rate
 - `Azure` SKU covers both Azure-to-Azure and on-premises-to-Azure scenarios
 - `System Center` SKU is for on-premises-to-on-premises replication via VMM


### PR DESCRIPTION
## Summary

Adds a new service reference for **Azure Migrate** (issue #140) at `management/azure-migrate.md`.

## Why this approach

Azure Migrate has **zero meters** in the Azure Retail Prices API — confirmed via 7 API queries across serviceName, productName, and meterName vectors, both regionally (eastus) and globally. The hub itself (discovery, assessment, business case) is completely free.

This follows the **no-meter service pattern** (like Management Groups and Entra ID) with `billingNeeds` pointing agents to the actual billing services:
- **Azure Site Recovery** — $25/VM/month for server replication (180-day free period)
- **Azure Database Migration Service** — Premium tier vCore billing (180-day free period); Standard tier is always free

## API Evidence

| Query | Results |
|---|---|
| `serviceName eq 'Azure Migrate'` (eastus) | 0 |
| `serviceName eq 'Azure Migrate'` (global) | 0 |
| `contains(productName, 'Migrate')` (eastus) | 0 |
| `contains(meterName, 'Migrate')` (eastus) | 0 |
| `serviceName eq 'Azure Site Recovery'` (eastus) | 2 meters |
| `serviceName eq 'Azure Database Migration Service'` (eastus) | 11 meters |

## Validation

All 27 checks passed:
```
pwsh tests/Validate-ServiceReference.ps1 -Path 'skills/azure-cost-calculator/references/services/management/azure-migrate.md' -CheckAliasUniqueness
RESULT: PASS - All checks passed
```

## A/B Determinism Testing

Two independent agents estimated costs for the same architectures using only this reference:

| Dimension | Arch 1: 50 VM Migration | Arch 2: 5 DB Online Migration |
|---|---|---|
| API query match | ✅ Identical | ⚠️ Minor filter variation |
| Free period logic | ✅ Identical | ✅ Identical |
| Context rating | A: 4/5, B: 4/5 | A: 3/5, B: 2/5 |
| Reasoning steps (Δ) | 1 | 1 |
| Assumptions needed | 6 each | 8 each |

Both agents correctly identified the 180-day free period, used `billingNeeds` to find dependent services, and deferred infrastructure costs to the appropriate service references. The DB migration edge case scored lower because DMS-specific details belong in a future DMS reference file.

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Azure Migrate pricing reference guide covering cost models, estimation guidance, query patterns showing no pricing meters for the hub, cost formulas separating hub vs dependent-service costs, known rates table, and guidance for estimating costs via dependent services.
  * Clarified free-period notes for Site Recovery: 31-day standard free trial and an extended 180-day free period when used via Azure Migrate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->