### PR TITLE
chore: add copilot-instructions.md symlink for VS Code Copilot contributors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` as a symlink to `../AGENTS.md`
- VS Code Copilot reads this file natively; contributors get project context without enabling experimental flags
- GitHub Copilot CLI already reads `AGENTS.md` directly, so no change needed there

Closes #675

## Test plan

- [ ] Verify symlink resolves correctly: `readlink .github/copilot-instructions.md` returns `../AGENTS.md`
- [ ] Open the repo in VS Code with GitHub Copilot and confirm project instructions are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration file for AI assistant instructions to standardize development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->