### PR TITLE
Audit storage service references (Stage 1/2): backup, data-box, data-lake-storage

### DIFF
--- a/skills/azure-cost-calculator/references/services/storage/backup.md
+++ b/skills/azure-cost-calculator/references/services/storage/backup.md
@@ -56,7 +56,7 @@ MeterName: SQL Server in Azure VM Protected Instances
 | `GRS Data Stored`                            | `Standard`               | `1 GB/Month`  | Geo-redundant vault storage |
 | `Archive LRS Data Stored`                    | `Archive`                | `1 GB/Month`  | Archive tier LRS            |
 
-Other workload types: `PostgreSQL`, `Azure Kubernetes`, `Azure Blob`, `ADLS Gen2 Vaulted`, `SAP ASE on Azure VM`. ZRS and RA-GRS storage meters also available.
+Other workload types: `PostgreSQL`, `Azure Kubernetes`, `Azure Blob`, `ADLS Gen2 Vaulted`, `SAP ASE on Azure VM`, `Cross region for ADLS and Blobs`. ZRS and RA-GRS storage meters also available. Blob/ADLS Gen2 Vaulted also include per-10K write operation meters by redundancy.
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/storage/data-box.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box.md
@@ -73,7 +73,7 @@ Multi-device = Per order × deviceCount
 
 ## Notes
 
-- Included days before overage: Data Box Disk = 3, Data Box 100 TB = 10, Heavy = 20
+- Included days before overage: Disk = 3, Data Box 100 TB = 10, V2 120 TB = 10, Heavy = 20, V2 525 TB = 20
 - Data Box Disk capacity: 8 TB usable per disk, up to 5 disks per order (40 TB max)
 - Data Box V2 (120 TB / 525 TB) is the newer generation with higher overage rates
 - Export orders use the same device fees; Azure Bandwidth egress charges are billed separately

--- a/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
@@ -69,10 +69,9 @@ MeterName: Cold LRS Data Stored
 | `Hot GRS Write Operations`       | `Hot GRS`       | `10K`         | GRS/RA-GRS shared                             |
 | `Hot Read Operations`            | _(any Hot)_     | `10K`         | Generic, not redundancy-specific              |
 | `Hot Iterative Write Operations` | `Hot LRS`       | `100`         | Directory listing; unit is per-100            |
-| `Cool Data Retrieval`            | _(any Cool)_    | `1 GB`        | Per-GB retrieval charge                       |
+| `Cool Data Retrieval`            | _(any Cool)_    | `1 GB`        | Per-GB retrieval; Cold tier same pattern      |
 | `Cool LRS Early Delete`          | `Cool LRS`      | `1 GB`        | Deleted before 30-day minimum                 |
 | `Cold LRS Data Stored`           | `Cold LRS`      | `1 GB/Month`  | Between Cool and Archive pricing              |
-| `Cold Data Retrieval`            | _(any Cold)_    | `1 GB`        | Per-GB retrieval charge                       |
 | `Cold LRS Early Delete`          | `Cold LRS`      | `1 GB`        | Deleted before 90-day minimum                 |
 | `Archive LRS Data Stored`        | `Archive LRS`   | `1 GB/Month`  | Cheapest storage; no ZRS/GZRS                 |
 | `Archive Data Retrieval`         | _(any Archive)_ | `1 GB`        | Standard rehydration                          |
@@ -97,3 +96,4 @@ Monthly = Σ(storage_retailPrice × GB_in_tier)
 - Archive tier: LRS, GRS, RA-GRS only (no ZRS/GZRS); Early Delete charges: Cool 30d, Cold 90d, Archive 180d
 - Iterative operations (directory listing) use per-100 unit for writes, per-10K for reads; Hot tier only
 - Flat Namespace product has identical storage pricing but no Index meter and lower transaction costs
+- **Private Endpoints**: sub-resources `dfs` and `blob` (never-assume)


### PR DESCRIPTION
## Storage Service Reference Audit — Stage 1 of 2

Closes #271

### Audit Approach

Each service was investigated by **3 independent pricing-investigator agents** (using `claude-opus-4.6`, `gpt-5.1-codex`, `claude-sonnet-4.5`) plus **1 compliance-reviewer agent**. Fresh findings were compared against existing files and reconciled.

### Investigation Reports Summary

#### backup.md (86 lines)
- **Investigators**: 3/3 unanimous on all API data (36 PAYG + 16 RI meters)
- **Disagreements**: None — no tiebreaker needed
- **Changes**: Added `Cross region for ADLS and Blobs` to workload footnote; added per-10K write operation note for Blob/ADLS Gen2 Vaulted
- **Compliance**: All YAML fields correct; section order, 45-line rule, 100-line limit all pass

#### data-box.md (81 lines)
- **Investigators**: 3/3 unanimous on all API data (19 meters across 5 products)
- **Disagreements**: None — no tiebreaker needed
- **Changes**: Added V2 included days to Notes (120 TB = 10 days, 525 TB = 20 days)
- **Compliance**: All YAML fields correct; Data Box V2 missing shipping meter confirmed by all investigators (already documented)

#### data-lake-storage.md (99 lines)
- **Investigators**: 3/3 unanimous on all API data (181 HNS + 173 Flat Namespace meters)
- **Disagreements**: None — no tiebreaker needed
- **Changes**: Added Private Endpoints note for `dfs` and `blob` sub-resources (never-assume, flagged by compliance reviewer); consolidated Cold Data Retrieval into Cool row to make room
- **Compliance**: PE sub-resources note was missing per CONTRIBUTING.md rules; now added

### Compliance Contract Summary

All 3 files were checked against:
- `CONTRIBUTING.md` — section ordering, line limits, formatting, hardcoded-price prohibition
- `docs/TEMPLATE.md` — file structure, query pattern format, trap syntax
- `tests/schema/frontmatter-schema.psd1` — YAML field validation, elision rules
- `skills/azure-cost-calculator/references/shared.md` — constants, disambiguation protocol
- `skills/azure-cost-calculator/references/pitfalls.md` — known API traps

### Documentation Cross-Check

All 3 investigators cross-checked against Microsoft Learn documentation for each service. Key findings:
- **Backup**: Size-tiered protected instance pricing (e.g., ≤50 GB VMs = $5/month) is documented on the pricing page but NOT exposed in the API (only returns the >50 GB rate). Free 31-day storage benefit confirmed not in API.
- **Data Box**: V2 shipping meter confirmed missing from API by all 3 investigators. Pricing pages confirm shipping charges exist but are not itemized in the Retail Prices API.
- **Data Lake Storage**: Tiered Hot pricing (0-50 TB / 50-500 TB / 500+ TB) confirmed matching `tierMinimumUnits` breakpoints. Archive ZRS found in 5 regions only (limited availability).

### Validation Output

All 3 files pass:
```
pwsh tests/Validate-ServiceReference.ps1 -Path {file} -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
RESULT: PASS - All checks passed (×3)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure Backup reference with new supported workload types and write operation meter details
  * Expanded Data Box reference with additional device variants and their included days before overage
  * Enhanced Data Lake Storage reference with new priority retrieval meters and Private Endpoints information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->