### PR TITLE
audit(databases): Stage 1/3 — cosmos-db, database-for-mysql, database-for-postgresql

### DIFF
--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
@@ -72,7 +72,10 @@ Total              = Throughput + Storage
 - The storage query returns multiple skuName variants (`RUs`, `mRUs`, `RUm`, `Free Tier`) — filter to `RUs` for standard provisioned
 - **Multi-region write (multi-master) costs ~2× single-region**: The `100 Multi-master RU/s` meter (skuName `mRUs`) is approximately double the price of the standard `100 RU/s` meter (skuName `RUs`). Always inform users about this multiplier when they request multi-region writes. For cost comparison, query both meters and show the per-region price difference.
 - **Autoscale provisioned throughput**: The API has a **separate product** (`Azure Cosmos DB autoscale`) with its own meter (`AP1 100 RUs`, skuName `AP1`). The autoscale rate is exactly 1.5× the standard provisioned rate and this premium is **already included** in the API price. Do NOT query the standard `100 RU/s` meter and manually multiply by 1.5 — instead query the autoscale product directly. With autoscale, billing is based on the maximum RU/s set; calculate as `autoscale_price × (maxRUs / 100) × 730`.
-- PE sub-resource matches the account API type (never-assume): `Sql`, `MongoDB`, `Cassandra`, `Gremlin`, or `Table`. Conditional: `SqlDedicated` (dedicated gateway), `Analytical` (Synapse Link)
+- **MongoDB vCore**: Cosmos DB for MongoDB vCore uses productName `Azure DocumentDB` with vCore-based billing (coordinator + worker nodes, per-vCore hourly). Do not use RU/s queries for vCore clusters.
+- **Backup costs**: Continuous backup (productName `Azure Cosmos DB - PITR`) and periodic snapshots (productName `Azure Cosmos DB Snapshot`) are billed separately per-GB. 7-day continuous backup is included free; 30-day and on-demand are charged.
+- **Add-on products**: Dedicated Gateway, Garnet Cache, Materialized Views, Analytics Storage, and Graph API compute have separate productNames under the same serviceName — query each individually.
+- **PE sub-resources** (never-assume): `Sql`, `MongoDB`, `Cassandra`, `Gremlin`, `Table`. Conditional: `SqlDedicated` (dedicated gateway), `Analytical` (Synapse Link)
 
 ## Reserved Instance Pricing
 

--- a/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
@@ -76,7 +76,7 @@ Total = Compute + Storage
 
 - Burstable: dev/test workloads, does NOT support RI, max 20 vCores
 - GP: production workloads, supports RI, per-vCore pricing with InstanceCount
-- MO Edsv5: high-memory workloads, per-size SKU pricing (Standard_E2d_v5 through Standard_E96d_v5)
+- MO Edsv5: per-size SKU pricing (Standard_E2d_v5 through Standard_E96d_v5, no RI); v6 MO series (Edsv6, Eadsv6) use per-vCore pricing with InstanceCount
 - High Availability doubles compute cost (deploys a standby replica)
 - Backup: first backup equal to provisioned storage is free; excess charged per-GB/month
 - Single Server is deprecated — all new deployments use Flexible Server
@@ -87,10 +87,12 @@ Total = Compute + Storage
 | ------------- | --------------------------------------------------------------------------------- |
 | GP, Ddsv5     | `Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute`   |
 | GP, Dadsv5    | `Azure Database for MySQL Flexible Server General Purpose Dadsv5 Series Compute`  |
-| GP, Dv3       | `Azure Database for MySQL Flexible Server General Purpose Dv3 Series Compute`     |
+| GP, Ddsv6     | `Azure Database for MySQL Flexible Server General Purpose Ddsv6 Series Compute`   |
+| GP, Dadsv6    | `Azure Database for MySQL Flexible Server General Purpose Dadsv6 Series Compute`  |
 | MO, Edsv5     | `Azure Database for MySQL Flexible Server Memory Optimized Edsv5 Series Compute`  |
 | MO, Eadsv5    | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
-| BC, Ev3       | `Azure Database for MySQL Flexible Server Business Critical Ev3 Series Compute`   |
+| MO, Edsv6     | `Azure Database for MySQL Flexible Server Memory Optimized Edsv6 Series Compute`  |
+| MO, Eadsv6    | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv6 Series Compute` |
 | Burstable, BS | `Azure Database for MySQL Flexible Server Burstable BS Series Compute`            |
 | Storage       | `Azure Database for MySQL Flexible Server Storage`                                |
 | Backup        | `Azure Database for MySQL Flexible Server Backup Storage`                         |

--- a/skills/azure-cost-calculator/references/services/databases/database-for-postgresql.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-postgresql.md
@@ -9,8 +9,6 @@ privateEndpoint: true
 
 # Azure Database for PostgreSQL Flexible Server
 
-**Multiple meters**: vCore compute (hourly) + storage (per-GB/month)
-
 > **Trap**: `productName` has inconsistent hyphen usage across series. Some use `General Purpose - Ddsv5` (with hyphen) while others use `General Purpose Dadsv5` (no hyphen). Always use the exact string from discovery — do not construct productName by pattern.
 
 ## Query Pattern
@@ -22,49 +20,60 @@ ProductName: Azure Database for PostgreSQL Flexible Server General Purpose - Dds
 SkuName: 4 vCore
 MeterName: vCore
 
-### Storage cost
+### Storage cost (100 GB)
 
 ServiceName: Azure Database for PostgreSQL
 ProductName: Az DB for PostgreSQL Flexible Server Storage
 SkuName: Storage
 MeterName: Storage Data Stored
+Quantity: 100 # storage size in GB
 
 ## Key Fields
 
-| Parameter     | How to determine             | Example values                                      |
-| ------------- | ---------------------------- | --------------------------------------------------- |
-| `productName` | Tier + series (exact match)  | See Product Names table below                       |
+| Parameter     | How to determine             | Example values                                       |
+| ------------- | ---------------------------- | ---------------------------------------------------- |
+| `productName` | Tier + series (exact match)  | See Product Names table below                        |
 | `skuName`     | vCore count string           | `'2 vCore'`, `'4 vCore'`, `'8 vCore'`, `'16 vCore'` |
-| `meterName`   | Always `'vCore'` for compute | `'vCore'`, `'Storage Data Stored'`                  |
-| `armSkuName`  | VM-like size                 | `Standard_D4ds_v5`, `Standard_D8ds_v5`              |
+| `meterName`   | Always `'vCore'` for compute | `'vCore'`, `'Storage Data Stored'`                   |
 
-## Product Names (common, case-sensitive)
+## Meter Names
 
-| Config                         | productName                                                                             |
-| ------------------------------ | --------------------------------------------------------------------------------------- |
-| General Purpose, Ddsv5 series  | `Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute`  |
-| General Purpose, Ddsv4 series  | `Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv4 Series Compute`  |
-| General Purpose, Dadsv5 series | `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv5 Series Compute`   |
-| General Purpose, Dsv3 series   | `Azure Database for PostgreSQL Flexible Server General Purpose - Dsv3 Series Compute`   |
-| Burstable, Bsv2 series         | `Azure Database for PostgreSQL Flexible Server Burstable - Bsv2 Series Compute`         |
-| Memory Optimized, Edsv5 series | `Azure Database for PostgreSQL Flexible Server Memory Optimized - Edsv5 Series Compute` |
-| Storage                        | `Az DB for PostgreSQL Flexible Server Storage`                                          |
-
-> **Note**: The storage productName uses the abbreviation `Az DB for PostgreSQL` — not the full `Azure Database for PostgreSQL`.
+| Meter                            | skuName             | unitOfMeasure | Notes                                  |
+| -------------------------------- | ------------------- | ------------- | -------------------------------------- |
+| `vCore`                          | `N vCore`           | `1 Hour`      | Per-vCore rate; N determines vCore count |
+| `Storage Data Stored`            | `Storage`           | `1 GB/Month`  | Standard LRS data storage              |
+| `Backup Storage LRS Data Stored` | `Backup Storage LRS` | `1 GB/Month` | Backup beyond free grant               |
 
 ## Cost Formula
 
 ```
 Monthly Compute = unitPrice × 730
-Monthly Storage = storagePrice × sizeGB
+Monthly Storage = storage_retailPrice × sizeGB
 Total = Compute + Storage
 ```
 
-Query storage rate from the API — it varies by region and currency.
-
 ## Notes
 
-- `skuName` determines the vCore count — no quantity multiplier needed for compute
-- Use the explore script with SearchTerm PostgreSQL Flexible to discover available series
-- High Availability doubles the compute cost (deploys a standby replica)
-- Backup storage: first backup equal to DB size is free; excess is charged per-GB/month
+- Burstable: dev/test workloads, does NOT support RI. Uses fixed SKU names (B1MS, B4ms, etc.)
+- GP: production workloads, supports RI. Uses `SkuName: N vCore` to select size
+- MO: high-memory workloads, supports RI. Same per-vCore pattern as GP
+- High Availability doubles compute cost (deploys a standby replica)
+- Backup storage: first backup equal to DB size is free; excess charged per-GB/month
+- Single Server is deprecated — all new deployments use Flexible Server
+- Cosmos DB for PostgreSQL meters share this serviceName — filter by productName to isolate Flexible Server
+
+## Product Names
+
+| Config         | productName                                                                            |
+| -------------- | -------------------------------------------------------------------------------------- |
+| GP, Ddsv5      | `Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute` |
+| GP, Dadsv5     | `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv5 Series Compute`  |
+| GP, Ddsv6      | `Azure Database for PostgreSQL Flexible Server General Purpose Ddsv6 Series Compute`   |
+| GP, Dadsv6     | `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv6 Series Compute`  |
+| MO, Edsv5      | `Azure Database for PostgreSQL Flexible Server Memory Optimized Edsv5 Series Compute`  |
+| MO, Eadsv5     | `Azure Database for PostgreSQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
+| MO, Edsv6      | `Azure Database for PostgreSQL Flexible Server Memory Optimized Edsv6 Series Compute`  |
+| Burstable, BS  | `Azure Database for PostgreSQL Flexible Server Burstable BS Series Compute`            |
+| Storage        | `Az DB for PostgreSQL Flexible Server Storage`                                         |
+
+> **Note**: The storage productName uses the abbreviation `Az DB for PostgreSQL` — not the full `Azure Database for PostgreSQL`.


### PR DESCRIPTION
## Summary

Audited 3 database service references per #254. For each service, dispatched **3× independent pricing investigators** (default, claude-sonnet-4.5, gpt-5.1-codex) + **1× compliance reviewer**, compared reports for consensus, then reconciled findings against existing files.

**Investigation agreement: 3/3 unanimous for all 3 services — zero disagreements across 9 pricing reports.**

---

### Cosmos DB (`cosmos-db.md`)

**Pricing Investigation (3/3 agree):** 14+ productName values, 107+ meters in eastus. RI requires `Region: Global` (regional queries return zero). MongoDB vCore uses `Azure DocumentDB` productName with different billing model.

**Compliance Review:** File was largely compliant. PE sub-resources note needed reformatting.

**Changes:**
- Added 3 notes: MongoDB vCore billing, backup costs (PITR + Snapshot), add-on products (Dedicated Gateway, Garnet Cache, Materialized Views, Graph API)
- Reformatted PE sub-resources note to standard `(never-assume)` format
- 85 → 87 lines ✅

---

### MySQL (`database-for-mysql.md`)

**Pricing Investigation (3/3 agree):** 82 consumption + 30 RI meters, 33+ productName values. v6 series available but missing from file. Dual vCore meter trap confirmed. Edsv5 MO uses per-SKU pricing with no RI.

**Compliance Review:** Product Names table had legacy entries (GP Dv3, BC Ev3). MO note didn't clarify v6 per-vCore vs Edsv5 per-SKU difference.

**Changes:**
- Replaced legacy Product Names with v6 series (GP Ddsv6, GP Dadsv6, MO Edsv6, MO Eadsv6)
- Updated MO note: v6 uses per-vCore pricing vs Edsv5 per-SKU (no RI for Edsv5)
- 97 → 98 lines ✅

---

### PostgreSQL (`database-for-postgresql.md`)

**Pricing Investigation (3/3 agree):** Multiple **factual errors** found in existing file:
- Wrong productNames: Ddsv4/Dsv3/Edsv5 had incorrect hyphens (only Ddsv5 has a hyphen)
- Burstable product was `Bsv2` (correct: `BS`)
- Missing v6 series, Confidential Compute, Mdsv2

**Compliance Review:** Additional structural issues:
- `(case-sensitive)` annotation on Product Names header (fails validation)
- Product Names section placed before Notes (wrong section order)
- Bold text line not in blockquote format
- No `Quantity:` parameter in storage query

**Changes:**
- Fixed all productName errors with API-verified values
- Corrected section order (Product Names after Notes)
- Added Meter Names table, tier limitation notes, v6 series
- Added `Quantity: 100` to storage query, removed non-standard bold text
- 71 → 79 lines ✅

---

### Validation

All 3 files pass full validation:
```
pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
```

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Cosmos DB cost reference documentation with detailed guidance on MongoDB vCore billing, backup costs, add-on products, and private endpoint sub-resources
  * Updated MySQL documentation to reflect latest v6 series pricing models and removed deprecated variants
  * Restructured PostgreSQL cost reference with improved table layouts, explicit cost formulas, and expanded guidance on workload types and server configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->