### PR TITLE
Audit analytics service references (Stage 2/3)

### DIFF
--- a/skills/azure-cost-calculator/references/services/analytics/fabric.md
+++ b/skills/azure-cost-calculator/references/services/analytics/fabric.md
@@ -83,6 +83,7 @@ Total Monthly    = Capacity + Storage + Overage
 - **OneLake storage billed separately**: Storage is not included in the CU-hour capacity rate; query the `OneLake` product for storage costs
 - **Pause/resume**: Pausing a capacity stops CU billing; OneLake storage charges continue
 - **Free mirroring storage**: Each F-SKU includes free mirroring equal to the SKU number in TB (e.g., F64 = 64 TB); excess at the `Storage Mirroring` rate
+- **Cosmos DB / SQL in Fabric**: Dedicated OneLake storage meters exist for these features at higher per-GB rates than standard OneLake; query `ProductName: OneLake` with the specific `SkuName` (e.g., `Cosmos DB Storage`, `SQL Storage`)
 - **Networking**: Data transfer billing is not yet active — Microsoft will provide 90 days notice before charges begin
 
 ## Reserved Instance Pricing

--- a/skills/azure-cost-calculator/references/services/analytics/signalr.md
+++ b/skills/azure-cost-calculator/references/services/analytics/signalr.md
@@ -3,12 +3,13 @@ serviceName: SignalR
 category: analytics
 aliases: [Azure SignalR Service, Real-time Messaging]
 primaryCost: "Per-unit daily rate (by tier) + messages per 1M/month"
+hasFreeGrant: true
 privateEndpoint: true
 ---
 
-# Azure SignalR Service
+# SignalR
 
-> **Trap (daily billing)**: Unit meters use `1/Day` billing. `Get-MonthlyMultiplier` returns `30` for these meters, so the script's `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30` — that would overcount by 30x.
+> **Trap (daily billing)**: Unit meters use `1/Day` billing. The script auto-multiplies by 30 for daily meters, so `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30` — that would overcount by 30×.
 
 > **Trap (free tier rows)**: The `Standard Unit - Free` meter returns a zero price. This is a free-tier grant (1 unit with 20 concurrent connections and 20K messages/day). Its price does not inflate `totalMonthlyCost`, but including it adds noise — filter by `MeterName` to exclude free-tier rows when estimating paid usage.
 

--- a/skills/azure-cost-calculator/references/services/analytics/stream-analytics.md
+++ b/skills/azure-cost-calculator/references/services/analytics/stream-analytics.md
@@ -74,3 +74,4 @@ Edge:              Monthly = retailPrice × deviceCount
 - **Dedicated tiers**: Same pricing as Standard counterparts; substitute `SkuName: Dedicated` or `Dedicated V2` in query patterns for isolated, high-throughput workloads
 - **Edge**: Per-device monthly flat rate; runs on IoT Edge devices for local stream processing
 - **No ArmSkuName**: All meters return empty `armSkuName` — do not filter by this field
+- Private endpoints require a Stream Analytics cluster (Dedicated tiers); Standard tier cloud jobs do not support PE


### PR DESCRIPTION
## Audit: Analytics Service References — Stage 2 of 3

Closes #246

### Approach

Each service was investigated by **3 independent pricing-investigator agents** (using `claude-sonnet-4.5`, `gpt-5.1-codex`, `claude-opus-4.6`) plus **1 compliance-reviewer agent** (`claude-sonnet-4.6`). Fresh references were generated, compared against existing files, and reconciled.

### Files Audited

#### `fabric.md` — Microsoft Fabric
**Investigation consensus**: All 3 investigators reached **unanimous agreement** on all findings. No tiebreaker needed.
- `serviceName`: `Microsoft Fabric` (3 products: Fabric Capacity, OneLake, Fabric Capacity Reservation)
- 64 Fabric Capacity meters (63 standard CU @ identical rate + 1 overage @ 3×)
- 10 OneLake storage meters (primary, cache, BCDR, mirroring, + Cosmos DB/SQL features)
- RI available: 1Y ≈ 3Y (~40.5% discount both terms)
- **Change**: Added note about Cosmos DB / SQL in Fabric dedicated storage meters (discovered by all 3 investigators but missing from existing file)

#### `signalr.md` — SignalR
**Investigation consensus**: All 3 investigators reached **unanimous agreement**. No tiebreaker needed.
- `serviceName`: `SignalR` (single product, 5 meters)
- Daily billing (1/Day) for units + per-1M for messages
- RI: **Not available** (confirmed by all 3)
- **Changes**:
  - Added missing `hasFreeGrant: true` (compliance violation — free tier: 1 unit, 20 connections, 20K messages/day)
  - Changed H1 from `# Azure SignalR Service` to `# SignalR` (match routing map display name)
  - Rewrote daily billing trap to remove internal `Get-MonthlyMultiplier` function name reference

#### `stream-analytics.md` — Stream Analytics
**Investigation consensus**: All 3 investigators reached **unanimous agreement**. No tiebreaker needed.
- `serviceName`: `Stream Analytics` (2 products: cloud + Edge)
- V2 SKUs: tiered pricing (3 bands at TierMinUnits 0, 730, 5840)
- Standard/Dedicated V1: identical flat rates ($0.11/hr)
- Edge: per-device monthly ($1.00/month)
- RI: **Not available** (confirmed by all 3)
- **Change**: Added PE tier restriction note (Dedicated clusters only — Standard jobs don't support PE)

### Compliance Review Summary
- **fabric.md**: Substantively compliant. Only gap was missing Cosmos DB/SQL storage meters (new features).
- **signalr.md**: 2 compliance violations found and fixed: missing `hasFreeGrant: true`, H1 title mismatch.
- **stream-analytics.md**: Missing PE tier restriction note (compliance gap — PE requires Dedicated cluster).

### Documentation Cross-Check
All 3 investigators cross-checked findings against Microsoft Learn pricing pages. No API-vs-documentation discrepancies found for core billing models.

### Validation
All 3 files pass `Validate-ServiceReference.ps1` with `-CheckAliasUniqueness`, `-CheckRoutingFileSync`, and `-CheckBillingNeeds`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fabric service documentation with guidance on dedicated storage meters for Cosmos DB and SQL.
  * Clarified SignalR billing calculation behavior and added free grant information.
  * Added Stream Analytics documentation about private endpoint tier requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->