### PR TITLE
fix: add stable insertion anchor to CHANGELOG.md for version bumps

### DIFF
--- a/.github/workflows/weekly-release.md
+++ b/.github/workflows/weekly-release.md
@@ -129,7 +129,7 @@ This ensures you are editing the `dev` versions of these files. The resulting pa
 
 ### 5b. Update `CHANGELOG.md`
 
-Insert a new version section **above** the previous version entry. Use today's date in YYYY-MM-DD format. Format:
+Insert a new version section **immediately after the `<!-- versions -->` comment** in `CHANGELOG.md`. Use today's date in YYYY-MM-DD format. Format:
 
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Azure Cost Calculator skill will be documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+<!-- versions -->
+
 ## [1.5.1] - 2026-03-19
 
 ### Changed


### PR DESCRIPTION
Closes #580

## What

Adds a `<!-- versions -->` comment between the header prose and the first release section in `CHANGELOG.md`. The weekly-release agent now inserts new version sections immediately after this anchor.

## Why

`safe_outputs` applies the agent's version-bump patch via `git am` on `dev`. The patch context lines come from `main`. When a content-cleanup PR modifies lines near the insertion point on `dev` before the next release, `git am` fails with a context mismatch.

The previous insertion instruction ("above the previous version entry") left the context lines as the body of the prior version section — lines that can legitimately change between releases. The `<!-- versions -->` anchor makes the context lines always the same two things: the anchor comment itself, and a released version header (`## [X.Y.Z] - date`), both of which are immutable once a release ships.

## Test plan

- [x] `gh aw compile` passes cleanly
- [x] Net change: 2 files, 3 lines
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved changelog management process with clearer organizational structure.

* **Chores**
  * Updated release workflow procedures for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->