### PR TITLE
fix: rewrite release workflow to use file-checkout instead of branch switching

### DIFF
--- a/.github/workflows/weekly-release.md
+++ b/.github/workflows/weekly-release.md
@@ -113,7 +113,7 @@ Apply SemVer rules based on the changelog categories you identified:
 
 ### 5a. Import changed files from `dev`
 
-For each file that changed between `main` and `dev` (from Step 2), import the `dev` version into your working tree using the `--` file-checkout syntax (this does **not** switch branches):
+For each file that changed between `main` and `dev` (from Step 2), import the `dev` version into your working tree using the `--` file-checkout syntax (this does **not** switch branches). Handle each `git diff --name-status` entry according to its status:
 
 ```bash
 # For each added (A) or modified (M) file:
@@ -121,6 +121,13 @@ git checkout origin/dev -- path/to/file
 
 # For each deleted (D) file:
 git rm path/to/file
+
+# For each renamed (R…) file (e.g., R100 old/path new/path):
+git checkout origin/dev -- new/path
+git rm old/path
+
+# For each copied (C…) file (e.g., C100 old/path new/path):
+git checkout origin/dev -- new/path
 ```
 
 **Skip** files in the ignore list from Step 2 (`.github/**`, `docs/**`, `tests/**`, etc.). Also skip `CHANGELOG.md` — you will update it in the next sub-step.
@@ -179,7 +186,7 @@ git commit -m "chore: bump version to X.Y.Z"
 
 ## Step 6 — Collect issue references
 
-GitHub only auto-closes issues when a PR merges into the **default branch** (`main`). Feature PRs merged into `dev` with `Closes #X` keywords do **not** close issues. To ensure issues are closed at release time, collect their references now.
+In this workflow, GitHub auto-closes issues when the release PR is merged into `main`. Feature PRs merged into `dev` with `Closes #X` keywords do **not** close issues at that time. To ensure issues are closed at release time, collect their references now.
 
 Find the last release tag on `main` (`git describe --tags --abbrev=0 origin/main`). Use `gh pr list --base dev --state merged` to list PRs merged into `dev` since that tag. From each PR's body and title, extract issue numbers referenced by closing keywords (`Closes`, `Fixes`, `Resolves` and their variants, e.g. `Fixes #400`). Deduplicate the list.
 


### PR DESCRIPTION
## Summary

Fixes the "No changes to commit - no commits found" error from `create_pull_request` safe output tool.

## Root Cause

The `create_pull_request` tool uses `git format-patch` to capture the agent's commits relative to the initial checkout (`main`). The safe-outputs job then applies this patch with `git am` on a fresh `main` checkout.

**Step 5 previously said**: "Create a new branch from `dev`" — this caused the agent to run `git checkout -b release origin/dev`, switching HEAD to a branch 246+ commits ahead of `main`. The patch mechanism then either:
- Generated a 246-commit patch exceeding `max_patch_size` (1024 KB)
- Failed to produce any patch at all → "No changes to commit"

The successful v1.0.1 run worked because the agent happened to cherry-pick individual commits onto `main` instead of switching branches — producing a clean 3-commit patch.

## Fix

### Safety Rules
- Added explicit constraint: **never switch branches** in the sandbox
- Explained `git checkout origin/dev -- <file>` (file-checkout) syntax vs branch switching

### Step 5 — Rewritten
- Replace "Create a branch from `dev`" with file-checkout approach:
  1. Stay on `main`
  2. `git checkout origin/dev -- <file>` for each changed file (imports without switching branches)
  3. Commit imported dev changes
  4. Make release edits (changelog, version bump)
  5. Commit release edits separately
- This produces clean commits on top of `main` that `git format-patch` can capture

### Step 6 — Simplified
- Removed verbose bash examples (`gh pr list | jq | grep` pipelines) that primed the agent toward CLI mode
- This was the original root cause of the `git push` regression (issue #417)
- Same intent preserved in concise prose

### Step 7 — Cleanup
- Removed redundant "Commit your changes" instruction (now handled by Step 5e)

## Validation

Workflow dispatch triggered on this branch: run #22554119121
- [ ] Agent stays on `main` (no branch switching)
- [ ] Agent uses `git checkout origin/dev -- <file>` to import files
- [ ] Agent calls `create_pull_request` (not `git push`)
- [ ] safe_outputs applies patch successfully
- [ ] Release PR is created targeting `main`

Closes #417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal documentation updates to the release process workflow. There are no user-facing changes or new features in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->