### PR TITLE
feat: trigger smoke evals in evaluate-critical when tests/evals/** changes

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -123,6 +123,8 @@ jobs:
               - 'skills/azure-cost-calculator/references/services/**'
             scripts:
               - 'skills/azure-cost-calculator/scripts/**'
+            eval-tasks:
+              - 'tests/evals/**'
       - name: Build eval scope
         id: scope
         env:
@@ -132,6 +134,7 @@ jobs:
           SERVICES: ${{ steps.filter.outputs.services }}
           SERVICES_FILES: ${{ steps.filter.outputs.services_files }}
           SCRIPTS: ${{ steps.filter.outputs.scripts }}
+          EVAL_TASKS: ${{ steps.filter.outputs.eval-tasks }}
           HAS_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN != '' && 'true' || 'false' }}
         run: |
           if [ "$HAS_TOKEN" != "true" ]; then
@@ -157,6 +160,10 @@ jobs:
           fi
           # Script changes affect the estimation pipeline: run smoke tests
           if [ "$SCRIPTS" == "true" ]; then
+            TAGS+=(smoke)
+          fi
+          # Eval task or grader changes: run smoke tests to validate the pipeline
+          if [ "$EVAL_TASKS" == "true" ]; then
             TAGS+=(smoke)
           fi
           # Deduplicate and export

--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -115,6 +115,7 @@ The workflow uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to
 | `skills/azure-cost-calculator/references/service-routing.md`        | `routing`     | alias-routing                |
 | `skills/azure-cost-calculator/references/services/**/X.md`          | `service:X`   | All tasks tagged `service:X` |
 | `skills/azure-cost-calculator/scripts/**`                           | `smoke`       | 4 smoke tasks                |
+| `tests/evals/**`                                                    | `smoke`       | 4 smoke tasks                |
 
 Service names are extracted from filenames dynamically (`basename virtual-machines.md .md` becomes `--tags service:virtual-machines`). Multiple tags are OR'd.
 
@@ -125,6 +126,7 @@ Service names are extracted from filenames dynamically (`basename virtual-machin
 | Single service file (e.g. virtual-machines.md) | 2         |
 | Docs-only change                               | 0         |
 | SKILL.md + 1 service file                      | 6         |
+| Eval task or grader change                     | 4         |
 | Manual dispatch (all 8 tasks x 1 trial)        | 8         |
 
 The job requires `COPILOT_GITHUB_TOKEN`; skips with a notice if not configured. `continue-on-error: true` prevents eval failures from blocking PRs while graders are being tuned.


### PR DESCRIPTION
Closes #594

## Summary

- Adds `eval-tasks` filter (`tests/evals/**`) to the `Detect critical file changes` step in `evaluate-critical`
- Maps `EVAL_TASKS=true` to the `smoke` tag in `Build eval scope`, so any change to an eval task YAML or grader triggers 4 smoke evals against a real model
- Documents the new trigger row and cost example in `docs/ops/evals.md`

## Why

Previously a contributor could add a broken grader or misconfigure a task ID and merge without any real-model validation. `waza check` catches schema errors but does not execute tasks. This change closes that gap: every `tests/evals/**` change now runs the 4 smoke tasks to confirm the eval pipeline executes end-to-end with a real model.

## Test plan

- [ ] CI `validate-eval-schema` passes (waza check on changed eval files)
- [ ] CI `evaluate-critical` runs with `smoke` tag when `tests/evals/**` changes (verify in Actions step summary that "Targeted eval tags: smoke" is logged)
- [ ] CI `evaluate-critical` skips when only non-eval, non-skill files change (e.g. docs-only)
- [ ] `docs/ops/evals.md` targets table includes the `tests/evals/**` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline to automatically detect evaluation-related changes and trigger smoke test suites without manual intervention.

* **Documentation**
  * Updated evaluation operations documentation to reflect new automated testing behaviors and associated resource usage metrics for evaluation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->