### PR TITLE
docs: document waza suggest as scaffold starting point for new eval tasks

### DIFF
--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -276,6 +276,7 @@ Examples from current service references:
 | `argument-hint` frontmatter diverges from agentskills.io spec                                                                           | Project convention; not blocking for evals                                                                                                                                                         |
 | `waza suggest` output directory defaults to `<skill-path>/evals` (i.e. `skills/azure-cost-calculator/evals`)                            | Pass `--output-dir tests/evals/azure-cost-calculator` to place files in the correct location                                                                                                        |
 | `waza suggest` generates task IDs, globs, and graders that diverge from project conventions                                             | Treat output as a scaffold only: rename IDs to `eval:<category>/<service>/<scenario>`, add correct tags, replace any prompt grader model references, and add the standard `uses-pricing-script` `tool_constraint` grader |
+| `waza suggest` fails intermittently with `parsing suggest response: response is not valid suggestion YAML`                               | LLM output occasionally does not parse; retry the command |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Part of #590. Closes #599.

## What

Documents `waza suggest` in `docs/ops/evals.md` as the recommended scaffold starting point when authoring a new eval task. Three locations updated: contributor workflow fast path, quick start section, and adding-a-task tip. Three known limitations added.

## Why

Contributors currently get "copy an existing task" as their starting point. `waza suggest` generates scaffolded task YAML from SKILL.md using LLM analysis, reducing cold-start friction. Without documentation, contributors won't know the command exists.

## Changes

- **Contributor workflow fast path**: added step 3 — run `waza suggest --dry-run` before authoring, with a link to Quick start for the invocation
- **Quick start**: added `waza suggest skills/azure-cost-calculator --dry-run` command block between `waza check` and `waza run`
- **Adding a task tip**: replaced "copy an existing task" with a `waza suggest` invocation and a reference to Known limitations
- **Known limitations**: added three rows covering the output-dir mismatch, convention divergence, and intermittent parse failure

## Verification

`waza suggest` was run multiple times locally (`~/bin/waza suggest skills/azure-cost-calculator --dry-run`) to confirm:
- Command syntax and flags are correct (`--dry-run` is the default)
- Successful output confirms the limitations: task IDs use flat names not `eval:<category>/<service>/<scenario>`, eval.yaml glob is `tasks/*.yaml` not the multi-depth pattern, prompt grader references `gpt-4o-mini`, no `tool_constraint` grader generated
- Default `--output-dir` is `<skill-path>/evals` confirmed from `--help` output
- One run failed with `parsing suggest response: response is not valid suggestion YAML` — confirmed intermittent LLM parse failure; documented in Known limitations

`waza check` passes: `eval.yaml schema valid`, `8 task file(s) validated`. No schema changes.

## Test evidence

```
📐 Schema Validation: Passed
   ✅  eval.yaml schema valid
   ✅  8 task file(s) validated
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated eval workflow documentation to incorporate a new scaffolding step.
  * Enhanced quick start guide with required environment variable configuration and dry-run command example.
  * Replaced generic scaffolding guidance with specific task generation instructions and manual review requirements.
  * Added comprehensive known limitations section documenting output directory behavior, ID/glob divergence, and YAML parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->