### PR TITLE
chore: merge main back to dev after release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Marketplace for the Azure Cost Calculator plugin",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [
     {
       "name": "azure-cost-calculator",
       "source": "./",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "description": "Real-time Azure cost estimation using the Azure Retail Prices API"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-cost-calculator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Real-time Azure cost estimation using the Azure Retail Prices API",
   "author": {
     "name": "ahmadabdalla"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Azure Cost Calculator skill will be documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.2] - 2026-03-06
+
+### Fixed
+
+- **Plugin manifest**: Removed invalid fields (category, skills, agents, commands paths) from plugin.json that were blocking Claude Code plugin installation
+- **Documentation**: Updated plugin-agents.md to reflect auto-discovery of agents and commands directories
+
 ## [1.2.1] - 2026-03-06
 
 ### Changed

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
 metadata:
   author: ahmadabdalla
-  version: "1.2.1"
+  version: "1.2.2"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
Automated back-merge after release using a dedicated branch. This replaces #481 to avoid committing conflict resolution on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin installation compatibility issue by removing invalid manifest fields.
  * Updated documentation to reflect auto-discovery of agents and commands directories.

* **Chores**
  * Bumped version to 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->