### PR TITLE
fix: move timeout_seconds to top-level in linux-p1-v3 task

### DIFF
--- a/tests/evals/azure-cost-calculator/tasks/compute/app-service/linux-p1-v3.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/compute/app-service/linux-p1-v3.yaml
@@ -10,10 +10,9 @@ tags:
   - single-service
   - compute
   - service:app-service
+timeout_seconds: 30
 inputs:
   prompt: "Estimate the monthly cost of running 2 Linux App Service P1 v3 instances in East US"
-config:
-  timeout_seconds: 30
 expected:
   output_contains:
     - "Assumptions"


### PR DESCRIPTION
## Summary

- `config.timeout_seconds` is not a valid field in the Waza task schema — the value was silently ignored
- Moves `timeout_seconds: 30` to the correct top-level position, matching the pattern already used in `smoke/disambiguation-sql.yaml`

## Test plan

- [ ] `waza check` passes (schema validation)
- [ ] CI `validate-eval-schema` job passes

Closes #591
Part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->