### PR TITLE
Audit web service references: cognitive-search, static-web-apps

### DIFF
--- a/skills/azure-cost-calculator/references/services/web/cognitive-search.md
+++ b/skills/azure-cost-calculator/references/services/web/cognitive-search.md
@@ -3,6 +3,7 @@ serviceName: Azure Cognitive Search
 category: web
 aliases: [Azure AI Search, Search Service, Full-text Search]
 primaryCost: "Fixed hourly rate per search unit (SU) × 730, varies by tier"
+hasFreeGrant: true
 privateEndpoint: true
 ---
 
@@ -68,3 +69,4 @@ Total = Monthly Base + Semantic
 - **Free tier**: 1 index, 50 MB storage, no SLA. Use `skuName='Free'`.
 - **Tier limits**: Basic supports up to 3 replicas, 1 partition. Standard tiers support up to 12 replicas, 12 partitions. L1/L2 support up to 12 replicas, 12 partitions.
 - **Semantic Ranker**: Billed daily, not hourly. Script auto-multiplies `1/Day` by 30. Also has per-query overage meters (`Semantic Ranker queries`, `Semantic Ranker Overage Queries`).
+- **Private Endpoints**: Supported on Basic tier and above — not available on the Free tier.

--- a/skills/azure-cost-calculator/references/services/web/static-web-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/static-web-apps.md
@@ -76,3 +76,4 @@ Total       = App + Bandwidth + AFD Add-on
 - **Bandwidth**: Standard includes 100 GB/month free. Query API for overage rate per GB — the API returns two bandwidth rows per region (free tier and overage tier).
 - **Azure Front Door add-on**: Optional. Provides enterprise-grade edge with WAF, custom rules, and bot protection. Query API for current hourly rate.
 - **Tier limitations**: Free tier — 2 custom domains, 0.5 GB storage, community support. Standard tier — 5 custom domains, 2 GB storage, SLA-backed.
+- **Private Endpoints**: Supported on Standard tier only — not available on the Free tier.


### PR DESCRIPTION
## Service Reference Audit — Web

Closes #273

### Audit Summary

Audited **2 service reference files** in the `web` category using the multi-agent validation pipeline. Each service was investigated by **3 independent pricing-investigator agents** (using claude-sonnet-4.5, gpt-5.1-codex, claude-opus-4.6) plus **1 compliance-reviewer agent**.

### Investigation Reports — Agreement/Disagreement

#### Azure Cognitive Search
- **3/3 unanimous** on all findings: serviceName (`Azure Cognitive Search`), single productName (`Azure AI Search`), 30 meters total, all 7 base tiers + CC variants, Semantic Ranker meters, Agentic Retrieval meters, no RI availability
- **No disagreements** — no tiebreaker needed
- All 3 investigators confirmed existing query patterns, meter names, and traps are accurate

#### Azure Static Web Apps
- **3/3 unanimous** on all findings: API serviceName (`Azure App Service`), productName (`Static Web Apps`), 4 meter rows (3 meters + 1 tiered bandwidth), no RI, eastus unavailable, Free tier has no API meters
- **No disagreements** — no tiebreaker needed
- All 3 investigators confirmed existing file content is accurate and up-to-date

### Compliance Contract Summary

#### Cognitive Search
- **Gap found**: Missing `hasFreeGrant: true` — Free SKU (1 index, 50 MB, no SLA) exists but field was omitted
- **Gap found**: Missing Private Endpoint tier restriction note — PE requires Basic tier or above (not available on Free)
- **H1 title note**: File uses `# Azure AI Search` (current Microsoft branding) while routing map display name is `Azure Cognitive Search`. Left as-is since it reflects the current official service name.
- All other fields, sections, and formatting passed compliance review

#### Static Web Apps
- **Gap found**: Missing Private Endpoint tier restriction note — PE requires Standard tier (not available on Free)
- All YAML fields, query patterns, traps, and section ordering passed compliance review

### Documentation Cross-Check Findings

#### Cognitive Search
- Pricing page and Learn docs confirm all API findings
- S3 HD is a hosting mode (not separate SKU) — no separate API meter, consistent with docs
- CC (Customer-Controlled encryption) variants confirmed as separate SKUs with ~10% premium
- Agentic Retrieval is a newer feature with sub-cent token pricing and free grants per reasoning level

#### Static Web Apps
- All API pricing matches documentation (/month Standard App, 100 GB free bandwidth, bash.20/GB overage, bash.024/hr AFD add-on)
- Minor discrepancy: pricing page says "billed on a per hour basis" but API meter is `1/Month` — treated as monthly per API evidence
- PE confirmed Standard-only via Learn docs

### Changes Made

| File | Change | Rationale |
|------|--------|-----------|
| `cognitive-search.md` | Added `hasFreeGrant: true` to YAML | Free SKU exists; field was missing (compliance gap) |
| `cognitive-search.md` | Added PE tier restriction note | PE requires Basic+; CONTRIBUTING.md requires note for tier restrictions |
| `static-web-apps.md` | Added PE tier restriction note | PE requires Standard; CONTRIBUTING.md requires note for tier restrictions |

### Validation

Both files pass all checks:
```
pwsh tests/Validate-ServiceReference.ps1 -Path ...cognitive-search.md -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
RESULT: PASS - All checks passed

pwsh tests/Validate-ServiceReference.ps1 -Path ...static-web-apps.md -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
RESULT: PASS - All checks passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service documentation with clarifications on Private Endpoints availability across service tiers. Cognitive Search now specifies support on Basic tier and above, while Static Web Apps support is limited to Standard tier only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->