### PR TITLE
chore: align dev with main after v1.5.1 bootstrap release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-cost-calculator",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "description": "Real-time Azure cost estimation using the Azure Retail Prices API",
   "author": {
     "name": "ahmadabdalla"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Azure Cost Calculator skill will be documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.1] - 2026-03-19
+
+### Changed
+
+- **CI/CD**: Replaced squash-based release workflow with merge-based flow to preserve commit history
+- **CI/CD**: Refactored release scripts into testable modules under `.github/scripts/release/`
+- **Documentation**: Updated operational guides for merge-based release process
+
 ## [1.4.0] - 2026-03-15
 
 ### Added

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
 metadata:
   author: ahmadabdalla
-  version: "1.4.0"
+  version: "1.5.1"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
## Summary

- Merges `main` into `dev` to sync branches after the v1.5.1 bootstrap release
- This is the **last back-merge ever needed** — the new merge-based release flow (#571) keeps branches aligned automatically
- Clean merge with no conflicts: main's version files (v1.5.1) applied on top of dev

## Context

The old squash-based release created divergent history: main had squash commits that dev didn't recognize as shared ancestry. This one-time merge establishes a common merge-base so future releases (via merge commits) maintain shared ancestry between both branches.

## What changed

Only version files updated from main's v1.5.1 release:
- `.claude-plugin/plugin.json` → 1.5.1
- `CHANGELOG.md` → v1.5.1 section added
- `skills/azure-cost-calculator/SKILL.md` → version: 1.5.1

## Test plan

- [x] Clean merge — no conflicts
- [x] Version files show 1.5.1
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.5.1
  * Release tooling and workflow improvements implemented

* **Documentation**
  * Updated operational documentation reflecting process enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->