### PR TITLE
chore: remove JSON step summary dumps from eval CI jobs

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -82,13 +82,15 @@ jobs:
       - name: Run evaluations (mock)
         if: steps.filter.outputs.relevant == 'true'
         continue-on-error: true
-        run: waza run --verbose
-      - name: Upload transcripts
+        run: waza run --verbose --output results.json
+      - name: Upload results
         if: always() && steps.filter.outputs.relevant == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: eval-transcripts-mock
-          path: transcripts/
+          name: eval-results-mock
+          path: |
+            results.json
+            transcripts/
           retention-days: 30
           if-no-files-found: warn
 
@@ -180,17 +182,19 @@ jobs:
         run: |
           # Build tag args from comma-separated list
           IFS=',' read -ra TAG_ARRAY <<< "$EVAL_TAGS"
-          ARGS=(--verbose)
+          ARGS=(--verbose --output results.json)
           for t in "${TAG_ARRAY[@]}"; do
             ARGS+=(--tags "$t")
           done
           waza run "${ARGS[@]}"
-      - name: Upload transcripts
+      - name: Upload results
         if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: eval-transcripts-critical
-          path: transcripts/
+          name: eval-results-critical
+          path: |
+            results.json
+            transcripts/
           retention-days: 30
           if-no-files-found: warn
 
@@ -222,16 +226,18 @@ jobs:
           EVAL_MODEL: ${{ inputs.model }}
           EVAL_TAG: ${{ inputs.tag }}
         run: |
-          ARGS=(--model "$EVAL_MODEL" --verbose)
+          ARGS=(--model "$EVAL_MODEL" --verbose --output results.json)
           if [ -n "$EVAL_TAG" ]; then
             ARGS+=(--tags "$EVAL_TAG")
           fi
           waza run "${ARGS[@]}"
-      - name: Upload transcripts
+      - name: Upload results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: eval-transcripts-${{ inputs.model }}
-          path: transcripts/
+          name: eval-results-${{ inputs.model }}
+          path: |
+            results.json
+            transcripts/
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
Part of #590.

## What

Removes the `Display results summary` step and `results.json` artifact from all three eval jobs (`evaluate-mock`, `evaluate-critical`, `run-evals`). Keeps `transcripts/` upload — that's actual debug data for failed runs.

## Why

`results.json` had no consumer. The step summary JSON was unreadable inline and nobody was downloading the artifact. Surfaced during analysis of #596 (closed): the original issue proposed adding JUnit output on top of JSON output, but the right answer was that neither has a reader.

## What's kept

Transcript artifacts are renamed from `eval-results-*` to `eval-transcripts-*` to accurately reflect their content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized evaluation workflow to remove automatic generation and display of a local results artifact, streamlining artifact handling and reporting.

---

Note: Internal infrastructure update with no direct user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->