### PR TITLE
fix: contains() case-sensitivity and PS 5.1 -File array caveat

### DIFF
--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -97,7 +97,7 @@ After presenting the estimate, the user may request changes (switch region, add 
 3. **Ask before assuming** — if a required parameter is ambiguous or missing (tier, SKU, quantity, currency, node count, traffic volume), stop and ask the user. At the request level, clarify vague inputs (Step 2). At the parameter level, apply the Disambiguation Protocol (Step 5).
 4. **Default output format is Json** — never use Summary (invisible to agents)
 5. **Lazy-load service references** — only read files from `references/services/` directly required by the user's query. Use the file-search workflow (Step 2) to locate specific files.
-6. **PowerShell: use `-File`, not `-Command`** — run scripts with `pwsh -File` or `powershell.exe -File`; on Linux/macOS, bash strips OData quotes from inline commands
+6. **PowerShell: use `-File`, not `-Command`** — run scripts with `pwsh -File` or `powershell.exe -File`; on Linux/macOS, bash strips OData quotes from inline commands. **PS 5.1 caveat:** use `-Command` instead of `-File` when passing array parameters (e.g., `-Region 'eastus','australiaeast'`), because `-File` mode does not parse PowerShell expression syntax and collapses the array into a single string.
 7. **Use consistent output categories** — group line items by category directory names from `references/services/` (compute, databases, networking, etc.)
 8. **Scope to user-specified resources** — only include resources explicitly stated in the user's architecture. Companion resources from `billingNeeds` are included automatically.
 

--- a/skills/azure-cost-calculator/scripts/lib/Build-ODataFilter.ps1
+++ b/skills/azure-cost-calculator/scripts/lib/Build-ODataFilter.ps1
@@ -16,7 +16,7 @@ function Build-ODataFilter {
             if ($key -eq 'contains') {
                 foreach ($containsFilter in $value) {
                     $escaped = $containsFilter.Value -replace "'", "''"
-                    $parts += "contains($($containsFilter.Field), '$escaped')"
+                    $parts += "contains(tolower($($containsFilter.Field)), '$($escaped.ToLower())')"
                 }
             }
             else {

--- a/skills/azure-cost-calculator/scripts/lib/build-odata-filter.sh
+++ b/skills/azure-cost-calculator/scripts/lib/build-odata-filter.sh
@@ -16,7 +16,9 @@ build_odata_filter() {
             field="${rest%%=*}"
             value="${rest#*=}"
             value="${value//$sq/$sq$sq}"
-            parts+=("contains($field, '$value')")
+            local lower_value
+            lower_value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+            parts+=("contains(tolower($field), '$lower_value')")
         else
             field="${arg%%=*}"
             value="${arg#*=}"

--- a/tests/unit/bash/lib/build-odata-filter.bats
+++ b/tests/unit/bash/lib/build-odata-filter.bats
@@ -26,19 +26,19 @@ setup() {
 @test "single contains filter" {
     run build_odata_filter "contains:productName=Redis"
     [ "$status" -eq 0 ]
-    [ "$output" = "contains(productName, 'Redis')" ]
+    [ "$output" = "contains(tolower(productName), 'redis')" ]
 }
 
 @test "multiple contains filters joined with and" {
     run build_odata_filter "contains:productName=Redis" "contains:skuName=Standard"
     [ "$status" -eq 0 ]
-    [ "$output" = "contains(productName, 'Redis') and contains(skuName, 'Standard')" ]
+    [ "$output" = "contains(tolower(productName), 'redis') and contains(tolower(skuName), 'standard')" ]
 }
 
 @test "mixed equality and contains filters" {
     run build_odata_filter "serviceName=Cache" "contains:productName=Redis" "armRegionName=eastus"
     [ "$status" -eq 0 ]
-    [ "$output" = "serviceName eq 'Cache' and contains(productName, 'Redis') and armRegionName eq 'eastus'" ]
+    [ "$output" = "serviceName eq 'Cache' and contains(tolower(productName), 'redis') and armRegionName eq 'eastus'" ]
 }
 
 @test "empty value in equality filter is skipped" {
@@ -62,7 +62,7 @@ setup() {
 @test "single quote in contains value is escaped" {
     run build_odata_filter "contains:productName=Azure's Redis"
     [ "$status" -eq 0 ]
-    [ "$output" = "contains(productName, 'Azure''s Redis')" ]
+    [ "$output" = "contains(tolower(productName), 'azure''s redis')" ]
 }
 
 @test "multiple single quotes are all escaped" {
@@ -80,7 +80,7 @@ setup() {
 @test "contains value with equals sign preserves everything after first equals" {
     run build_odata_filter "contains:field=val=ue"
     [ "$status" -eq 0 ]
-    [ "$output" = "contains(field, 'val=ue')" ]
+    [ "$output" = "contains(tolower(field), 'val=ue')" ]
 }
 
 @test "three equality filters joined correctly" {
@@ -92,5 +92,5 @@ setup() {
 @test "contains filter with empty value still produces output" {
     run build_odata_filter "contains:field="
     [ "$status" -eq 0 ]
-    [ "$output" = "contains(field, '')" ]
+    [ "$output" = "contains(tolower(field), '')" ]
 }

--- a/tests/unit/powershell/lib/Build-ODataFilter.Tests.ps1
+++ b/tests/unit/powershell/lib/Build-ODataFilter.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'Build-ODataFilter' {
                 )
             }
             $result = Build-ODataFilter -Filters $filters
-            $result | Should -Be "contains(meterName, 'Spot')"
+            $result | Should -Be "contains(tolower(meterName), 'spot')"
         }
 
         It 'should produce multiple contains expressions joined with and' {
@@ -82,7 +82,7 @@ Describe 'Build-ODataFilter' {
                 )
             }
             $result = Build-ODataFilter -Filters $filters
-            $result | Should -Be "contains(meterName, 'Spot') and contains(skuName, 'Standard')"
+            $result | Should -Be "contains(tolower(meterName), 'spot') and contains(tolower(skuName), 'standard')"
         }
 
         It 'should combine contains with equality filters' {
@@ -94,7 +94,7 @@ Describe 'Build-ODataFilter' {
                 armRegionName = 'eastus'
             }
             $result = Build-ODataFilter -Filters $filters
-            $result | Should -Be "serviceName eq 'Virtual Machines' and contains(meterName, 'Spot') and armRegionName eq 'eastus'"
+            $result | Should -Be "serviceName eq 'Virtual Machines' and contains(tolower(meterName), 'spot') and armRegionName eq 'eastus'"
         }
     }
 
@@ -118,7 +118,7 @@ Describe 'Build-ODataFilter' {
                 )
             }
             $result = Build-ODataFilter -Filters $filters
-            $result | Should -Be "contains(meterName, 'it''s')"
+            $result | Should -Be "contains(tolower(meterName), 'it''s')"
         }
 
         It 'should escape apostrophes in equality values for OData' {


### PR DESCRIPTION
## Summary

Fixes #413 — two usability issues affecting cross-runtime experience.

### 1. `contains()` OData filter is now case-insensitive

The Azure Retail Prices API `contains()` operator is case-sensitive. Searching for `'redis'` returned zero results because the API stores `'Redis'` (capital R).

**Fix:** Wrap with OData `tolower()` in both runtimes:
- **PowerShell** (`Build-ODataFilter.ps1`): `contains(tolower(field), 'lowered_value')`
- **Bash** (`build-odata-filter.sh`): same `tolower()` wrap + `tr` to lowercase the input value

### 2. SKILL.md rule 6 — PS 5.1 array parameter caveat

Added documentation that `powershell.exe -File` does not parse PowerShell expression syntax, so array parameters (e.g., `-Region 'eastus','australiaeast'`) collapse into a single string on PS 5.1. Workaround: use `-Command` for array arguments.

### Live A/B validation

Tested against the live Azure Retail Prices API comparing this branch vs `dev`:

| Test | Branch | Runtime | `'redis'` (lowercase) | `'Redis'` (correct case) |
|------|--------|---------|----------------------|-------------------------|
| 1 | dev (baseline) | Bash | ❌ 0 results, exit 2 | ✅ 5 results |
| 2 | dev (baseline) | PowerShell | ❌ 0 results | ✅ 5 results |
| 3 | fix branch | Bash | ✅ 5 results | ✅ 5 results |
| 4 | fix branch | PowerShell | ✅ 5 results | ✅ 5 results |

### Files changed
- `skills/azure-cost-calculator/scripts/lib/Build-ODataFilter.ps1` — tolower() wrap
- `skills/azure-cost-calculator/scripts/lib/build-odata-filter.sh` — tolower() wrap
- `skills/azure-cost-calculator/SKILL.md` — rule 6 PS 5.1 caveat
- `tests/unit/powershell/lib/Build-ODataFilter.Tests.ps1` — updated assertions
- `tests/unit/bash/lib/build-odata-filter.bats` — updated assertions