### PR TITLE
fix: scope evaluate-mock to negative tests only

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -81,8 +81,7 @@ jobs:
           sed -i 's/executor:[[:space:]]*copilot-sdk/executor: mock/' tests/evals/azure-cost-calculator/eval.yaml
       - name: Run evaluations (mock)
         if: steps.filter.outputs.relevant == 'true'
-        continue-on-error: true
-        run: waza run --verbose --output results.json
+        run: waza run --tags negative --verbose --output results.json
       - name: Upload results
         if: always() && steps.filter.outputs.relevant == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -100,7 +100,7 @@ Three jobs in `.github/workflows/eval.yml` run on PRs to `dev`; one additional j
 | Job                           | Executor      | What it does                                     | LLM calls |
 | ----------------------------- | ------------- | ------------------------------------------------ | --------- |
 | `validate-eval-schema`        | n/a           | `waza check` (schema validation only)            | 0         |
-| `evaluate-mock`               | `mock`        | Validates eval pipeline with simulated responses | 0         |
+| `evaluate-mock`               | `mock`        | Runs `--tags negative` only; validates trigger grader wiring | 0         |
 | `evaluate-critical`           | `copilot-sdk` | Real AI evals; only tasks matching changed files | 0-8       |
 | `run-evals` (manual dispatch) | `copilot-sdk` | All tasks by default; optional comma-separated tag filter   | up to 8   |
 
@@ -135,7 +135,7 @@ The job requires `COPILOT_GITHUB_TOKEN`; skips with a notice if not configured. 
 
 ### Mock executor
 
-Validates eval YAML parsing, grader config, and pipeline without authentication. Positive tests fail under mock (no real AI output); negative tests pass (mock does not activate skills). Uses `continue-on-error: true`.
+Runs only `--tags negative` tasks. Negative tests pass deterministically under mock because the mock executor never activates skills. Positive tests are excluded: they require real AI output and always fail under mock, producing no actionable signal. `waza check` (run in `validate-eval-schema`) already covers schema and grader config validation.
 
 ### Copilot SDK executor
 


### PR DESCRIPTION
Closes #605. Part of #590.

## Summary

- `evaluate-mock` now runs `waza run --tags negative` instead of all 8 tasks
- Removes `continue-on-error: true`; the 2 negative tasks pass deterministically under mock
- Updates `docs/ops/evals.md` CI table and mock executor section to reflect the new behavior

## Why

The mock executor never activates skills, so positive tests always fail with no actionable signal. `waza check` (in `validate-eval-schema`) already covers schema and grader config. The only meaningful work `evaluate-mock` can do is confirm the trigger grader wiring works for negative tests.

## Validation

PR itself changes `tests/evals/**`-adjacent files, so `evaluate-mock` will run and the 2 negative tasks should pass (0 failures). `evaluate-critical` should fire with `smoke` tag due to `tests/evals/**` not being changed here, but `.github/workflows/eval.yml` is also not in any `evaluate-critical` filter, so it should skip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation documentation to clarify mock evaluation scope, test scenario handling, and validation coverage boundaries.

* **Chores**
  * Modified continuous integration pipeline configuration to refine test filtering in the evaluation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->