### PR TITLE
fix: add negative pricing-tier assertions to windows-d4s-v5 task

### DIFF
--- a/tests/evals/azure-cost-calculator/tasks/compute/virtual-machines/windows-d4s-v5.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/compute/virtual-machines/windows-d4s-v5.yaml
@@ -39,6 +39,18 @@ graders:
       contains:
         - "4"
     weight: 0.5
+  - type: text
+    name: no-spot-pricing
+    config:
+      not_contains:
+        - "Spot"
+    weight: 1.0
+  - type: text
+    name: no-low-priority-pricing
+    config:
+      not_contains:
+        - "Low Priority"
+    weight: 1.0
   - type: behavior
     name: uses-pricing-script
     config:


### PR DESCRIPTION
## Summary

- The `windows-d4s-v5` task description explicitly calls out Spot and Low Priority pricing as the key trap for VM queries, but no graders enforced their absence from the output
- Adds `no-spot-pricing` and `no-low-priority-pricing` text graders (weight 1.0 each) using `not_contains`
- Mirrors the pattern already used in `linux-b2s-multi-instance.yaml` (`no-windows-pricing` grader)

## Test plan

- [ ] `waza check` passes (schema validation)
- [ ] CI `validate-eval-schema` job passes

Closes #592
Part of #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation checks to ensure cost calculator output meets expected quality criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->