### PR TITLE
feat: add JUnit reporter to eval CI jobs (#596)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run evaluations (mock)
         if: steps.filter.outputs.relevant == 'true'
         continue-on-error: true
-        run: waza run --verbose --output results.json
+        run: waza run --verbose --output results.json --reporter junit:results-junit.xml
       - name: Display results summary
         if: always() && steps.filter.outputs.relevant == 'true'
         run: |
@@ -99,6 +99,7 @@ jobs:
           name: eval-results-mock
           path: |
             results.json
+            results-junit.xml
             transcripts/
           retention-days: 30
           if-no-files-found: warn
@@ -191,7 +192,7 @@ jobs:
         run: |
           # Build tag args from comma-separated list
           IFS=',' read -ra TAG_ARRAY <<< "$EVAL_TAGS"
-          ARGS=(--verbose --output results.json)
+          ARGS=(--verbose --output results.json --reporter junit:results-junit.xml)
           for t in "${TAG_ARRAY[@]}"; do
             ARGS+=(--tags "$t")
           done
@@ -212,6 +213,7 @@ jobs:
           name: eval-results-critical
           path: |
             results.json
+            results-junit.xml
             transcripts/
           retention-days: 30
           if-no-files-found: warn
@@ -244,7 +246,7 @@ jobs:
           EVAL_MODEL: ${{ inputs.model }}
           EVAL_TAG: ${{ inputs.tag }}
         run: |
-          ARGS=(--model "$EVAL_MODEL" --verbose --output results.json)
+          ARGS=(--model "$EVAL_MODEL" --verbose --output results.json --reporter junit:results-junit.xml)
           if [ -n "$EVAL_TAG" ]; then
             ARGS+=(--tags "$EVAL_TAG")
           fi
@@ -267,6 +269,7 @@ jobs:
           name: eval-results-${{ inputs.model }}
           path: |
             results.json
+            results-junit.xml
             transcripts/
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
Closes #596 (Step 1 of 2).

## What

Adds `--reporter junit:results-junit.xml` to `waza run` in all three eval jobs (`evaluate-mock`, `evaluate-critical`, `run-evals`) and includes `results-junit.xml` in each artifact upload alongside `results.json`.

## Why Step 1 only

Per the [pre-implementation analysis comment on #596](https://github.com/ahmadabdalla/azure-cost-calculator-skill/issues/596#issuecomment-4114507448), the issue assumes GitHub Actions natively renders JUnit XML as a "Tests" tab — but that only happens when a reporter action (e.g. `dorny/test-reporter`) posts a check run. That action requires `checks: write` permission, which this workflow does not have today.

This PR produces the JUnit file and makes it downloadable. After this merges and the CI runs, we can observe whether a Tests tab appears. If not (expected), a follow-up adds `checks: write` + the reporter action.

## Test plan

- [ ] `evaluate-mock` run includes `results-junit.xml` in the uploaded artifact
- [ ] `evaluate-critical` and `run-evals` likewise include the JUnit file
- [ ] No regression on existing JSON output or step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced evaluation workflows to generate and collect JUnit format test reports alongside existing evaluation artifacts for improved CI/CD integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->