### PR TITLE
feat: support comma-separated tag input in run-evals dispatch

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -230,7 +230,9 @@ jobs:
           if [ -n "$EVAL_TAG" ]; then
             IFS=',' read -ra TAG_ARRAY <<< "$EVAL_TAG"
             for t in "${TAG_ARRAY[@]}"; do
-              ARGS+=(--tags "$t")
+              t="${t#"${t%%[![:space:]]*}"}"
+              t="${t%"${t##*[![:space:]]}"}"
+              [ -n "$t" ] && ARGS+=(--tags "$t")
             done
           fi
           waza run "${ARGS[@]}"

--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -102,7 +102,7 @@ Three jobs in `.github/workflows/eval.yml` run on PRs to `dev`; one additional j
 | `validate-eval-schema`        | n/a           | `waza check` (schema validation only)            | 0         |
 | `evaluate-mock`               | `mock`        | Validates eval pipeline with simulated responses | 0         |
 | `evaluate-critical`           | `copilot-sdk` | Real AI evals; only tasks matching changed files | 0-8       |
-| `run-evals` (manual dispatch) | `copilot-sdk` | All tasks; 1 trial each; accepts comma-separated tag filter | up to 8   |
+| `run-evals` (manual dispatch) | `copilot-sdk` | All tasks by default; optional comma-separated tag filter   | up to 8   |
 
 ### How `evaluate-critical` targets tasks
 


### PR DESCRIPTION
Closes #597.

## Summary

- `run-evals` manual dispatch now splits the `tag` input on commas and passes each value as a separate `--tags` flag, matching the pattern already used in `evaluate-critical`
- Input description updated to document the comma-separated format
- `docs/ops/evals.md` CI pipeline table updated

## Behaviour

- Blank input: runs all tasks (unchanged)
- Single tag (e.g. `service:cosmos-db`): runs as before
- Multiple tags (e.g. `service:cosmos-db,service:virtual-machines`): runs tasks matching either tag

## Test plan

- [ ] Trigger `run-evals` with a blank tag — all tasks run
- [ ] Trigger `run-evals` with a single tag — only matching tasks run
- [ ] Trigger `run-evals` with two comma-separated tags — tasks matching either tag run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation workflow now accepts multiple comma-separated tags for selective evaluation runs.

* **Documentation**
  * Updated evaluation documentation to reflect comma-separated tag support in the evaluation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->