### PR TITLE
Audit IoT service references (Stage 1/2): event-grid, event-hubs, iot-hub

### DIFF
--- a/skills/azure-cost-calculator/references/services/iot/event-hubs.md
+++ b/skills/azure-cost-calculator/references/services/iot/event-hubs.md
@@ -14,8 +14,6 @@ privateEndpoint: true
 
 ## Query Pattern
 
-All patterns below use `ServiceName: Event Hubs`.
-
 ### Standard tier — throughput unit (base cost)
 
 ServiceName: Event Hubs

--- a/skills/azure-cost-calculator/references/services/iot/iot-hub.md
+++ b/skills/azure-cost-calculator/references/services/iot/iot-hub.md
@@ -3,6 +3,7 @@ serviceName: IoT Hub
 category: iot
 aliases: [Device Messaging]
 primaryCost: "Per-unit monthly flat rate by tier (Free, B1–B3, S1–S3) × unit count"
+hasFreeGrant: true
 privateEndpoint: true
 ---
 
@@ -14,16 +15,16 @@ privateEndpoint: true
 
 ## Query Pattern
 
-All patterns below use `ServiceName: IoT Hub` and `ProductName: IoT Hub` unless noted otherwise.
-
 ### Standard S1 tier — per unit/month (use InstanceCount: N for multi-unit)
 
 ServiceName: IoT Hub
+ProductName: IoT Hub
 MeterName: S1 Unit
 
 ### Basic B1 tier
 
 ServiceName: IoT Hub
+ProductName: IoT Hub
 MeterName: B1 Unit
 
 ### IoT Hub Device Provisioning Service — 100K operations (Quantity in 1K units)


### PR DESCRIPTION
## Service Reference Audit — IoT (Stage 1 of 2)

Closes #260

### Audit Summary

Performed a full multi-agent audit of 3 IoT service reference files using the `service-reference` orchestrator workflow. For each service, dispatched **3 independent pricing investigators** (claude-sonnet-4.5, claude-haiku-4.5, gpt-5.1-codex) and **1 compliance reviewer**, then aggregated findings using consensus-driven validation.

---

### Event Grid (`event-grid.md`) — ✅ No changes

**Pricing Investigation Consensus (3/3 unanimous):**
- 4 meters confirmed: Standard Operations (100K), Standard Event Operations (1M), Standard MQTT Operations (1M), Standard Throughput Unit (1 Hour)
- 7 total API rows (3 meters × free+paid tiers + throughput)
- Free grants verified: 100K/mo for Standard Ops, 1M/mo each for Event Ops and MQTT Ops
- No RI, no zone-redundancy, single productName/skuName (Event Grid / Standard)
- Existing file at 83 lines fully accurate and compliant

**Compliance Review:** All checklist items pass. No changes required.

---

### Event Hubs (`event-hubs.md`) — 🔧 Minor fix

**Pricing Investigation Consensus (3/3 unanimous):**
- 11 meters across 4 tiers (Basic, Standard, Premium, Dedicated) + Geo Replication
- No RI, no free grants
- All meter names, unitOfMeasure, and pricing confirmed accurate

**Changes:**
- Removed redundant `All patterns below use ServiceName: Event Hubs` preamble (line 17). Query blocks already include `ServiceName: Event Hubs` per CONTRIBUTING.md batch mode rule. The preamble violated the guidance: "Do not rely on 'All patterns below use...' preambles."

---

### IoT Hub (`iot-hub.md`) — 🔧 Moderate fixes

**Pricing Investigation Consensus (3/3 unanimous):**
- 12 meters across 3 products: IoT Hub (Free/B1-B3/S1-S3), IoT Hub Device Provisioning (S1 Operations), Device Update for IoT Hub (Free/Standard)
- No RI, `1/Month` unitOfMeasure confirmed (no ×730 conversion)
- Free tier verified: 1 unit max, 8K msgs/day

**Changes:**
1. Added `hasFreeGrant: true` to YAML — Free tier exists but was not flagged in frontmatter
2. Removed `All patterns below use...` preamble and added explicit `ProductName: IoT Hub` to S1 and B1 query blocks for batch mode self-containment (aligns with the trap's own instruction to always use ProductName filter)

---

### Disagreements & Tiebreakers

**None required.** All 3 pricing investigators were unanimous on all data points for all 3 services. No tiebreaker investigations were needed.

### Validation

All files pass:
```
pwsh tests/Validate-ServiceReference.ps1 -Path {file} -CheckAliasUniqueness -CheckRoutingFileSync -CheckBillingNeeds
```
- event-grid.md: 83 lines, PASS
- event-hubs.md: 80 lines, PASS
- iot-hub.md: 74 lines, PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in Event Hubs reference documentation by removing redundant pattern information.
  * Enhanced IoT Hub reference documentation metadata to better reflect service product mappings for Standard, Basic, and Device Provisioning Service tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->