### PR TITLE
feat: set release PRs to non-draft and add plugin install to README

### DIFF
--- a/.github/workflows/weekly-release.lock.yml
+++ b/.github/workflows/weekly-release.lock.yml
@@ -22,7 +22,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# frontmatter-hash: 38810801b58a65f429b03fc1155c9548175af6ab0099b7d7b02efac577654423
+# frontmatter-hash: 1ac0a5de5dd9f297820f66b4283ac0b76df138d6ce35dc888fbaeba6a4df3d53
 
 name: "Weekly Release"
 "on":
@@ -198,7 +198,7 @@ jobs:
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"release: \". Labels [release] will be automatically added. PRs will be created as drafts.",
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"release: \". Labels [release] will be automatically added.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1050,7 +1050,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"main\",\"draft\":true,\"labels\":[\"release\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"release: \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"main\",\"draft\":false,\"labels\":[\"release\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"release: \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/weekly-release.md
+++ b/.github/workflows/weekly-release.md
@@ -17,7 +17,7 @@ safe-outputs:
     base-branch: main
     title-prefix: "release: "
     labels: [release]
-    draft: true
+    draft: false
 concurrency:
   group: weekly-release
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ Real-time Azure cost estimation using the public [Azure Retail Prices API](https
 
 ## Install
 
+**Plugin install** (recommended — versioned releases):
+
+```bash
+# GitHub Copilot CLI or Claude Code (run inside a session)
+/plugin install ahmadabdalla/azure-cost-calculator-skill
+```
+
+**npx** (works with any agent):
+
 ```bash
 npx skills add ahmadabdalla/azure-cost-calculator-skill
 ```
 
 > **Don't have `npx`?** Install [Node.js](https://nodejs.org/) (which includes `npm` and `npx`), or run `npm install -g skills` first then use `skills add ahmadabdalla/azure-cost-calculator-skill`.
 
-The CLI auto-detects your agent (Claude Code, Cursor, GitHub Copilot, Codex, etc.) and installs the skill to the correct directory.
+Plugin install pulls from versioned releases with changelog tracking and update control. The npx method pulls the latest from the `main` branch directly — it always gets the current stable content but without version pinning or rollback.
 
 ## Usage
 


### PR DESCRIPTION
## Changes

- Set `weekly-release.md` safe-output to `draft: false` so release PRs open as ready-for-review
- Add `/plugin install` method to README for Copilot CLI and Claude Code
- Clarify that npx pulls latest `main` without version pinning or rollback
- Recompile `weekly-release.lock.yml`

Relates to #390