### PR TITLE
test: add currencyCode placement assertions for bash and ps (#611)

### DIFF
--- a/tests/unit/bash/lib/invoke-retail-prices-query.bats
+++ b/tests/unit/bash/lib/invoke-retail-prices-query.bats
@@ -66,13 +66,14 @@ SCRIPT
     local url
     url=$(cat "$MOCK_DIR/curl_args")
 
-    # currencyCode must appear as a separate &currencyCode= parameter
-    [[ "$url" == *"&currencyCode=AUD"* ]]
+    # currencyCode must appear as its own query parameter (order-independent)
+    [[ "$url" == *'?currencyCode=AUD'* || "$url" == *'&currencyCode=AUD'* ]]
 
     # currencyCode must NOT appear inside the $filter= value
-    # Extract the portion before &currencyCode= and verify it contains no 'currencyCode'
-    local filter_part="${url%%&currencyCode=*}"
-    [[ "$filter_part" != *"currencyCode"* ]]
+    if grep -q '\$filter=[^&]*currencyCode' <<< "$url"; then
+        echo "currencyCode unexpectedly found inside \$filter parameter in URL: $url" >&2
+        false
+    fi
 }
 
 @test "currency code with special characters is URL-encoded" {

--- a/tests/unit/powershell/lib/Invoke-RetailPricesQuery.Tests.ps1
+++ b/tests/unit/powershell/lib/Invoke-RetailPricesQuery.Tests.ps1
@@ -156,8 +156,8 @@ Describe 'Invoke-RetailPricesQuery' {
             Invoke-RetailPricesQuery -Filter "serviceName eq 'VMs'" -CurrencyCode 'AUD'
 
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
-                $Uri -like '*&currencyCode=AUD*' -and
-                ($Uri -replace '&currencyCode=.*$', '') -notlike '*currencyCode*'
+                $Uri -match '[?\&]currencyCode=AUD(\&|$)' -and
+                ($Uri -replace '[?\&]currencyCode=[^\&]*', '') -notmatch 'currencyCode'
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds a bats test verifying `currencyCode` is passed as `&currencyCode=<value>` (separate query parameter, not inside the `$filter` string) in `invoke-retail-prices-query.sh`
- Adds the equivalent Pester test for `Invoke-RetailPricesQuery.ps1` using the existing `ParameterFilter` pattern

Both tests assert two conditions: `currencyCode=<value>` appears after `&`, and the `$filter=` portion of the URL contains no `currencyCode`.

The trap is already documented in `pitfalls.md` under API Query Traps. This closes the test coverage gap.

Closes #611

## Test plan

- [ ] `bash tests/unit/run-bats-tests.sh` — new bats test `ok`
- [ ] `pwsh tests/unit/Run-PesterTests.ps1` — new Pester test passes, 184 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests (Bash and PowerShell) that validate currency code parameters are sent as standalone URL query parameters (e.g., ?currencyCode=AUD or &currencyCode=AUD) and are not embedded inside filter expressions, improving coverage around request URI construction for retail prices API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->