### PR TITLE
Audit: Compute service references (Stage 3/3)

### DIFF
--- a/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
+++ b/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
@@ -45,6 +45,7 @@ InstanceCount: 3
 
 | Meter               | Regions |
 | ------------------- | ------- |
+| AV36 VCF BYOL Node  | 1       |
 | AV36P VCF BYOL Node | 27      |
 | AV48 VCF BYOL Node  | 16      |
 | AV52 VCF BYOL Node  | 5       |
@@ -64,7 +65,7 @@ Minimum 3 hosts per cluster.
 - vSphere, vSAN, and NSX-T included in per-host price
 - Broadcom VCF subscription required separately — not in API
 - Trial nodes exist for all SKUs at zero cost — exclude from estimates
-- AV64: broadest availability (41 regions); AV52: most limited (5 regions)
+- AV36: single region (italynorth); AV64: broadest availability (41 regions); AV52: most limited (5 regions)
 - 5-year RI available for AV48 and AV64 only
 - Max 16 hosts/cluster, 12 clusters/private cloud (up to 192 hosts)
 - SQL Server on AVS billed separately under serviceName `Virtual Machines Licenses`

--- a/skills/azure-cost-calculator/references/services/compute/windows-virtual-desktop.md
+++ b/skills/azure-cost-calculator/references/services/compute/windows-virtual-desktop.md
@@ -64,3 +64,4 @@ HCI vCPU:         Monthly = retailPrice × 730 × vCPUCount
 ## Notes
 
 - Multi-session Windows 11/10 Enterprise is unique to AVD and allows multiple users per VM, reducing per-user compute cost
+- Session host VMs are charged at Linux compute rates for Windows 10/11 single-session and multi-session OS


### PR DESCRIPTION
## Summary

Closes #252 — Audit of the final 2 compute service references using the multi-agent validation pipeline.

### Files Audited

| File | Lines | Changes |
|------|-------|---------|
| `vmware-solution.md` | 72 → 73 | Added AV36 VCF BYOL meter, updated availability note |
| `windows-virtual-desktop.md` | 67 → 68 | Added Linux compute rates note |

### Investigation Pipeline

Each service was investigated by **3 independent pricing-investigator agents** (using claude-opus-4.6, claude-sonnet-4.5, gpt-5.1-codex) plus **1 compliance-reviewer agent**.

#### Azure VMware Solution — Pricing Investigation Consensus

**Unanimous (3/3):** `serviceName=Specialized Compute`, 4 current VCF BYOL SKUs (AV36P/AV48/AV52/AV64), RI terms (1Y/3Y for all, 5Y for AV48+AV64 only), trial nodes at $0, legacy CloudSimple/Virtustream products, hourly per-host billing, VCF BYOL external dependency, min 3 nodes.

**Disagreement resolved — AV36 VCF BYOL:** Report 1 (claude-opus-4.6) found this SKU in italynorth at $8.61/hr (1 region, no RI). Report 3 (gpt-5.1-codex) initially stated no AV36 meter exists but noted the pricing page lists it. Report 2 (claude-sonnet-4.5) did not enumerate it. **Resolution:** Report 1 provided concrete API data with specific pricing; the Azure pricing page also lists AV36 VCF BYOL as a current SKU. Sided with Report 1.

**Existing file assessment:** Remarkably accurate. Only change: added AV36 VCF BYOL to Meter Names table and updated the regional availability note.

#### Windows Virtual Desktop — Pricing Investigation Consensus

**Unanimous (3/3):** `serviceName=Windows Virtual Desktop`, `productName=Azure Virtual Desktop`, 4 SKUs with 7 meters (duplicate meter names per SKU are naming variants), no RI, M365/Windows licensing entitlement trap, HCI meter mixing trap, billing dependencies on VMs + Storage.

**No disagreements** — all 3 reports found identical meters, prices, and edge cases.

**Key finding incorporated:** All 3 reports confirmed that session host VMs are charged at Linux compute rates for Windows 10/11 OS — a significant cost estimation insight missing from the existing Notes section.

### Compliance Contract Summary

Both compliance reviews confirmed:
- YAML frontmatter: all required fields present, elision rules correctly applied
- Section order: correct (YAML → Title → Traps → Query Pattern → Key Fields → Meter Names → Cost Formula → Notes)
- 45-line rule: both files have first query pattern well within lines 1–45
- 100-line limit: VMware at 73, WVD at 68
- No hardcoded prices, no verified dates

### Documentation Cross-Check

- **VMware Solution:** Azure pricing page confirms VCF BYOL model, per-host hourly billing, AV36 VCF BYOL as current SKU, minimum 3 nodes
- **Windows Virtual Desktop:** MS Learn confirms per-user access pricing model, M365 license entitlement, VMs at Linux rates

### Validation

Both files pass all checks:
```
pwsh tests/Validate-ServiceReference.ps1 -Path {file} -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
RESULT: PASS - All checks passed (×2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure VMware Solution cost reference with new AV36 VCF BYOL Node pricing meter and improved region availability details
  * Clarified Windows Virtual Desktop session host VM billing information in cost documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->