### PR TITLE
feat: remove GitHub skill dependency from service-ref-pr-reviewer

### DIFF
--- a/.github/agents/service-ref-pr-reviewer.md
+++ b/.github/agents/service-ref-pr-reviewer.md
@@ -26,7 +26,7 @@ All GitHub REST API calls below require no authentication (repo is public). Use 
 
 Fetch PR details from the GitHub REST API:
 
-```
+```http
 GET https://api.github.com/repos/{owner}/{repo}/pulls/{PR_NUMBER}
 ```
 
@@ -36,7 +36,7 @@ Extract: number, author login, head branch name, `head.sha`, `head.repo.full_nam
 
 Fetch all PR comments and review comments (add `?per_page=100` and follow `Link: rel="next"` pagination until exhausted):
 
-```
+```http
 GET https://api.github.com/repos/{owner}/{repo}/issues/{PR_NUMBER}/comments?per_page=100
 GET https://api.github.com/repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments?per_page=100
 ```
@@ -47,7 +47,7 @@ Store all comments; they may contain context about design decisions, known issue
 
 Fetch the list of changed files (add `?per_page=100` and follow `Link: rel="next"` pagination until exhausted):
 
-```
+```http
 GET https://api.github.com/repos/{owner}/{repo}/pulls/{PR_NUMBER}/files?per_page=100
 ```
 
@@ -60,9 +60,9 @@ If no service reference files are changed, display: "No service reference files 
 For fork PRs, `head.repo.full_name` will differ from the base repo; fetch the ref explicitly using `head.sha` before creating the worktree:
 
 ```bash
-git fetch origin pull/{PR_NUMBER}/head
+git fetch origin "pull/$PR_NUMBER/head"
 WORKTREE_DIR="../pr-review-$PR_NUMBER"
-git worktree add "$WORKTREE_DIR" "$HEAD_SHA"
+git worktree add "$WORKTREE_DIR" FETCH_HEAD
 cd "$WORKTREE_DIR"
 ```
 
@@ -89,7 +89,7 @@ For each changed service reference file, read the full content. Note:
 
 Fetch the full PR diff from the GitHub REST API:
 
-```
+```http
 GET https://api.github.com/repos/{owner}/{repo}/pulls/{PR_NUMBER}
 Accept: application/vnd.github.diff
 ```
@@ -326,12 +326,22 @@ Output the compiled review to the console in full. This is the primary output of
 
 After displaying it, ask the user: **"Do you want to post this review to the PR? (yes/no)"**
 
-If the user confirms, write the review body to a unique temp file using the `edit` tool, then post it:
+If the user confirms:
+
+1. Create a temp directory and set the file path:
 
 ```bash
-REVIEW_FILE=$(mktemp /tmp/pr-review-XXXXXX.md)
-gh pr comment {PR_NUMBER} --body-file "$REVIEW_FILE"
-rm -f "$REVIEW_FILE"
+REVIEW_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pr-review.XXXXXX")
+REVIEW_FILE="$REVIEW_DIR/pr-review.md"
+```
+
+2. Use the `edit` tool to write the full compiled review content into `$REVIEW_FILE`.
+
+3. Post the comment and clean up:
+
+```bash
+gh pr comment $PR_NUMBER --body-file "$REVIEW_FILE"
+rm -rf "$REVIEW_DIR"
 ```
 
 If there are **blocking issues**, also submit a formal review requesting changes:

--- a/docs/ops/custom-agents.md
+++ b/docs/ops/custom-agents.md
@@ -166,7 +166,7 @@ Sub-agents use restricted toolsets (principle of least privilege):
 
 ### What it does
 
-When the Copilot coding agent is assigned to review a PR using the `service-ref-pr-reviewer` custom agent, it runs a review-focused consensus workflow:
+When a human invokes the `service-ref-pr-reviewer` agent locally with a PR number, it runs a review-focused consensus workflow:
 
 1. **Orchestrator** (`service-ref-pr-reviewer`) gathers PR metadata (diff, comments, author), creates a dedicated worktree for the PR branch, and identifies changed service reference files.
 2. **Pricing Investigator A** (`pricing-investigator`, first instance) independently investigates the Azure Retail Prices API and compares findings against the PR's file content.
@@ -223,7 +223,7 @@ The `service-ref-pr-reviewer` agent is designed for PRs that create, update, enh
 | Symptom                          | Likely cause                                                                      | Fix                                                                        |
 | -------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | Agent not appearing              | File not merged to default branch                                                 | Merge to main; verify `.github/agents/service-ref-pr-reviewer.md` exists   |
-| No service reference files found | PR doesn't change files under `skills/azure-cost-calculator/references/services/` | Expected; agent posts a skip message and stops                             |
+| No service reference files found | PR doesn't change files under `skills/azure-cost-calculator/references/services/` | Expected; agent displays a skip message in the console and stops           |
 | Worktree creation fails          | Branch not fetched or conflicting worktree exists                                 | Ensure PR branch is available; remove stale worktrees                      |
 | Sub-agent not invoked            | Orchestrator's `tools` list missing `agent`                                       | Ensure `tools: ["read", "search", "edit", "execute", "agent", "web"]`      |
 | GitHub API fetch fails           | Network issue or unauthenticated GitHub API rate limiting after multiple requests | Retry; if rate-limited, wait and retry, or set `GH_TOKEN` to raise limits  |


### PR DESCRIPTION
## Summary

- Replace all "Use the GitHub skill" references in `service-ref-pr-reviewer` with direct GitHub REST API web fetches (no auth required, repo is public)
- Display the compiled review in the console as the agent's primary output
- After displaying, ask the user whether to post the review to the PR; if yes, use `gh` CLI commands inline
- Add `argument-hint` to frontmatter so the agent prompts for a PR number on invocation
- Update `docs/ops/custom-agents.md`: dependency table, architecture diagram, troubleshooting rows

## Test plan

- [x] Invoke `service-ref-pr-reviewer` with a PR number and verify Phase 0 fetches PR data without `gh` auth
- [x] Confirm the review is displayed in the console at the end of Phase 6
- [x] Confirm the agent asks before posting and correctly runs `gh pr comment` + `gh pr review` when confirmed
- [x] Confirm the agent exits cleanly when the user declines to post

Closes #679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent accepts a PR number argument for targeted reviews (manual invocation).
  * Console-first workflow: displays the structured review by default, with an optional user-confirmed post to GitHub that will publish approval or request-changes as appropriate.
  * Improved checkout support for forked PRs when reviewing locally.

* **Documentation**
  * Docs updated to explain manual invocation, console workflow, and revised troubleshooting for network/CLI authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->