### PR TITLE
Compact service-routing.md syntax: drop YAML fences for flat delimited format

### DIFF
--- a/docs/ops/service-routing-split.md
+++ b/docs/ops/service-routing-split.md
@@ -48,8 +48,8 @@ The routing file is self-contained and does not reference the catalog. Agents th
 When implementing a service from the catalog:
 
 1. **Check the catalog** - look up the service in `docs/service-catalog.md` for:
-   - Exact `serviceName` (`s:` field)
-   - Aliases (`a:` field)
+   - Exact `serviceName` (service name before the colon)
+   - Aliases (comma-separated values after the colon)
    - Category (section heading)
 
 2. **Create the reference file** - add the `.md` file in the appropriate category folder under `skills/azure-cost-calculator/references/services/`.
@@ -71,9 +71,8 @@ When tracking a service that does not have a reference file yet:
 
 1. Add entry to `docs/service-catalog.md` under the appropriate category:
 
-   ```yaml
-   - s: "Service Name"
-     a: [Alias1, Alias2]
+   ```
+   - Service Name: Alias1, Alias2
    ```
 
 2. **Do NOT add to agent routing** - the routing file only contains implemented services with existing files.

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -14,348 +14,183 @@ Example: "Azure Data Factory" - `data-factory.md` | "SignalR" - `signalr.md` | "
 - API `serviceFamily` may differ from category here. Always use this file's category.
 - Services with no retail meter still need reference files.
 
-## Compute (`services/compute/`)
+## Compute (services/compute/)
 
-```yaml
-- s: "Cloud Services"
-  a: [Cloud Services (classic), PaaS VMs, Worker Roles, Web Roles]
-- s: "Service Fabric"
-  a: [Service Fabric Mesh, SF, SF Mesh, Microservices, Microservices Cluster, Reliable Services]
-- s: "Azure Red Hat OpenShift"
-  a: [ARO, OpenShift]
-- s: "Specialized Compute"
-  a: [SAP HANA Large Instances, Azure Boost]
-- s: "HPC Cache"
-  a: [High Performance Compute Cache]
-- s: "Durable Task Scheduler"
-  a: [Durable Tasks, Workflow Scheduler]
-- s: "Azure VM Image Builder"
-  a: [Image Builder, AIB, VM Image, Custom Image]
-- s: "Virtual Machines Licenses"
-  a: [VM Licenses, BYOL, Windows Server License, SQL Server License]
-- s: "Azure Local"
-  a: [Azure Stack Local, Hybrid Compute]
-```
+- Cloud Services: Cloud Services (classic), PaaS VMs, Worker Roles, Web Roles
+- Service Fabric: Service Fabric Mesh, SF, SF Mesh, Microservices, Microservices Cluster, Reliable Services
+- Azure Red Hat OpenShift: ARO, OpenShift
+- Specialized Compute: SAP HANA Large Instances, Azure Boost
+- HPC Cache: High Performance Compute Cache
+- Durable Task Scheduler: Durable Tasks, Workflow Scheduler
+- Azure VM Image Builder: Image Builder, AIB, VM Image, Custom Image
+- Virtual Machines Licenses: VM Licenses, BYOL, Windows Server License, SQL Server License
+- Azure Local: Azure Stack Local, Hybrid Compute
 
-## Containers (`services/containers/`)
+## Containers (services/containers/)
 
-```yaml
-- s: "AKS on Azure Stack HCI"
-  a: [AKS-HCI, AKS on HCI, Kubernetes on Azure Stack HCI]
-- s: "Azure Arc-enabled AKS"
-  a: [Arc AKS, Arc-enabled Kubernetes, Arc K8s]
-```
+- AKS on Azure Stack HCI: AKS-HCI, AKS on HCI, Kubernetes on Azure Stack HCI
+- Azure Arc-enabled AKS: Arc AKS, Arc-enabled Kubernetes, Arc K8s
 
-## Databases (`services/databases/`)
+## Databases (services/databases/)
 
-```yaml
-- s: "Azure Database for MariaDB"
-  a: [MariaDB, Azure MariaDB]
-- s: "Azure Managed Instance for Apache Cassandra"
-  a: [Cassandra MI, Apache Cassandra, Managed Cassandra]
-- s: "SQL Data Warehouse"
-  a: [Azure Synapse SQL Pool (dedicated), DW, Data Warehouse]
-- s: "SQL Server Stretch Database"
-  a: [Stretch DB, SQL Stretch]
-- s: "Azure Arc Enabled Databases"
-  a: [Arc SQL MI, Arc PostgreSQL, Arc-enabled Data Services]
-- s: "Azure SQL Edge"
-  a: [Edge Database, IoT SQL]
-- s: "SQL DB Edge"
-  a: [Edge SQL (legacy name for Azure SQL Edge)]
-```
+- Azure Database for MariaDB: MariaDB, Azure MariaDB
+- Azure Managed Instance for Apache Cassandra: Cassandra MI, Apache Cassandra, Managed Cassandra
+- SQL Data Warehouse: Azure Synapse SQL Pool (dedicated), DW, Data Warehouse
+- SQL Server Stretch Database: Stretch DB, SQL Stretch
+- Azure Arc Enabled Databases: Arc SQL MI, Arc PostgreSQL, Arc-enabled Data Services
+- Azure SQL Edge: Edge Database, IoT SQL
+- SQL DB Edge: Edge SQL (legacy name for Azure SQL Edge)
 
-## Networking (`services/networking/`)
+## Networking (services/networking/)
 
-```yaml
-- s: "Azure Firewall Manager"
-  a: [Firewall Policy]
-- s: "Virtual WAN"
-  a: [vWAN, WAN Hub]
-- s: "Bandwidth"
-  a: [Data Transfer, Egress, Outbound Transfer, Inter-region Transfer]
-- s: "Network Watcher"
-  a: [NSG Flow Logs, Connection Monitor]
-- s: "Azure Orbital"
-  a: [Ground Station, Satellite]
-- s: "Private Mobile Network"
-  a: [Private 5G Core, Mobile Network, MEC]
-- s: "Azure Route Server"
-  a: [BGP Routing]
-- s: "Advanced Container Networking Services"
-  a: [Advanced CNI, Container Networking, Cilium, Azure CNI Overlay]
-- s: "Microsoft Azure Peering Service"
-  a: [ISP Peering, Internet Peering]
-- s: "Azure Programmable Connectivity"
-  a: [APC, Network APIs]
-```
+- Azure Firewall Manager: Firewall Policy
+- Virtual WAN: vWAN, WAN Hub
+- Bandwidth: Data Transfer, Egress, Outbound Transfer, Inter-region Transfer
+- Network Watcher: NSG Flow Logs, Connection Monitor
+- Azure Orbital: Ground Station, Satellite
+- Private Mobile Network: Private 5G Core, Mobile Network, MEC
+- Azure Route Server: BGP Routing
+- Advanced Container Networking Services: Advanced CNI, Container Networking, Cilium, Azure CNI Overlay
+- Microsoft Azure Peering Service: ISP Peering, Internet Peering
+- Azure Programmable Connectivity: APC, Network APIs
 
-## Storage (`services/storage/`)
+## Storage (services/storage/)
 
-```yaml
-- s: "Azure NetApp Files"
-  a: [NetApp, ANF, Azure NetApp]
-- s: "Azure Elastic SAN"
-  a: [SAN, Block Storage]
-- s: "Azure Managed Lustre"
-  a: [Lustre, HPC Storage]
-- s: "StorSimple"
-  a: [Hybrid Cloud Storage, StorSimple Array, StorSimple Virtual Array]
-```
+- Azure NetApp Files: NetApp, ANF, Azure NetApp
+- Azure Elastic SAN: SAN, Block Storage
+- Azure Managed Lustre: Lustre, HPC Storage
+- StorSimple: Hybrid Cloud Storage, StorSimple Array, StorSimple Virtual Array
 
-## Security (`services/security/`)
+## Security (services/security/)
 
-```yaml
-- s: "Microsoft Purview"
-  a: [Data Governance, Data Catalog]
-- s: "Azure confidential ledger"
-  a: [CCF, Blockchain Ledger]
-- s: "Azure Cloud HSM"
-  a: [Dedicated HSM, Hardware Security Module]
-- s: "Microsoft Azure Payment HSM"
-  a: [Payment Processing HSM]
-- s: "Azure IoT Security"
-  a: [Defender for IoT, OT Security]
-- s: "Microsoft Security Copilot"
-  a: [Copilot for Security]
-- s: "Microsoft Graph Services"
-  a: [Microsoft Graph, Graph API metered usage]
-- s: "Microsoft Defender Experts"
-  a: [XDR Experts, Managed Detection and Response]
-- s: "Multi-Factor Authentication"
-  a: [MFA, Multi-Factor Auth, Azure MFA, Two-Factor Authentication]
-- s: "Trusted Signing"
-  a: [Code Signing, Azure Code Signing]
-- s: "Microsoft Entra"
-  a: [Entra Suite, Microsoft Entra (exact API name), Entra ID metered]
-- s: "Microsoft Entra Verified ID"
-  a: [Verified ID, Verifiable Credentials, Decentralized Identity, DID]
-```
+- Microsoft Purview: Data Governance, Data Catalog
+- Azure confidential ledger: CCF, Blockchain Ledger
+- Azure Cloud HSM: Dedicated HSM, Hardware Security Module
+- Microsoft Azure Payment HSM: Payment Processing HSM
+- Azure IoT Security: Defender for IoT, OT Security
+- Microsoft Security Copilot: Copilot for Security
+- Microsoft Graph Services: Microsoft Graph, Graph API metered usage
+- Microsoft Defender Experts: XDR Experts, Managed Detection and Response
+- Multi-Factor Authentication: MFA, Multi-Factor Auth, Azure MFA, Two-Factor Authentication
+- Trusted Signing: Code Signing, Azure Code Signing
+- Microsoft Entra: Entra Suite, Microsoft Entra (exact API name), Entra ID metered
+- Microsoft Entra Verified ID: Verified ID, Verifiable Credentials, Decentralized Identity, DID
 
-## Monitoring (`services/monitoring/`)
+## Monitoring (services/monitoring/)
 
-```yaml
-- s: "Insight and Analytics"
-  a: [OMS (legacy), Insight and Analytics (legacy)]
-```
+- Insight and Analytics: OMS (legacy), Insight and Analytics (legacy)
 
-## Management (`services/management/`)
+## Management (services/management/)
 
-```yaml
-- s: "Automation"
-  a: [Runbooks, DSC, Update Management]
-- s: "Azure Chaos Studio"
-  a: [Chaos Engineering, Fault Injection]
-- s: "Scheduler"
-  a: [Azure Scheduler (legacy), Job Scheduler]
-- s: "Azure Arc"
-  a: [Hybrid Management, Arc-enabled Servers, Arc-enabled K8s]
-- s: "Azure Lighthouse"
-  a: [Delegated Resource Management, MSP Management]
-- s: "Azure Policy"
-  a: [Compliance, Governance]
-- s: "Azure Advisor"
-  a: [Best Practices]
-- s: "Azure Cost Management"
-  a: [Billing, Budgets, Cost Analysis]
-- s: "Azure Blueprints"
-  a: [Governance Templates (deprecated)]
-- s: "Azure Resource Mover"
-  a: [Move Resources, Subscription Mover]
-- s: "Azure Update Manager"
-  a: [Patch Management, OS Updates]
-- s: "Azure Virtual Enclaves"
-  a: [Isolated Environments, Secure Enclaves]
-- s: "Change Tracking and Inventory"
-  a: [Change Tracking, Inventory Tracking, Configuration Tracking]
-- s: "Dynamics 365 for Customer Insights"
-  a: [Customer Insights, D365 CI, Dynamics 365 Analytics]
-```
+- Automation: Runbooks, DSC, Update Management
+- Azure Chaos Studio: Chaos Engineering, Fault Injection
+- Scheduler: Azure Scheduler (legacy), Job Scheduler
+- Azure Arc: Hybrid Management, Arc-enabled Servers, Arc-enabled K8s
+- Azure Lighthouse: Delegated Resource Management, MSP Management
+- Azure Policy: Compliance, Governance
+- Azure Advisor: Best Practices
+- Azure Cost Management: Billing, Budgets, Cost Analysis
+- Azure Blueprints: Governance Templates (deprecated)
+- Azure Resource Mover: Move Resources, Subscription Mover
+- Azure Update Manager: Patch Management, OS Updates
+- Azure Virtual Enclaves: Isolated Environments, Secure Enclaves
+- Change Tracking and Inventory: Change Tracking, Inventory Tracking, Configuration Tracking
+- Dynamics 365 for Customer Insights: Customer Insights, D365 CI, Dynamics 365 Analytics
 
-## Integration (`services/integration/`)
+## Integration (services/integration/)
 
-```yaml
-- s: "Azure API Center"
-  a: [API Catalog, API Inventory]
-- s: "BizTalk Services"
-  a: [BizTalk, BizTalk Services (legacy), B2B Integration]
-```
+- Azure API Center: API Catalog, API Inventory
+- BizTalk Services: BizTalk, BizTalk Services (legacy), B2B Integration
 
-## Analytics (`services/analytics/`)
+## Analytics (services/analytics/)
 
-```yaml
-- s: "Azure Data Explorer"
-  a: [ADX, Kusto]
-- s: "HDInsight"
-  a: [Hadoop, Spark, HBase, Kafka, HDI]
-- s: "Azure Analysis Services"
-  a: [AAS, Tabular Model]
-- s: "Power BI"
-  a: [Power BI Service]
-- s: "Power BI Embedded"
-  a: [PBI Embedded, Embedded Analytics]
-- s: "Data Catalog"
-  a: [Data Catalog (legacy)]
-- s: "Azure Purview"
-  a: [Purview Data Map, Data Estate Scanning]
-- s: "Azure Data Share"
-  a: [Data Sharing]
-- s: "Microsoft Fabric"
-  a: [Fabric Capacity, OneLake, Lakehouse]
-- s: "Microsoft Planetary Computer Pro"
-  a: [Planetary Computer, Geospatial Analytics]
-- s: "Data Lake Store"
-  a: [ADLS Gen1, Azure Data Lake (legacy)]
-- s: "Web PubSub"
-  a: [WebSocket Service]
-- s: "Microsoft Graph data connect"
-  a: [Microsoft 365 Data, M365 Data Export]
-```
+- Azure Data Explorer: ADX, Kusto
+- HDInsight: Hadoop, Spark, HBase, Kafka, HDI
+- Azure Analysis Services: AAS, Tabular Model
+- Power BI: Power BI Service
+- Power BI Embedded: PBI Embedded, Embedded Analytics
+- Data Catalog: Data Catalog (legacy)
+- Azure Purview: Purview Data Map, Data Estate Scanning
+- Azure Data Share: Data Sharing
+- Microsoft Fabric: Fabric Capacity, OneLake, Lakehouse
+- Microsoft Planetary Computer Pro: Planetary Computer, Geospatial Analytics
+- Data Lake Store: ADLS Gen1, Azure Data Lake (legacy)
+- Web PubSub: WebSocket Service
+- Microsoft Graph data connect: Microsoft 365 Data, M365 Data Export
 
-## AI + ML (`services/ai-ml/`)
+## AI + ML (services/ai-ml/)
 
-```yaml
-- s: "Foundry Models"
-  a: [Azure AI Foundry Models, Model Catalog, AI Foundry]
-```
+- Foundry Models: Azure AI Foundry Models, Model Catalog, AI Foundry
 
-## IoT (`services/iot/`)
+## IoT (services/iot/)
 
-```yaml
-- s: "IoT Central"
-  a: [IoT SaaS, IoT Application]
-- s: "Azure Maps"
-  a: [Location Services, Geospatial]
-- s: "Digital Twins"
-  a: [ADT, IoT Modeling]
-- s: "Time Series Insights"
-  a: [TSI, Time Series, IoT Analytics (deprecated/migrating)]
-- s: "AKS Edge Essentials"
-  a: [AKS Edge, K8s Edge, Kubernetes Edge Essentials]
-- s: "Azure Device Registry"
-  a: [IoT Device Registry, Asset Registry]
-- s: "Azure IoT Operations"
-  a: [IoT Ops, Edge IoT, Azure IoT OPC UA]
-- s: "Windows 10 IoT Core Services"
-  a: [IoT Core, Windows IoT, IoT Core Services, Windows CE]
-```
+- IoT Central: IoT SaaS, IoT Application
+- Azure Maps: Location Services, Geospatial
+- Digital Twins: ADT, IoT Modeling
+- Time Series Insights: TSI, Time Series, IoT Analytics (deprecated/migrating)
+- AKS Edge Essentials: AKS Edge, K8s Edge, Kubernetes Edge Essentials
+- Azure Device Registry: IoT Device Registry, Asset Registry
+- Azure IoT Operations: IoT Ops, Edge IoT, Azure IoT OPC UA
+- Windows 10 IoT Core Services: IoT Core, Windows IoT, IoT Core Services, Windows CE
 
-## Developer Tools (`services/developer-tools/`)
+## Developer Tools (services/developer-tools/)
 
-```yaml
-- s: "App Configuration"
-  a: [Feature Flags, Configuration Store]
-- s: "Azure Lab Services"
-  a: [Classroom Labs, DevTest Labs]
-- s: "Microsoft Playwright Testing"
-  a: [Playwright, Browser Testing, E2E Testing]
-- s: "Azure App Testing"
-  a: [Mobile App Testing]
-- s: "Azure Fluid Relay"
-  a: [Fluid Framework, Real-time Collaboration]
-- s: "Azure Grafana Service"
-  a: [Managed Grafana, Azure Managed Grafana, Grafana Dashboard]
-- s: "Visual Studio Codespaces"
-  a: [Codespaces (legacy), Cloud Dev Environments]
-- s: "Azure DevTest Labs"
-  a: [Lab VMs, Dev Environments]
-- s: "Microsoft Dev Box"
-  a: [Cloud Dev Workstation, Developer VM]
-- s: "Azure Deployment Environments"
-  a: [ADE, IaC Templates]
-- s: "Azure Load Testing"
-  a: [JMeter, Performance Testing]
-- s: "GitHub"
-  a: [GitHub Enterprise, GitHub Actions, GitHub Copilot]
-- s: "GitHub AE"
-  a: [GitHub Enterprise (Azure-hosted, legacy)]
-- s: "Test Base"
-  a: [Test Base for Microsoft 365, Compatibility Testing]
-- s: "Visual Studio Subscription"
-  a: [VS Subscription, MSDN, Visual Studio Enterprise/Professional]
-```
+- App Configuration: Feature Flags, Configuration Store
+- Azure Lab Services: Classroom Labs, DevTest Labs
+- Microsoft Playwright Testing: Playwright, Browser Testing, E2E Testing
+- Azure App Testing: Mobile App Testing
+- Azure Fluid Relay: Fluid Framework, Real-time Collaboration
+- Azure Grafana Service: Managed Grafana, Azure Managed Grafana, Grafana Dashboard
+- Visual Studio Codespaces: Codespaces (legacy), Cloud Dev Environments
+- Azure DevTest Labs: Lab VMs, Dev Environments
+- Microsoft Dev Box: Cloud Dev Workstation, Developer VM
+- Azure Deployment Environments: ADE, IaC Templates
+- Azure Load Testing: JMeter, Performance Testing
+- GitHub: GitHub Enterprise, GitHub Actions, GitHub Copilot
+- GitHub AE: GitHub Enterprise (Azure-hosted, legacy)
+- Test Base: Test Base for Microsoft 365, Compatibility Testing
+- Visual Studio Subscription: VS Subscription, MSDN, Visual Studio Enterprise/Professional
 
-## Identity (`services/identity/`)
+## Identity (services/identity/)
 
-```yaml
-- s: "Azure Active Directory B2C"
-  a: [AAD B2C, Azure AD B2C, External Identities B2C, Entra External ID]
-- s: "Azure Active Directory for External Identities"
-  a: [AAD External, B2B, Guest Users, Entra External ID]
-- s: "Microsoft Entra Domain Services"
-  a: [AAD DS, Azure AD DS, Managed AD]
-- s: "Windows 365 Agents"
-  a: [Cloud PC Agents]
-```
+- Azure Active Directory B2C: AAD B2C, Azure AD B2C, External Identities B2C, Entra External ID
+- Azure Active Directory for External Identities: AAD External, B2B, Guest Users, Entra External ID
+- Microsoft Entra Domain Services: AAD DS, Azure AD DS, Managed AD
+- Windows 365 Agents: Cloud PC Agents
 
-## Web (`services/web/`)
+## Web (services/web/)
 
-```yaml
-- s: "Azure Spring Cloud"
-  a: [Azure Spring Apps, Java Microservices]
-- s: "Community Training"
-  a: [Learning]
-```
+- Azure Spring Cloud: Azure Spring Apps, Java Microservices
+- Community Training: Learning
 
-## Communication (`services/communication/`)
+## Communication (services/communication/)
 
-```yaml
-- s: "AI Ops"
-  a: [Telecom AI Ops, Azure Operator Insights]
-- s: "Packet Core"
-  a: [Azure Private 5G Core, Mobile Packet Core]
-- s: "Azure Operator Nexus"
-  a: [Telecom Nexus, Carrier Network]
-- s: "Voice Core"
-  a: [Telecom Voice, Core Voice Infrastructure]
-- s: "Routing"
-  a: [ACS Routing, Communication Routing, Call Routing]
-```
+- AI Ops: Telecom AI Ops, Azure Operator Insights
+- Packet Core: Azure Private 5G Core, Mobile Packet Core
+- Azure Operator Nexus: Telecom Nexus, Carrier Network
+- Voice Core: Telecom Voice, Core Voice Infrastructure
+- Routing: ACS Routing, Communication Routing, Call Routing
 
-## Specialist (`services/specialist/`)
+## Specialist (services/specialist/)
 
-```yaml
-- s: "Azure Blockchain"
-  a: [Blockchain Service, Blockchain Workbench (deprecated)]
-- s: "Azure Remote Rendering"
-  a: [3D Rendering, Mixed Reality]
-- s: "Quantum Computing"
-  a: [Azure Quantum, Q#]
-- s: "Azure API for FHIR"
-  a: [FHIR API, Healthcare API, Health Data Services]
-- s: "Energy Data Manager"
-  a: [OSDU, Oil & Gas Data]
-- s: "Microsoft Dragon Copilot"
-  a: [Healthcare Copilot, Clinical Documentation]
-- s: "Microsoft Copilot Studio"
-  a: [Power Virtual Agents, Chatbot Builder]
-- s: "Syntex"
-  a: [SharePoint Syntex, Document Processing]
-- s: "Azure Spatial Anchors"
-  a: [AR Anchors, Mixed Reality Anchors]
-- s: "Azure Stack Edge"
-  a: [Edge Computing, Edge Appliance]
-- s: "Azure Stack HCI"
-  a: [HCI, Hyper-Converged Infrastructure]
-- s: "Azure Stack Hub"
-  a: [Azure Stack (original)]
-- s: "Azure Orbital Edge"
-  a: [Edge Satellite, Space Edge Computing]
-- s: "Firmware Analysis"
-  a: [Defender for IoT Firmware, IoT Firmware]
-- s: "Dataverse"
-  a: [Common Data Service, CDS, Power Platform Data]
-- s: "Power Apps"
-  a: [PowerApps, Low-code Apps, Canvas Apps, Model-driven]
-- s: "Power Automate"
-  a: [Flow, Microsoft Flow, Workflow Automation]
-- s: "Power Pages"
-  a: [Portal, Power Apps Portals, Low-code Websites]
-- s: "PlayFab"
-  a: [Game Backend, Game Services]
-- s: "MS Bing Services"
-  a: [Bing Search, Bing API, Bing Search API]
-- s: "SAP Embrace"
-  a: [SAP on Azure, SAP Integration]
-```
-
+- Azure Blockchain: Blockchain Service, Blockchain Workbench (deprecated)
+- Azure Remote Rendering: 3D Rendering, Mixed Reality
+- Quantum Computing: Azure Quantum, Q#
+- Azure API for FHIR: FHIR API, Healthcare API, Health Data Services
+- Energy Data Manager: OSDU, Oil & Gas Data
+- Microsoft Dragon Copilot: Healthcare Copilot, Clinical Documentation
+- Microsoft Copilot Studio: Power Virtual Agents, Chatbot Builder
+- Syntex: SharePoint Syntex, Document Processing
+- Azure Spatial Anchors: AR Anchors, Mixed Reality Anchors
+- Azure Stack Edge: Edge Computing, Edge Appliance
+- Azure Stack HCI: HCI, Hyper-Converged Infrastructure
+- Azure Stack Hub: Azure Stack (original)
+- Azure Orbital Edge: Edge Satellite, Space Edge Computing
+- Firmware Analysis: Defender for IoT Firmware, IoT Firmware
+- Dataverse: Common Data Service, CDS, Power Platform Data
+- Power Apps: PowerApps, Low-code Apps, Canvas Apps, Model-driven
+- Power Automate: Flow, Microsoft Flow, Workflow Automation
+- Power Pages: Portal, Power Apps Portals, Low-code Websites
+- PlayFab: Game Backend, Game Services
+- MS Bing Services: Bing Search, Bing API, Bing Search API
+- SAP Embrace: SAP on Azure, SAP Integration

--- a/skills/azure-cost-calculator/references/service-routing.md
+++ b/skills/azure-cost-calculator/references/service-routing.md
@@ -4,9 +4,9 @@ Agent-facing routing for Azure services with implemented reference files.
 
 For the Category Index and constants, see [shared.md](shared.md).
 
-Filename convention: strip "Azure"/"Microsoft"/"MS" prefix → kebab-case → `.md`
+Filename convention: strip "Azure"/"Microsoft"/"MS" prefix → kebab-case → .md
 Branded compound words (SignalR, DevOps, OpenAI, BizTalk, PlayFab, PubSub) are single tokens - lowercase without hyphens.
-Example: "Azure Data Factory" → `data-factory.md` | "SignalR" → `signalr.md` | "Azure DevOps" → `devops.md`
+Example: "Azure Data Factory" → data-factory.md | "SignalR" → signalr.md | "Azure DevOps" → devops.md
 
 ## Routing Notes
 
@@ -14,235 +14,126 @@ Example: "Azure Data Factory" → `data-factory.md` | "SignalR" → `signalr.md`
 - API `serviceFamily` may differ from category here. Always use this file's category.
 - Services with no retail meter still need reference files.
 
-## Compute (`services/compute/`)
+## Compute (services/compute/)
 
-```yaml
-- s: "Virtual Machines"
-  a: [VMs, Azure VMs, IaaS VMs, VM Scale Sets, VMSS, Dedicated Host]
-- s: "Azure App Service"
-  a: [Web Apps, App Service Plan, ASP]
-- s: "Functions"
-  a: [Serverless Functions, Function App]
-- s: "Azure Container Apps"
-  a: [ACA, Container Apps]
-- s: "Azure Kubernetes Service"
-  a: [AKS, Kubernetes, K8s, AKS Automatic, Kubernetes Automatic]
-- s: "Azure Batch"
-  a: [HPC Batch, Batch Compute]
-- s: "Azure VMware Solution"
-  a: [AVS, VMware on Azure]
-- s: "Windows Virtual Desktop"
-  a: [Azure Virtual Desktop, AVD, WVD]
-```
+- Virtual Machines: VMs, Azure VMs, IaaS VMs, VM Scale Sets, VMSS, Dedicated Host
+- Azure App Service: Web Apps, App Service Plan, ASP
+- Functions: Serverless Functions, Function App
+- Azure Container Apps: ACA, Container Apps
+- Azure Kubernetes Service: AKS, Kubernetes, K8s, AKS Automatic, Kubernetes Automatic
+- Azure Batch: HPC Batch, Batch Compute
+- Azure VMware Solution: AVS, VMware on Azure
+- Windows Virtual Desktop: Azure Virtual Desktop, AVD, WVD
 
-## Containers (`services/containers/`)
+## Containers (services/containers/)
 
-```yaml
-- s: "Container Instances"
-  a: [ACI, Serverless Containers]
-- s: "Container Registry"
-  a: [ACR, Docker Registry]
-```
+- Container Instances: ACI, Serverless Containers
+- Container Registry: ACR, Docker Registry
 
-## Databases (`services/databases/`)
+## Databases (services/databases/)
 
-```yaml
-- s: "SQL Database"
-  a: [Azure SQL, SQL DB]
-- s: "SQL Managed Instance"
-  a: [SQL MI, Azure SQL MI, Managed Instance]
-- s: "Azure Cosmos DB"
-  a: [CosmosDB, DocumentDB, Multi-model DB]
-- s: "Azure Database for PostgreSQL"
-  a: [PostgreSQL, Postgres, Azure Postgres, PostgreSQL Flexible Server]
-- s: "Azure Database for MySQL"
-  a: [MySQL, Azure MySQL, MySQL Flexible Server]
-- s: "Redis Cache"
-  a: [Azure Cache for Redis, Redis, Azure Redis, Managed Redis]
-- s: "Azure Database Migration Service"
-  a: [DMS, Database Migration, DB Migration Service]
-```
+- SQL Database: Azure SQL, SQL DB
+- SQL Managed Instance: SQL MI, Azure SQL MI, Managed Instance
+- Azure Cosmos DB: CosmosDB, DocumentDB, Multi-model DB
+- Azure Database for PostgreSQL: PostgreSQL, Postgres, Azure Postgres, PostgreSQL Flexible Server
+- Azure Database for MySQL: MySQL, Azure MySQL, MySQL Flexible Server
+- Redis Cache: Azure Cache for Redis, Redis, Azure Redis, Managed Redis
+- Azure Database Migration Service: DMS, Database Migration, DB Migration Service
 
-## Networking (`services/networking/`)
+## Networking (services/networking/)
 
-```yaml
-- s: "Application Gateway"
-  a: [App Gateway, AGW, WAF, Azure WAF, WAF v2, Web Application Firewall, WAF Policy]
-- s: "Azure Firewall"
-  a: [AzFW, Azure Firewall Premium/Standard/Basic]
-- s: "Azure Bastion"
-  a: [Bastion Host, Jump Host, Jump Box]
-- s: "Azure DDOS Protection"
-  a: [DDoS, DDoS Protection, DDoS Network Protection, DDoS IP Protection]
-- s: "ExpressRoute"
-  a: [ER, Dedicated Circuit]
-- s: "Virtual Network"
-  a: [VNet, Peering]
-- s: "VPN Gateway"
-  a: [VPN, Site-to-Site, Point-to-Site, S2S, P2S]
-- s: "Load Balancer"
-  a: [ALB, LB, Standard LB, Basic LB]
-- s: "Azure Front Door Service"
-  a: [AFD, Front Door, Front Door Premium/Standard, Front Door WAF]
-- s: "Azure DNS"
-  a: [DNS Zones, Public DNS Zones]
-- s: "Private DNS"
-  a: [Private DNS, Private DNS Zones]
-- s: "Traffic Manager"
-  a: [DNS Load Balancer]
-- s: "Azure Private Link"
-  a: [Private Endpoint, PE]
-- s: "Content Delivery Network"
-  a: [CDN, Azure CDN, CDN Classic, Azure CDN Classic, Content Delivery]
-- s: "NAT Gateway"
-  a: [Azure NAT, SNAT, Outbound Connectivity]
-- s: "IP Addresses"
-  a: [Public IP, PIP, Public IP Address]
-```
+- Application Gateway: App Gateway, AGW, WAF, Azure WAF, WAF v2, Web Application Firewall, WAF Policy
+- Azure Firewall: AzFW, Azure Firewall Premium/Standard/Basic
+- Azure Bastion: Bastion Host, Jump Host, Jump Box
+- Azure DDOS Protection: DDoS, DDoS Protection, DDoS Network Protection, DDoS IP Protection
+- ExpressRoute: ER, Dedicated Circuit
+- Virtual Network: VNet, Peering
+- VPN Gateway: VPN, Site-to-Site, Point-to-Site, S2S, P2S
+- Load Balancer: ALB, LB, Standard LB, Basic LB
+- Azure Front Door Service: AFD, Front Door, Front Door Premium/Standard, Front Door WAF
+- Azure DNS: DNS Zones, Public DNS Zones
+- Private DNS: Private DNS, Private DNS Zones
+- Traffic Manager: DNS Load Balancer
+- Azure Private Link: Private Endpoint, PE
+- Content Delivery Network: CDN, Azure CDN, CDN Classic, Azure CDN Classic, Content Delivery
+- NAT Gateway: Azure NAT, SNAT, Outbound Connectivity
+- IP Addresses: Public IP, PIP, Public IP Address
 
-## Storage (`services/storage/`)
+## Storage (services/storage/)
 
-```yaml
-- s: "Storage"
-  a: [Blob Storage, Azure Files, Table Storage, Queue Storage, Azure Storage]
-- s: "Data Lake Storage"
-  a: [Data Lake Gen2, ADLS, ADLS Gen2, Azure Data Lake]
-- s: "Backup"
-  a: [Azure Backup, Recovery Services Vault, MARS Agent, VM Backup]
-- s: "Data Box"
-  a: [Data Box Disk, Data Box Heavy, Import/Export]
-- s: "Managed Disks"
-  a: [Managed Disks, Azure Disks, Premium SSD, Standard SSD, Ultra Disk, Disk Storage]
-```
+- Storage: Blob Storage, Azure Files, Table Storage, Queue Storage, Azure Storage
+- Data Lake Storage: Data Lake Gen2, ADLS, ADLS Gen2, Azure Data Lake
+- Backup: Azure Backup, Recovery Services Vault, MARS Agent, VM Backup
+- Data Box: Data Box Disk, Data Box Heavy, Import/Export
+- Managed Disks: Managed Disks, Azure Disks, Premium SSD, Standard SSD, Ultra Disk, Disk Storage
 
-## Security (`services/security/`)
+## Security (services/security/)
 
-```yaml
-- s: "Key Vault"
-  a: [AKV, KV, Managed HSM]
-- s: "Microsoft Defender for Cloud"
-  a: [Azure Security Center, CSPM, CWP, MDC]
-- s: "Sentinel"
-  a: [SIEM, SOAR, Azure Sentinel]
-```
+- Key Vault: AKV, KV, Managed HSM
+- Microsoft Defender for Cloud: Azure Security Center, CSPM, CWP, MDC
+- Sentinel: SIEM, SOAR, Azure Sentinel
 
-## Monitoring (`services/monitoring/`)
+## Monitoring (services/monitoring/)
 
-```yaml
-- s: "Azure Monitor"
-  a: [Metrics, Alerts, Diagnostics, Platform Metrics, Basic Logs, Auxiliary Logs, Data Archive]
-- s: "Application Insights"
-  a: [App Insights, APM, Application Performance Monitoring, Application Performance, AppInsights, Azure Application Insights]
-- s: "Log Analytics"
-  a: [OMS, LA, Workspace, Logs, Log Analytics Workspace, Azure Monitor Logs, Operations Management Suite]
-```
+- Azure Monitor: Metrics, Alerts, Diagnostics, Platform Metrics, Basic Logs, Auxiliary Logs, Data Archive
+- Application Insights: App Insights, APM, Application Performance Monitoring, Application Performance, AppInsights, Azure Application Insights
+- Log Analytics: OMS, LA, Workspace, Logs, Log Analytics Workspace, Azure Monitor Logs, Operations Management Suite
 
-## Management (`services/management/`)
+## Management (services/management/)
 
-```yaml
-- s: "Azure Site Recovery"
-  a: [ASR, Disaster Recovery, DR]
-- s: "Azure Migrate"
-  a: [Server Assessment, Migration Tools]
-- s: "Management Groups"
-  a: [Management Group, Azure Management Groups, Subscription Organization]
-```
+- Azure Site Recovery: ASR, Disaster Recovery, DR
+- Azure Migrate: Server Assessment, Migration Tools
+- Management Groups: Management Group, Azure Management Groups, Subscription Organization
 
-## Integration (`services/integration/`)
+## Integration (services/integration/)
 
-```yaml
-- s: "Service Bus"
-  a: [ASB, Queues, Topics]
-- s: "Logic Apps"
-  a: [Workflows, Logic App Standard/Consumption]
-- s: "API Management"
-  a: [APIM, API Gateway]
-```
+- Service Bus: ASB, Queues, Topics
+- Logic Apps: Workflows, Logic App Standard/Consumption
+- API Management: APIM, API Gateway
 
-## Analytics (`services/analytics/`)
+## Analytics (services/analytics/)
 
-```yaml
-- s: "Azure Synapse Analytics"
-  a: [Synapse, Synapse Workspace, Synapse SQL, Synapse Spark]
-- s: "Azure Data Factory v2"
-  a: [ADF, ADF v2, ETL, Data Pipeline, Azure Data Factory]
-- s: "Azure Databricks"
-  a: [DBX, Spark on Azure]
-- s: "Stream Analytics"
-  a: [ASA, Real-time Analytics]
-- s: "SignalR"
-  a: [Azure SignalR Service, Real-time Messaging]
-```
+- Azure Synapse Analytics: Synapse, Synapse Workspace, Synapse SQL, Synapse Spark
+- Azure Data Factory v2: ADF, ADF v2, ETL, Data Pipeline, Azure Data Factory
+- Azure Databricks: DBX, Spark on Azure
+- Stream Analytics: ASA, Real-time Analytics
+- SignalR: Azure SignalR Service, Real-time Messaging
 
-## AI + ML (`services/ai-ml/`)
+## AI + ML (services/ai-ml/)
 
-```yaml
-- s: "Azure Machine Learning"
-  a: [Azure ML, AML, ML Workspace]
-- s: "Foundry Tools"
-  a: [Azure AI Foundry Tools, AI Studio, AI Foundry Workspace, Azure AI Services, Cognitive Services, Vision, Speech, Language, Decision]
-- s: "Azure Bot Service"
-  a: [Bot Framework, Chatbot]
-- s: "Intelligent Recommendations"
-  a: [Recommendations, Personalization]
-- s: "Microsoft Genomics"
-  a: [Genomics Workspace]
-- s: "Azure OpenAI Service"
-  a: [OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4]
-- s: "Machine Learning Studio"
-  a: [ML Studio (classic), Classic ML]
-```
+- Azure Machine Learning: Azure ML, AML, ML Workspace
+- Foundry Tools: Azure AI Foundry Tools, AI Studio, AI Foundry Workspace, Azure AI Services, Cognitive Services, Vision, Speech, Language, Decision
+- Azure Bot Service: Bot Framework, Chatbot
+- Intelligent Recommendations: Recommendations, Personalization
+- Microsoft Genomics: Genomics Workspace
+- Azure OpenAI Service: OpenAI, GPT, Azure OpenAI, AOAI, ChatGPT, GPT-4
+- Machine Learning Studio: ML Studio (classic), Classic ML
 
-## IoT (`services/iot/`)
+## IoT (services/iot/)
 
-```yaml
-- s: "IoT Hub"
-  a: [Device Messaging]
-- s: "Event Hubs"
-  a: [Kafka on Azure, Event Streaming]
-- s: "Event Grid"
-  a: [Event Routing, Event-driven]
-- s: "Notification Hubs"
-  a: [Push Notifications, ANH]
-```
+- IoT Hub: Device Messaging
+- Event Hubs: Kafka on Azure, Event Streaming
+- Event Grid: Event Routing, Event-driven
+- Notification Hubs: Push Notifications, ANH
 
-## Developer Tools (`services/developer-tools/`)
+## Developer Tools (services/developer-tools/)
 
-```yaml
-- s: "Azure DevOps"
-  a: [ADO, VSTS, Repos, Pipelines, Boards, Artifacts]
-```
+- Azure DevOps: ADO, VSTS, Repos, Pipelines, Boards, Artifacts
 
-## Identity (`services/identity/`)
+## Identity (services/identity/)
 
-```yaml
-- s: "Microsoft Entra ID"
-  a: [Azure AD, Azure Active Directory, AAD, Directory]
-```
+- Microsoft Entra ID: Azure AD, Azure Active Directory, AAD, Directory
 
-## Web (`services/web/`)
+## Web (services/web/)
 
-```yaml
-- s: "Azure Cognitive Search"
-  a: [Azure AI Search, Search Service, Full-text Search]
-- s: "Azure Static Web Apps"
-  a: [SWA, JAMstack]
-```
+- Azure Cognitive Search: Azure AI Search, Search Service, Full-text Search
+- Azure Static Web Apps: SWA, JAMstack
 
-## Communication (`services/communication/`)
+## Communication (services/communication/)
 
-```yaml
-- s: "Phone Numbers"
-  a: [ACS Phone Numbers, PSTN, Telephony]
-- s: "Voice"
-  a: [ACS Voice, Voice Calling, VOIP]
-- s: "Email"
-  a: [ACS Email, Email Communication]
-- s: "Messaging"
-  a: [ACS Chat, Chat Messaging]
-- s: "SMS"
-  a: [ACS SMS, Text Messaging]
-- s: "Network Traversal"
-  a: [ACS TURN, TURN Relay]
-```
-
+- Phone Numbers: ACS Phone Numbers, PSTN, Telephony
+- Voice: ACS Voice, Voice Calling, VOIP
+- Email: ACS Email, Email Communication
+- Messaging: ACS Chat, Chat Messaging
+- SMS: ACS SMS, Text Messaging
+- Network Traversal: ACS TURN, TURN Relay

--- a/tests/lib/validation/Test-AliasRoutingSync.ps1
+++ b/tests/lib/validation/Test-AliasRoutingSync.ps1
@@ -8,7 +8,7 @@ function Get-RoutingMapEntry {
     .SYNOPSIS
         Parses routing map entries from service-routing.md.
     .DESCRIPTION
-        Extracts s: (service) and a: (aliases) pairs from YAML code blocks
+        Extracts service and alias entries from colon-delimited lines
         in the routing map markdown file.
     .PARAMETER RoutingMapPath
         Path to the service-routing.md file.
@@ -25,27 +25,31 @@ function Get-RoutingMapEntry {
 
     $lines = @(Get-Content -Path $RoutingMapPath -Encoding UTF8)
     $entries = [System.Collections.Generic.List[hashtable]]::new()
-    $inYaml = $false
-    $currentService = $null
+    $inSection = $false
 
     foreach ($line in $lines) {
-        if ($line -match '^```yaml') { $inYaml = $true; continue }
-        if ($line -match '^```' -and $inYaml) { $inYaml = $false; continue }
-        if (-not $inYaml) { continue }
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line -match '^\s*#') {
+            if ($line -match '^##\s+.+\(services/[^)]+\)') { $inSection = $true }
+            continue
+        }
+        if (-not $inSection) { continue }
+        if ($line -notmatch '^\s*-\s+') { continue }
 
-        if ($line -match '^\s*-\s+s:\s*"([^"]+)"') {
-            $currentService = $Matches[1]
+        $entryLine = $line -replace '^\s*-\s+', ''
+        $colonIndex = $entryLine.IndexOf(':')
+        if ($colonIndex -lt 0) { continue }
+        $serviceName = $entryLine.Substring(0, $colonIndex).Trim()
+        $aliasString = $entryLine.Substring($colonIndex + 1).Trim()
+
+        if (-not $serviceName) { continue }
+
+        $aliases = @()
+        foreach ($a in ($aliasString -split ',')) {
+            $trimmed = $a.Trim()
+            if ($trimmed) { $aliases += $trimmed }
         }
-        elseif ($line -match '^\s+a:\s*\[(.+)\]' -and $null -ne $currentService) {
-            $rawAliases = $Matches[1]
-            $aliases = @()
-            foreach ($a in ($rawAliases -split ',')) {
-                $trimmed = $a.Trim().Trim('"', "'")
-                if ($trimmed) { $aliases += $trimmed }
-            }
-            $entries.Add(@{ Service = $currentService; Aliases = $aliases })
-            $currentService = $null
-        }
+        $entries.Add(@{ Service = $serviceName; Aliases = $aliases })
     }
 
     , $entries
@@ -90,7 +94,7 @@ function Test-AliasRoutingSync {
 
     if (-not (Test-Path $RoutingMapPath)) {
         $checks.Add((New-ValidationCheck -Name 'alias_routing_sync' -Pass $false `
-            -PassMessage 'n/a' -FailMessage "Routing map not found: $RoutingMapPath"))
+                    -PassMessage 'n/a' -FailMessage "Routing map not found: $RoutingMapPath"))
     }
     else {
         $routingEntries = Get-RoutingMapEntry -RoutingMapPath $RoutingMapPath
@@ -151,8 +155,8 @@ function Test-AliasRoutingSync {
                 $info = $fileAliasSet[$key]
                 $fileList = $info.Files -join ', '
                 $checks.Add((New-ValidationCheck -Name 'alias_routing_sync' -Pass $false `
-                    -PassMessage 'n/a' `
-                    -FailMessage "File alias '$($info.Alias)' (in $fileList) not found in routing map"))
+                            -PassMessage 'n/a' `
+                            -FailMessage "File alias '$($info.Alias)' (in $fileList) not found in routing map"))
             }
         }
 
@@ -170,8 +174,8 @@ function Test-AliasRoutingSync {
                 $key = $alias.ToLowerInvariant()
                 if (-not $fileAliasSet.ContainsKey($key)) {
                     $checks.Add((New-ValidationCheck -Name 'alias_routing_sync' -Pass $false `
-                        -PassMessage 'n/a' `
-                        -FailMessage "Routing alias '$alias' (entry: $($entry.Service)) not found in any file"))
+                                -PassMessage 'n/a' `
+                                -FailMessage "Routing alias '$alias' (entry: $($entry.Service)) not found in any file"))
                 }
             }
         }
@@ -179,8 +183,8 @@ function Test-AliasRoutingSync {
 
     if ($checks.Count -eq 0) {
         $checks.Add((New-ValidationCheck -Name 'alias_routing_sync' -Pass $true `
-            -PassMessage 'All aliases are in sync between routing map and service files' `
-            -FailMessage 'n/a'))
+                    -PassMessage 'All aliases are in sync between routing map and service files' `
+                    -FailMessage 'n/a'))
     }
 
     , $checks

--- a/tests/lib/validation/Test-BillingNeedsReference.ps1
+++ b/tests/lib/validation/Test-BillingNeedsReference.ps1
@@ -1,14 +1,15 @@
 ﻿Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot 'New-ValidationCheck.ps1')
 . (Join-Path $PSScriptRoot 'Get-FrontMatter.ps1')
+. (Join-Path $PSScriptRoot 'Test-AliasRoutingSync.ps1')  # imports Get-RoutingMapEntry
 function Test-BillingNeedsReference {
     <#
     .SYNOPSIS
         Checks that every billingNeeds entry references a valid routing map service name.
     .DESCRIPTION
-        Reads the service-routing.md file to build a set of known routing
-        map service names (s: values), then verifies every billingNeeds
-        entry in every service file matches an actual routing map name.
+        Uses Get-RoutingMapEntry to build a set of known routing map service
+        names, then verifies every billingNeeds entry in every service file
+        matches an actual routing map name.
         Returns one or more check results.
     .PARAMETER RootPath
         Root directory of the services folder to scan for billingNeeds references.
@@ -27,7 +28,7 @@ function Test-BillingNeedsReference {
     $checks = [System.Collections.Generic.List[object]]::new()
     $RootPath = (Resolve-Path -Path $RootPath).Path
     $files = Get-ChildItem -Path $RootPath -Filter '*.md' -Recurse
-    # First pass: collect all known routing map service names (case-insensitive)
+    # Collect all known routing map service names via shared parser
     $routingMapPath = Join-Path (Split-Path $RootPath -Parent) 'service-routing.md'
     if (-not (Test-Path $routingMapPath)) {
         $checks.Add((New-ValidationCheck -Name 'billing_needs_reference' -Pass $false `
@@ -35,15 +36,10 @@ function Test-BillingNeedsReference {
         , $checks
         return
     }
+    $routingEntries = Get-RoutingMapEntry -RoutingMapPath $routingMapPath
     $routingNames = @{}
-    $routingLines = @(Get-Content -Path $routingMapPath -Encoding UTF8)
-    foreach ($line in $routingLines) {
-        if ($line -match "^\s*-\s*s:\s*[`"']?([^`"']+)[`"']?\s*$") {
-            $name = $Matches[1].Trim()
-            if ($name) {
-                $routingNames[$name.ToLowerInvariant()] = $name
-            }
-        }
+    foreach ($entry in $routingEntries) {
+        $routingNames[$entry.Service.ToLowerInvariant()] = $entry.Service
     }
     # Second pass: validate billingNeeds references
     foreach ($file in $files) {


### PR DESCRIPTION
## Summary

Converts `service-routing.md` and `docs/service-catalog.md` from YAML-in-fenced-code-blocks to flat colon-delimited list items, reducing agent token consumption by **30%** on the routing file.

Closes #224

## Format change

**Before:**
````
## Compute (`services/compute/`)

```yaml
- s: "Virtual Machines"
  a: [VMs, Azure VMs, IaaS VMs, VM Scale Sets, VMSS, Dedicated Host]
```
````

**After:**
```
## Compute (services/compute/)
- Virtual Machines: VMs, Azure VMs, IaaS VMs, VM Scale Sets, VMSS, Dedicated Host
```

## Token measurement (cl100k_base)

| Metric | main | this branch | change |
|--------|------|-------------|--------|
| Lines | 248 | 139 | -109 (44%) |
| Chars | 6961 | 5892 | -1069 (15%) |
| **Tokens** | **2107** | **1467** | **-640 (30.4%)** |

## Changes

### Routing files
- `service-routing.md` — converted 76 entries to compact format
- `docs/service-catalog.md` — converted 130 entries to compact format

### Validation parsers (audit-driven improvements)
- `Test-AliasRoutingSync.ps1` — rewrote `Get-RoutingMapEntry` for new format; tightened to require `- ` list-item prefix (prevents prose false-positives); added closing-paren check on section header regex
- `Test-BillingNeedsReference.ps1` — **eliminated duplicate parser**; now dot-sources and reuses `Get-RoutingMapEntry` (DRY consolidation)

### Documentation
- `docs/ops/service-routing-split.md` — updated format examples and field references

## Validation

All checks pass:
```
pwsh tests/Validate-ServiceReference.ps1 -Path 'skills/azure-cost-calculator/references/services/**/*.md' \
  -CheckAliasUniqueness -CheckAliasRoutingSync -CheckBillingNeeds -CheckRoutingFileSync
RESULT: PASS - All checks passed
```

PSScriptAnalyzer: zero findings at all severity levels.

## Audit trail

Parser changes were reviewed by GPT-5.3-Codex and Gemini 3 Pro code-review agents. Both identified:
1. Parser duplication (fixed: consolidated to single `Get-RoutingMapEntry`)
2. Overly permissive matching (fixed: requires `- ` prefix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified service name and alias descriptions in routing documentation.
  * Simplified documentation formatting from YAML-style blocks to inline lists for improved readability across service catalogs and routing references.

* **Tests**
  * Updated validation logic to align with documentation format changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->