### PR TITLE
fix: instruct weekly release agent to use create_pull_request tool

### DIFF
--- a/.github/workflows/weekly-release.md
+++ b/.github/workflows/weekly-release.md
@@ -32,7 +32,7 @@ You are a release manager for the **azure-cost-calculator-skill** repository. Yo
 These constraints are absolute and override all other instructions:
 
 - **Never** push directly to `main` — only create a pull request.
-- **Never** use `git push`, `gh pr create`, or any direct git/CLI commands to create or push branches. The `create_pull_request` tool handles branch creation and PR submission automatically.
+- **Never** use `git push`, `gh pr create`, or any direct CLI commands to push branches or open pull requests. Local branch creation and commits with `git` are expected; use the `create_pull_request` tool to publish the branch and submit the PR.
 - **Never** modify files outside the release scope (`plugin.json`, `CHANGELOG.md`, `skills/azure-cost-calculator/SKILL.md`).
 - **Never** fabricate changes — only document what actually changed in the diff.
 - If you are uncertain about a change classification, use the more conservative category.
@@ -188,7 +188,7 @@ Deduplicate the issue numbers. If no issue references are found, skip this step 
 
 Commit your changes locally, then call the `create_pull_request` tool with:
 
-- **Title**: `release: vX.Y.Z`
+- **Title**: `vX.Y.Z` (the `release: ` prefix is added automatically)
 - **Body**: Include:
   - A summary of all changes grouped by category
   - The version bump rationale (e.g., "Minor bump: 2 new services added")
@@ -201,4 +201,4 @@ Commit your changes locally, then call the `create_pull_request` tool with:
     ```
     This ensures GitHub auto-closes the issues when the release PR is merged to `main`.
 
-> **Important**: Do not use `git push` or `gh pr create`. The `create_pull_request` tool handles branch creation and PR submission.
+> **Important**: Do not use `git push` or `gh pr create`. The `create_pull_request` tool handles pushing the branch and submitting the PR.


### PR DESCRIPTION
## Summary

Hotfix targeting main directly — the weekly release workflow runs from main, so this fix needs to be on main to unblock the next release.

The weekly release agent was attempting `git push` / `gh pr create` directly from its sandbox (which lacks push credentials), causing silent failures where the workflow reported success but no release PR was created.

## Changes

- **Safety rule added**: Explicitly prohibit `git push`, `gh pr create`, or any direct git/CLI commands for branch/PR creation
- **Step 7 rewritten**: Reference the `create_pull_request` tool explicitly, with an Important callout reinforcing the constraint

## Validation

Ran the workflow on this branch — agent correctly used `create_pull_request` tool instead of `missing_tool`:
- [Test run #6](https://github.com/ahmadabdalla/azure-cost-calculator-skill/actions/runs/22553093574)

See #418 for the matching dev PR. Fixes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to clarify PR creation procedures and tooling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->