### PR TITLE
fix: remove invalid plugin.json fields blocking Claude Code install

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,10 +15,6 @@
     "budget",
     "calculator"
   ],
-  "category": "cloud",
   "homepage": "https://github.com/ahmadabdalla/azure-cost-calculator",
-  "repository": "https://github.com/ahmadabdalla/azure-cost-calculator",
-  "skills": "./skills/",
-  "agents": "./agents/",
-  "commands": "./commands/"
+  "repository": "https://github.com/ahmadabdalla/azure-cost-calculator"
 }

--- a/docs/plugin-agents.md
+++ b/docs/plugin-agents.md
@@ -11,7 +11,7 @@ This repository has two separate agent systems serving different audiences:
 | Audience   | Plugin consumers                                       | Repository maintainers               |
 | Platform   | Copilot CLI + Claude Code                              | GitHub Copilot coding agent          |
 | Purpose    | Azure cost estimation                                  | Service reference authoring & review |
-| Loaded via | `.claude-plugin/plugin.json` → `"agents": "./agents/"` | GitHub default branch                |
+| Loaded via | Auto-discovered from `agents/` directory               | GitHub default branch                |
 | Invocation | Local terminal                                         | Hosted on GitHub infrastructure      |
 | Context    | Plugin files only (skill, scripts, references)         | Full repo access, issue/PR context   |
 
@@ -178,7 +178,7 @@ Plugin agents inherit the **consumer's** permission settings, not this repositor
 
 ### Command support
 
-Plugin commands (the `commands/` directory, referenced in `plugin.json` as `"commands": "./commands/"`) are not supported on all platforms:
+Plugin commands (auto-discovered from the `commands/` directory) are not supported on all platforms:
 
 | Platform        | Slash commands (`/estimate-cost`) | Agent addressing (`@cost-analyst`) |
 | --------------- | --------------------------------- | ---------------------------------- |


### PR DESCRIPTION
## Summary

- Remove `category` key from `.claude-plugin/plugin.json` — not in Claude Code's plugin manifest schema, causes `Unrecognized key: "category"` validation error
- Remove redundant `skills`, `agents`, and `commands` path declarations that point to default auto-discovery directories (`./skills/`, `./agents/`, `./commands/`) — both Claude Code and Copilot CLI auto-discover these without explicit declaration, and the directory-style `agents` value caused `agents: Invalid input` validation error
- Update `docs/plugin-agents.md` references to reflect auto-discovery instead of explicit manifest wiring

## Test plan

- [x] `claude plugin validate .claude-plugin/plugin.json` passes with no errors
- [x] JSON is syntactically valid
- [x] `agents/`, `skills/`, `commands/` directories exist at plugin root for auto-discovery
- [ ] `claude plugin install azure-cost-calculator@acc-plugin` succeeds after merge
- [ ] Agent `cost-analyst` appears in `/agents` after install
- [ ] `/azure-cost-calculator:estimate-cost` skill is available after install

Fixes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated plugin loading and command discovery documentation to reflect auto-discovery from directory structures.

* **Chores**
  * Simplified plugin manifest configuration by removing explicit configuration declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->