### PR TITLE
Add billable GB deduction formula with grant interaction to sentinel.md

### DIFF
--- a/skills/azure-cost-calculator/references/services/management/sentinel.md
+++ b/skills/azure-cost-calculator/references/services/management/sentinel.md
@@ -64,14 +64,22 @@ Quantity: 500
 
 ## Cost Formula
 
+### Billable GB (simplified pricing)
+
+```
+defender_free_GB = min(security_table_GB, serverCount × 0.5 × 30)   # Defender P2 (see defender-for-cloud.md)
+m365_free_GB    = min(m365_table_GB, userCount × 0.005 × 30)        # M365 E5; tables don't overlap with P2
+billableGB      = total_IsBillable_GB - defender_free_GB - m365_free_GB
+```
+
+> Grants are volume deductions (applied before tier pricing), for ingestion only — retention uses total physical ingestion (see `log-analytics.md`). P2 grant requires Defender auto-provisioned DCRs. No LA 5 GB/month free tier under simplified pricing.
+
 ```
 PAYG:       Monthly = payg_retailPrice × billableGB
-Commitment: Monthly = tier_retailPrice × 30 + (tier_retailPrice ÷ tierGB) × max(0, dailyGB - tierGB) × 30
+Commitment: Monthly = tier_retailPrice × 30 + (tier_retailPrice ÷ tierGB) × max(0, billableGB ÷ 30 - tierGB) × 30
 Basic Logs: Monthly = basic_retailPrice × queryGB
 Data Lake:  Monthly = storage_retailPrice × storedGB + ingestion_retailPrice × ingestedGB + query_retailPrice × queriedGB
 ```
-
-> For Defender for Cloud related free data grants, see `security/defender-for-cloud.md`.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Defines `billableGB` in `sentinel.md` Cost Formula — previously used but never computed. Agents had no inline formula showing how to apply Defender P2 and M365 E5 free data grants, causing ~16-18% overestimation of Sentinel ingestion costs (see #182).

### Changes

- **Billable GB formula**: Explicit 3-line computation showing Defender P2 (`serverCount × 0.5 × 30`) and M365 E5 (`userCount × 0.005 × 30`) deductions from `total_IsBillable_GB`
- **Grant independence**: Documented that grants target non-overlapping table sets (no ordering dependency)
- **Volume deduction note**: Grants are applied before tier pricing; ingestion-only (retention uses total physical volume); P2 requires Defender auto-provisioned DCRs
- **LA 5 GB/month caveat**: Noted as not applicable under simplified pricing (cross-ref #188)
- **Commitment formula**: Updated `dailyGB` → `billableGB ÷ 30` to use the same post-deduction variable
- **Removed** passive cross-reference (`see defender-for-cloud.md`) — replaced with the actual formula

### Validation

- 28/28 checks pass (`Validate-ServiceReference.ps1 -CheckAliasUniqueness`)
- 92 lines (limit: 100)
- Claims validated by 5 independent research agents (Opus 4.6, Gemini 3 Pro, GPT-5.3 Codex) against official MS docs

Fixes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure Sentinel cost calculation references with clarified billable GB formulas
  * Added explanatory notes about free data grants, ingestion vs retention, and Defender for Cloud requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->