### PR TITLE
fix: move argument-hint to top-level SKILL.md frontmatter

### DIFF
--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -2,11 +2,11 @@
 name: azure-cost-calculator
 description: Helps estimate and calculate Azure resource costs. Use this skill when users ask about Azure pricing, cost estimation, resource sizing costs, comparing pricing tiers, budgeting for Azure deployments, or understanding Azure billing. Triggers include questions like "how much will this cost in Azure", "estimate Azure costs", "compare Azure pricing", "budget for Azure resources".
 license: MIT
+argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
 metadata:
   author: ahmadabdalla
   version: "1.1.1"
-  argument-hint: "<azure-service-name>"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
## Summary

Moves `argument-hint` from nested `metadata` to top-level SKILL.md frontmatter, fixing Claude Code autocomplete visibility.

## Investigation

Cross-referenced three specifications governing SKILL.md frontmatter:

| Field | [Agent Skills Spec](https://agentskills.io/specification) | [Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-skills) | [Claude Code](https://code.claude.com/docs/en/skills) |
|---|---|---|---|
| `name` | Required | Required | Optional (recommended) |
| `description` | Required | Required | Recommended |
| `license` | Optional | Optional | — |
| `compatibility` | Optional (max 500 chars) | — | — |
| `metadata` | Optional (arbitrary k/v map) | — | — |
| **`argument-hint`** | — | — | **Optional (top-level only)** |

### Key findings

1. **`argument-hint` must be top-level for Claude Code** — Claude Code reads it as a top-level frontmatter field for autocomplete hints. Nested under `metadata`, it was invisible.

2. **`metadata` block must stay** — Three reasons:
   - **Standalone installs** via [skills.sh](https://skills.sh) (`npx skills add`) copy the skill directory without `plugin.json`, so `metadata.author` and `metadata.version` are the only source of that info
   - **Weekly Release CI** (Step 5d) explicitly updates `metadata.version` in SKILL.md
   - **Agent Skills spec** places custom fields like `author`/`version` inside `metadata` per its own examples

3. **`compatibility` stays** — It is a valid field in the [Agent Skills open standard](https://agentskills.io/specification) (max 500 chars). Both platforms ignore unknown fields, but future spec-compliant platforms may use it.

### Options assessed

| Option | Description | Decision |
|---|---|---|
| **A — Move argument-hint** | Promote to top-level, keep everything else | ✅ Selected |
| B — A + allowed-tools | Also add `allowed-tools` field | Deferred — needs tool scoping design |
| C — A + drop compatibility | Move compatibility to body | Rejected — valid spec field |

## Changes

**`skills/azure-cost-calculator/SKILL.md`** — Moved `argument-hint: "<azure-service-name>"` from `metadata` to top-level frontmatter. No other changes.

Closes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration structure for the Azure Cost Calculator skill definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->