### PR TITLE
fix: redesign alias-routing smoke task to use disambiguation prompt

### DIFF
--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -231,9 +231,9 @@ Routing is proven indirectly through the agent's knowledge of the service's neve
       These are "never-assume" parameters the agent must not guess.
 
       Review the agent response and score it:
-      - Score 1.0 if the agent asks for at least one missing parameter and does NOT provide a cost estimate.
-      - Score 0.5 if the agent asks for clarification but also includes a cost estimate.
-      - Score 0.0 if the agent provides a cost estimate without asking for any missing parameters.
+      - Score 1.0 if the agent asks for at least one of the listed never-assume parameters and does NOT provide a cost estimate.
+      - Score 0.5 if the agent asks for at least one of the listed never-assume parameters but also includes a cost estimate.
+      - Score 0.0 if the agent provides a cost estimate without asking for any of the listed never-assume parameters.
 
       Return ONLY a decimal number between 0.0 and 1.0 with no other text.
   weight: 2.0

--- a/tests/evals/azure-cost-calculator/tasks/smoke/alias-routing.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/smoke/alias-routing.yaml
@@ -30,9 +30,9 @@ graders:
         These are "never-assume" parameters the agent must not guess.
 
         Review the agent response and score it:
-        - Score 1.0 if the agent asks for at least one missing parameter and does NOT provide a cost estimate.
-        - Score 0.5 if the agent asks for clarification but also includes a cost estimate.
-        - Score 0.0 if the agent provides a cost estimate without asking for any missing parameters.
+        - Score 1.0 if the agent asks for provisioned throughput (RU/s) and/or storage (GB) and does NOT provide a cost estimate.
+        - Score 0.5 if the agent asks for provisioned throughput (RU/s) and/or storage (GB) but also includes a cost estimate.
+        - Score 0.0 if the agent provides a cost estimate without asking for provisioned throughput (RU/s) or storage (GB).
 
         Return ONLY a decimal number between 0.0 and 1.0 with no other text.
     weight: 2.0


### PR DESCRIPTION
## Summary

- Replaces the full estimation prompt ("How much does CosmosDB cost for 400 RU/s in East US?") with a parameter-free prompt ("How much does CosmosDB cost?")
- Switches the task from alias routing + estimation to alias routing + disambiguation adherence
- Removes all text graders (`resolved-service-name`, `user-specified-throughput`); adds `asks-before-estimating` LLM judge and `skill_invocation` grader
- Flips `expected.output_contains` to `output_not_contains` (no estimate should be produced)
- Cleans up `docs/ops/evals.md`: removes snapshot content and bloat, genericises routing task design guidance with placeholders, removes unjustified assumptions

## Root cause

The original prompt provided enough context for a full Cosmos DB estimation. With the alias "CosmosDB" and a missing storage parameter, the agent produced verbose assumption reasoning that pushed response generation past the 300s eval session timeout. Evidence from the same CI run:

| Task | Tool calls | Duration |
|------|-----------|----------|
| `alias-routing` (original) | 4 | 300s (timeout) |
| `provisioned-throughput` (happy-path, canonical name + complete params) | 4 | 68s |

The 232s gap with identical tool call counts points to response generation being the bottleneck, not the tool calls themselves.

## Grader iteration

Three CI runs were needed to arrive at the final grader design:

**Run 1** — `resolved-service-name` checked for "Azure Cosmos DB". Agent responded with "Cosmos DB" (no "Azure" prefix). Score: 0.

**Run 2** — Changed to substring "Cosmos DB". Agent responded with "CosmosDB" (no space). Score: 0.

**Run 3** — Changed to regex `Cosmos\s*DB`. Agent responded with "Before I can run a live price query, I need a few details" with no service name at all. Root insight: text graders on service name are fundamentally unreliable in disambiguation responses. The agent may echo the alias, use a variant spelling, or drop the name entirely. No regex reliably matches all forms.

**Resolution**: drop `resolved-service-name` entirely. Routing is proven indirectly through the agent's knowledge of Cosmos DB's never-assume parameters. If the agent asks for provisioned throughput (RU/s) and storage (GB), it must have read the correct reference file. The `asks-before-estimating` LLM judge grader encodes exactly this: it names those parameters in its scoring criteria and requires the agent ask for them without producing an estimate.

## What the graders now test

- `asks-before-estimating` (prompt, weight 2.0): agent asked for at least one Cosmos DB never-assume parameter (throughput or storage) without providing a cost estimate. Scores 1.0 / 0.5 / 0.0.
- `skill-activated` (skill_invocation, weight 1.0): azure-cost-calculator skill was invoked.

No text graders. The `provisioned-throughput` happy-path task continues to cover full Cosmos DB estimation with text graders and the pricing script grader.

## Determinism validation

Four manual `workflow_dispatch` runs after the final grader design:

| Run | `asks-before-estimating` | `skill-activated` | Duration |
|-----|--------------------------|-------------------|----------|
| 1 | 1.00 | 1.00 | 18s |
| 2 | 1.00 | 1.00 | 22s |
| 3 | 1.00 | 1.00 | 26s |
| 4 | 1.00 | 1.00 | 19s |

4/4 passes, 18–26s each (well within 300s). One unrelated `provisioned-throughput` failure observed (agent wrote "1000" instead of "1,000") — pre-existing flakiness, not introduced by this PR.

## evals.md changes

The routing task design learnings are captured generically so they apply to any service, not just Cosmos DB:

- New "Routing task design" subsection with parameter-free prompt rationale and LLM judge template using `{Service Name}` / `{never-assume parameter list}` placeholders
- Two new troubleshooting rows: session timeout and non-deterministic text grader failure modes
- Removed: "Read this first" nav section, contributor workflow with `waza suggest`, task directory tree snapshot, "Adding a task" duplicate section
- Fixed: unjustified "always use East US" assumption, inaccurate global 300s timeout claim, em dashes throughout, `waza suggest` rows consolidated to single "do not use" entry

## Test plan

- [x] `alias-routing` completes without `context deadline exceeded`
- [x] `asks-before-estimating` scores 1.00 (agent asks for throughput/storage, no estimate produced)
- [x] `skill-activated` scores 1.00
- [x] Task duration well under 300s (18–26s observed)
- [x] `waza check` passes

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated smoke evaluations for cost-estimation workflows to require agents ask for required parameters (provisioned throughput and storage) before giving estimates
  * Broadened inquiry scenarios to use more general prompts and prevent inappropriate auto-generated cost estimates
  * Smoke-triggered runs now execute all smoke tasks instead of a fixed subset
* **Documentation**
  * Added routing task design guidance, updated quick-start and grader guidance, and new troubleshooting notes clarifying prompt requirements and grader behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->