### PR TITLE
fix: update stale comments and restore push paths filter

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,9 @@ on:
     branches: [dev, main]
   push:
     branches: [dev]
+    paths:
+      - "skills/azure-cost-calculator/scripts/**"
+      - "tests/unit/**"
 
 permissions:
   contents: read

--- a/.github/workflows/validate-service-references.yml
+++ b/.github/workflows/validate-service-references.yml
@@ -2,7 +2,8 @@
 # Validate Service References
 # ---------------------------------------------------------
 # Runs the validation script against service reference files
-# whenever a pull request touches relevant paths.
+# on every pull request, skipping validation when no relevant
+# paths changed.
 #
 # HOW IT WORKS
 # 1. GitHub triggers this workflow on EVERY pull request to
@@ -181,8 +182,9 @@ jobs:
       # --- Step 4: Routing sync (fallback) ---
       # Steps 3a and 3b already include -CheckRoutingFileSync,
       # so this only runs when NEITHER of them executed — e.g.
-      # a service file was deleted (not caught by ACMR filter)
-      # but the paths: trigger still fired.
+      # a service file was deleted but no other service files
+      # were added/modified, yet paths-filter still detected a
+      # relevant change.
       # Note: the script requires at least one file passed to -Path,
       # so we pick the first .md we can find.
       - name: Validate routing file sync


### PR DESCRIPTION
Follow-up to #450 — addresses review comments from Copilot.

## Changes

1. **`validate-service-references.yml`** — Updated header comment (line 5) to say the workflow runs on every PR and skips when no relevant paths changed, instead of the stale "whenever a pull request touches relevant paths"
2. **`validate-service-references.yml`** — Updated routing-sync fallback comment (line 181-185) to remove reference to the removed top-level `paths:` trigger
3. **`unit-tests.yml`** — Restored `paths:` filter for `push` events only. Push events don't have the required-check problem (that only affects PRs), so running checkout + paths-filter on every push to dev is wasteful

## Review comments addressed
- https://github.com/ahmadabdalla/azure-cost-calculator/pull/450#discussion_r2885780984
- https://github.com/ahmadabdalla/azure-cost-calculator/pull/450#discussion_r2885781007
- https://github.com/ahmadabdalla/azure-cost-calculator/pull/450#discussion_r2885781015