### PR TITLE
fix: replace wholesale dev import with version-field edits in weekly release

### DIFF
--- a/.github/workflows/weekly-release.md
+++ b/.github/workflows/weekly-release.md
@@ -117,7 +117,7 @@ Apply SemVer rules based on the changelog categories you identified:
 
 > **Critical (patch mechanism constraint)**: Stay on the initially checked-out branch (the default branch). The `create_pull_request` tool generates a `git format-patch` of your commits relative to the initial checkout. The `safe-outputs` job then applies this patch on a fresh `dev` checkout. If you switch branches, the patch will be empty or fail.
 >
-> Do **not** use `git checkout origin/dev -- <file>` to import files from `dev`. Importing whole files produces a patch whose context lines are anchored to the `dev` content. When `safe-outputs` applies that patch against `dev`, lines that `dev` already changed conflict and `git am` exits 128. Make only the minimal, version-specific edits described below.
+> Do **not** use `git checkout origin/dev -- <file>` to import files from `dev`. `git format-patch` always records the preimage from the initially checked-out branch (the default branch), so a commit that wholesale-replaces a file with the `dev` copy produces hunks whose `-` context lines describe the old default-branch content. When `safe-outputs` later applies that patch on top of a fresh `dev` checkout, those `-` lines no longer exist, `git am` cannot find anchors, and it exits 128. Make only the minimal, version-specific edits described below.
 
 ### 5a. Update `CHANGELOG.md`
 
@@ -166,8 +166,8 @@ jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > /tmp/plug
 Update **only** the `version:` field in the YAML frontmatter using `sed`. Do not read or overwrite the file from `origin/dev`:
 
 ```bash
-CURRENT_VERSION=$(git show origin/dev:.claude-plugin/plugin.json | jq -r .version)
-sed -i "s/  version: \"$CURRENT_VERSION\"/  version: \"$NEW_VERSION\"/" \
+# $NEW_VERSION must already be set (defined in step 5b)
+sed -i "s/\(  version: \"\)[^\"]*/\1$NEW_VERSION/" \
   skills/azure-cost-calculator/SKILL.md
 ```
 


### PR DESCRIPTION
## Problem

The weekly release pipeline failed to create a PR on run [23432710743](https://github.com/ahmadabdalla/azure-cost-calculator/actions/runs/23432710743):

```
✗ Message 1 (create_pull_request) failed: Failed to apply patch
Failed to apply patch: The process '/usr/bin/git' failed with exit code 128
```

Root cause: Step 5a imported entire files from `origin/dev` via `git checkout origin/dev -- ...`. `git format-patch` records the preimage from the initially checked-out branch (main), so a commit that wholesale-replaces a file with the `dev` copy produces hunks whose `-` context lines describe the old main content. When `safe-outputs` applies that patch on top of a fresh `dev` checkout, those `-` lines no longer exist, `git am` cannot find anchors, and it exits 128.

This failure is deterministic: it occurs on every weekly run where `dev` has content changes to `CHANGELOG.md` or `SKILL.md` relative to `main`, which is the normal state between releases.

## Fix

Remove the wholesale import step. Replace with surgical, field-only edits:

- `plugin.json`: `jq` to update only the `version` field
- `SKILL.md`: `sed` with a capture-group regex to update only the `version:` frontmatter line
- `CHANGELOG.md`: insert after the `<!-- versions -->` anchor (unchanged)

The resulting patch contains only 3 hunks (one per file, each a minimal version field change plus the new changelog section). It applies cleanly to `dev` regardless of how much content has diverged between branches.

## Verification

Three independent validations were run against real branch content:

**1. Broken approach reproduces the failure**

```
git am /tmp/broken.patch
Patch failed at 0001 ...
Exit code: 128  ✗
```

**2. Fixed approach passes**

```
git am /tmp/fixed.patch
Applying: chore: bump version to 1.5.2
Exit code: 0  ✓
Patch: 57 lines, 3 files — SKILL.md hunk is 1 line only
```

**3. Sub-agent dry run — agent given only the updated instructions, no solution hint**

The agent executed Steps 1–5d against a local repo with real main/dev branch content (dev 5 commits ahead with em-dash rewrites in SKILL.md). It correctly used `jq` and `sed` without falling back to `git checkout origin/dev --`. The generated patch was then applied to the dev-state:

```
git am agent.patch
Applying: chore: bump version to 1.5.2
Exit code: 0  ✓
Patch: 56 lines, 3 files
```

Post-apply version fields:
```
"version": "1.5.2"       ← plugin.json
  version: "1.5.2"       ← SKILL.md
## [1.5.2] - 2026-03-24  ← CHANGELOG.md
```

## Prerequisite for next Monday's run

The `CHANGELOG.md` insertion anchor (`<!-- versions -->`) must exist on `main` before the next weekly run. It is already present on `dev`. It reaches `main` through the release PR (dev→main). Ensure this week's release PR merges to `main` before the next Monday 00:00 UTC cron trigger.

---
Fixes #585