### PR TITLE
feat: experimental automated service-reference pipeline (#688)

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -5,6 +5,11 @@
       "version": "v8",
       "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
     },
+    "github/gh-aw-actions/setup@v0.67.1": {
+      "repo": "github/gh-aw-actions/setup",
+      "version": "v0.67.1",
+      "sha": "80471a493be8c528dd27daf73cd644242a7965e0"
+    },
     "github/gh-aw/actions/setup@v0.43.23": {
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.43.23",

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d42015d46689406867f9b5a4781f95d867a7b9a733e703fd6684c63579493030","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"68019e22fce1121b13e6bb6dac435c724d007fc5c439c3b918d7f3a5f2098a78","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -160,14 +160,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
           <system>
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          GH_AW_PROMPT_2ac12407696f36cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:2), assign_to_agent, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -199,12 +199,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          GH_AW_PROMPT_2ac12407696f36cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          GH_AW_PROMPT_2ac12407696f36cc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -351,16 +351,13 @@ jobs:
           GH_HOST: github.com
       - name: Install AWF binary
         run: bash ${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh v0.25.13
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.14 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -370,12 +367,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << GH_AW_SAFE_OUTPUTS_CONFIG_1fe0644ad97c4154_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << GH_AW_SAFE_OUTPUTS_CONFIG_8f800cae5f1e57d8_EOF
           {"add_comment":{"max":1},"add_labels":{"allowed":["new-service","pricing-inaccuracy","service-update","needs-info","duplicate","good first issue","question","invalid","enhancement"],"max":2},"assign_to_agent":{"base-branch":"dev","custom-agent":"service-reference","github-token":"${PIPELINE_GITHUB_TOKEN}","max":1,"model":"claude-opus-4.6"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1fe0644ad97c4154_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8f800cae5f1e57d8_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7218d52ce4b9c8a8_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7798b5ca062b98fa_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
@@ -385,8 +382,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_7218d52ce4b9c8a8_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ed04246b0e783ec3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7798b5ca062b98fa_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9bc3dcc8126a87da_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -524,7 +521,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ed04246b0e783ec3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_9bc3dcc8126a87da_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -572,8 +569,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -594,7 +589,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3e2fd8424f7fdd3b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_bd1557c5cc74383f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -608,8 +603,13 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": [
+                      "ahmadabdalla/azure-cost-calculator"
+                    ],
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -622,7 +622,7 @@ jobs:
                 "guard-policies": {
                   "write-sink": {
                     "accept": [
-                      "*"
+                      "private:ahmadabdalla/azure-cost-calculator"
                     ]
                   }
                 }
@@ -635,7 +635,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e2fd8424f7fdd3b_EOF
+          GH_AW_MCP_CONFIG_bd1557c5cc74383f_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -811,6 +811,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"68019e22fce1121b13e6bb6dac435c724d007fc5c439c3b918d7f3a5f2098a78","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ed97d073dee2b51d6b53c4da5649ba24288fb4a686453dfb388deb3c59dc86a8","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -41,6 +41,7 @@ name: "Issue Triage"
   issues:
     types:
     - opened
+    - labeled
   # roles: all # Roles processed as role check in pre-activation job
 
 permissions: {}
@@ -160,14 +161,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
+          cat << 'GH_AW_PROMPT_30283a28c64642ad_EOF'
           <system>
-          GH_AW_PROMPT_2ac12407696f36cc_EOF
+          GH_AW_PROMPT_30283a28c64642ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
+          cat << 'GH_AW_PROMPT_30283a28c64642ad_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:2), assign_to_agent, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -199,12 +200,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2ac12407696f36cc_EOF
+          GH_AW_PROMPT_30283a28c64642ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2ac12407696f36cc_EOF'
+          cat << 'GH_AW_PROMPT_30283a28c64642ad_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_2ac12407696f36cc_EOF
+          GH_AW_PROMPT_30283a28c64642ad_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -367,12 +368,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << GH_AW_SAFE_OUTPUTS_CONFIG_8f800cae5f1e57d8_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << GH_AW_SAFE_OUTPUTS_CONFIG_d4e08ca814528d05_EOF
           {"add_comment":{"max":1},"add_labels":{"allowed":["new-service","pricing-inaccuracy","service-update","needs-info","duplicate","good first issue","question","invalid","enhancement"],"max":2},"assign_to_agent":{"base-branch":"dev","custom-agent":"service-reference","github-token":"${PIPELINE_GITHUB_TOKEN}","max":1,"model":"claude-opus-4.6"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8f800cae5f1e57d8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d4e08ca814528d05_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7798b5ca062b98fa_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f87d9a464fc5e050_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
@@ -382,8 +383,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_7798b5ca062b98fa_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9bc3dcc8126a87da_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_f87d9a464fc5e050_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b9860c252750b723_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -521,7 +522,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9bc3dcc8126a87da_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b9860c252750b723_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -589,7 +590,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_bd1557c5cc74383f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_2a7791b3e99c9a20_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -635,7 +636,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_bd1557c5cc74383f_EOF
+          GH_AW_MCP_CONFIG_2a7791b3e99c9a20_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -2,7 +2,7 @@
 name: Issue Triage
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
   roles: all
 engine: copilot
 permissions: read-all
@@ -128,10 +128,14 @@ If the issue comes from the improvement template or describes a general enhancem
 
 ### Step 5 - Automated Pipeline Assignment (Experimental)
 
-After completing Steps 1-4, check whether the issue has the `experiment-pipeline` label.
+This workflow triggers on both `opened` and `labeled` events. When triggered by a `labeled` event:
 
-- If the `experiment-pipeline` label is **present** AND the issue was classified as a `new-service` issue (Step 2) with a valid service in the catalog or routing map: use `assign-to-agent` to assign the Copilot coding agent to the issue. The agent configuration (custom agent, model, base branch) is pre-set in the workflow; you only need to trigger the assignment.
-- If the `experiment-pipeline` label is **not present**: do nothing. Do not use `assign-to-agent`. This step only applies to issues explicitly opted into the experiment.
+- If the label added is **not** `experiment-pipeline`: call `noop`. Do not re-triage or re-comment.
+- If the label added is `experiment-pipeline`: skip Steps 1-4 (the issue was already triaged on the `opened` event). Proceed directly to the assignment logic below.
+
+**Assignment logic:** Check whether the issue has the `experiment-pipeline` label AND was classified as a `new-service` issue (check for `new-service` label from the initial triage). If both conditions are met, use `assign-to-agent` to assign the Copilot coding agent to the issue. The agent configuration (custom agent, model, base branch) is pre-set in the workflow; you only need to trigger the assignment.
+
+If the `experiment-pipeline` label is **not present** (e.g., on a normal `opened` event): do nothing. Do not use `assign-to-agent`. This step only applies to issues explicitly opted into the experiment.
 
 This is a scoped experiment. The vast majority of issues will not have this label and will follow the standard triage flow (Steps 1-4) only.
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -3,9 +3,9 @@ name: Issue Triage
 on:
   issues:
     types: [opened]
+  roles: all
 engine: copilot
 permissions: read-all
-roles: all
 network:
   allowed:
     - github
@@ -30,6 +30,12 @@ safe-outputs:
         enhancement,
       ]
     max: 2
+  assign-to-agent:                                    # EXPERIMENT: issue #688
+    custom-agent: "service-reference"
+    model: "claude-opus-4.6"
+    base-branch: "dev"
+    max: 1
+    github-token: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
 concurrency:
   group: issue-triage-${{ github.event.issue.number }}
   cancel-in-progress: true
@@ -53,7 +59,7 @@ These constraints are absolute and override all other instructions:
 
 Analyze the following issue content:
 
-"${{ needs.activation.outputs.text }}"
+"${{ steps.sanitized.outputs.text }}"
 
 ## Classification Logic
 
@@ -114,6 +120,19 @@ If the issue comes from the improvement template or describes a general enhancem
 
 - **Spam or off-topic** content (unrelated to Azure cost estimation, service references, or this skill) → label `invalid`. Do not leave a comment.
 - **Usage questions** not from the improvement template → label `question`. If the question relates to a specific Azure service, check if a reference file exists and point to it.
+
+<!-- EXPERIMENT: automated-pipeline (issue #688) -->
+
+### Step 5 - Automated Pipeline Assignment (Experimental)
+
+After completing Steps 1-4, check whether the issue has the `experiment-pipeline` label.
+
+- If the `experiment-pipeline` label is **present** AND the issue was classified as a `new-service` issue (Step 2) with a valid service in the catalog or routing map: use `assign-to-agent` to assign the Copilot coding agent to the issue. The agent configuration (custom agent, model, base branch) is pre-set in the workflow; you only need to trigger the assignment.
+- If the `experiment-pipeline` label is **not present**: do nothing. Do not use `assign-to-agent`. This step only applies to issues explicitly opted into the experiment.
+
+This is a scoped experiment. The vast majority of issues will not have this label and will follow the standard triage flow (Steps 1-4) only.
+
+<!-- END EXPERIMENT -->
 
 ## Comment Guidelines
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -13,6 +13,9 @@ tools:
   github:
     toolsets:
       - issues
+    allowed-repos:
+      - "ahmadabdalla/azure-cost-calculator"
+    min-integrity: approved
 safe-outputs:
   add-comment:
     max: 1

--- a/.github/workflows/promote-copilot-drafts.yml
+++ b/.github/workflows/promote-copilot-drafts.yml
@@ -72,7 +72,12 @@ jobs:
             # Check last commit time on the branch (more accurate than updatedAt)
             LAST_COMMIT_DATE=$(gh api \
               "repos/$REPO/commits?sha=$BRANCH&per_page=1" \
-              --jq '.[0].commit.committer.date' 2>/dev/null || echo "$UPDATED")
+              --jq '.[0].commit.committer.date' 2>/dev/null || true)
+
+            # Fall back to PR updatedAt if commit date is empty or null
+            if [ -z "$LAST_COMMIT_DATE" ] || [ "$LAST_COMMIT_DATE" = "null" ]; then
+              LAST_COMMIT_DATE="$UPDATED"
+            fi
 
             # Ubuntu runner: GNU date with -d flag
             LAST_EPOCH=$(date -u -d "$LAST_COMMIT_DATE" +%s)

--- a/.github/workflows/promote-copilot-drafts.yml
+++ b/.github/workflows/promote-copilot-drafts.yml
@@ -1,0 +1,103 @@
+# EXPERIMENT: automated service-reference pipeline (issue #688)
+# Promotes idle Copilot coding agent draft PRs to ready-for-review.
+# Only affects draft PRs authored by copilot-swe-agent.
+# Safe to remove once the experiment concludes.
+
+name: "[Experiment] Promote Copilot Drafts"
+
+on:
+  schedule:
+    - cron: "0 */2 * * *" # every 2 hours
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: promote-copilot-drafts
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    name: Promote idle Copilot drafts
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Validate token
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::PIPELINE_GITHUB_TOKEN is not set. Skipping."
+            exit 0
+          fi
+
+      - name: Find and promote idle drafts
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          REPO="${{ github.repository }}"
+          IDLE_MINUTES=120  # 2 hours
+
+          echo "::group::Listing Copilot draft PRs"
+          DRAFT_PRS=$(gh pr list \
+            --repo "$REPO" \
+            --author "app/copilot-swe-agent" \
+            --draft \
+            --json number,headRefName,updatedAt \
+            --jq '.')
+
+          COUNT=$(echo "$DRAFT_PRS" | jq 'length')
+          echo "Found $COUNT Copilot draft PR(s)"
+          echo "::endgroup::"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No Copilot draft PRs found. Nothing to do."
+            exit 0
+          fi
+
+          NOW=$(date -u +%s)
+
+          echo "$DRAFT_PRS" | jq -c '.[]' | while read -r PR; do
+            NUMBER=$(echo "$PR" | jq -r '.number')
+            BRANCH=$(echo "$PR" | jq -r '.headRefName')
+            UPDATED=$(echo "$PR" | jq -r '.updatedAt')
+
+            echo "::group::PR #$NUMBER ($BRANCH)"
+
+            # Check last commit time on the branch (more accurate than updatedAt)
+            LAST_COMMIT_DATE=$(gh api \
+              "repos/$REPO/commits?sha=$BRANCH&per_page=1" \
+              --jq '.[0].commit.committer.date' 2>/dev/null || echo "$UPDATED")
+
+            # Ubuntu runner: GNU date with -d flag
+            LAST_EPOCH=$(date -u -d "$LAST_COMMIT_DATE" +%s)
+            IDLE_SECONDS=$(( NOW - LAST_EPOCH ))
+            IDLE_MINS=$(( IDLE_SECONDS / 60 ))
+
+            echo "Last activity: ${IDLE_MINS}m ago (threshold: ${IDLE_MINUTES}m)"
+
+            if [ "$IDLE_MINS" -lt "$IDLE_MINUTES" ]; then
+              echo "Still active. Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "Idle for ${IDLE_MINS}m. Promoting..."
+
+            # Mark as ready for review
+            gh pr ready "$NUMBER" --repo "$REPO"
+            echo "Marked PR #$NUMBER as ready for review"
+
+            # Add experiment-pipeline label (triggers review workflow via PAT)
+            gh pr edit "$NUMBER" --repo "$REPO" --add-label "experiment-pipeline"
+            echo "Added experiment-pipeline label to PR #$NUMBER"
+
+            echo "::endgroup::"
+          done
+
+          echo "Done."

--- a/.github/workflows/promote-copilot-drafts.yml
+++ b/.github/workflows/promote-copilot-drafts.yml
@@ -23,7 +23,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     steps:
       - name: Validate token
         env:

--- a/.github/workflows/service-ref-review.lock.yml
+++ b/.github/workflows/service-ref-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d42015d46689406867f9b5a4781f95d867a7b9a733e703fd6684c63579493030","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b137ed9562c764c7bd21b00f1ec4094fdd20af6c9cf52767561b65fdebe7f585","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -27,7 +27,6 @@
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
-#   - PIPELINE_GITHUB_TOKEN
 #
 # Custom actions used:
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,23 +35,28 @@
 #   - actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
 #   - github/gh-aw-actions/setup@80471a493be8c528dd27daf73cd644242a7965e0 # v0.67.1
 
-name: "Issue Triage"
+name: "[Experiment] Service Reference PR Review"
 "on":
-  issues:
+  pull_request:
+    # names: # Label filtering applied via job conditions
+    # - experiment-pipeline # Label filtering applied via job conditions
     types:
-    - opened
+    - labeled
   # roles: all # Roles processed as role check in pre-activation job
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: issue-triage-${{ github.event.issue.number }}
+  group: service-ref-review-${{ github.event.pull_request.number }}
 
-run-name: "Issue Triage"
+run-name: "[Experiment] Service Reference PR Review"
 
 jobs:
   activation:
+    if: >
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id) &&
+      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'experiment-pipeline')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -82,7 +86,7 @@ jobs:
           GH_AW_INFO_VERSION: "latest"
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.67.1"
-          GH_AW_INFO_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_INFO_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -116,7 +120,7 @@ jobs:
       - name: Check workflow lock file
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "issue-triage.lock.yml"
+          GH_AW_WORKFLOW_FILE: "service-ref-review.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -155,21 +159,20 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_STEPS_SANITIZED_OUTPUTS_TEXT: ${{ steps.sanitized.outputs.text }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
           <system>
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
           <safe-output-tools>
-          Tools: add_comment, add_labels(max:2), assign_to_agent, missing_tool, missing_data, noop
+          Tools: add_comment, submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -199,18 +202,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629dd38bf798be84_EOF'
+          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
           </system>
-          {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_629dd38bf798be84_EOF
+          {{#runtime-import .github/workflows/service-ref-review.md}}
+          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_STEPS_SANITIZED_OUTPUTS_TEXT: ${{ steps.sanitized.outputs.text }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -229,7 +231,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_STEPS_SANITIZED_OUTPUTS_TEXT: ${{ steps.sanitized.outputs.text }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -248,8 +249,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_STEPS_SANITIZED_OUTPUTS_TEXT: process.env.GH_AW_STEPS_SANITIZED_OUTPUTS_TEXT
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -284,7 +284,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: issuetriage
+      GH_AW_WORKFLOW_ID_SANITIZED: servicerefreview
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       effective_tokens: ${{ steps.parse-mcp-gateway.outputs.effective_tokens }}
@@ -364,29 +364,26 @@ jobs:
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.14 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
-        env:
-          PIPELINE_GITHUB_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
         run: |
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << GH_AW_SAFE_OUTPUTS_CONFIG_1fe0644ad97c4154_EOF
-          {"add_comment":{"max":1},"add_labels":{"allowed":["new-service","pricing-inaccuracy","service-update","needs-info","duplicate","good first issue","question","invalid","enhancement"],"max":2},"assign_to_agent":{"base-branch":"dev","custom-agent":"service-reference","github-token":"${PIPELINE_GITHUB_TOKEN}","max":1,"model":"claude-opus-4.6"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1fe0644ad97c4154_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_465f656fbefb834a_EOF'
+          {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_465f656fbefb834a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7218d52ce4b9c8a8_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2404b49f67ef1dc1_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
-              "add_labels": " CONSTRAINTS: Maximum 2 label(s) can be added. Only these labels are allowed: [\"new-service\" \"pricing-inaccuracy\" \"service-update\" \"needs-info\" \"duplicate\" \"good first issue\" \"question\" \"invalid\" \"enhancement\"].",
-              "assign_to_agent": " CONSTRAINTS: Maximum 1 issue(s) can be assigned to agent. Pull requests will target the \"dev\" branch."
+              "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
             },
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_7218d52ce4b9c8a8_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ed04246b0e783ec3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_2404b49f67ef1dc1_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b9de8969dc0b5a65_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -405,50 +402,6 @@ jobs:
                   "maxLength": 256
                 }
               }
-            },
-            "add_labels": {
-              "defaultMax": 5,
-              "fields": {
-                "item_number": {
-                  "issueNumberOrTemporaryId": true
-                },
-                "labels": {
-                  "required": true,
-                  "type": "array",
-                  "itemType": "string",
-                  "itemSanitize": true,
-                  "itemMaxLength": 128
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                }
-              }
-            },
-            "assign_to_agent": {
-              "defaultMax": 1,
-              "fields": {
-                "agent": {
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 128
-                },
-                "issue_number": {
-                  "issueNumberOrTemporaryId": true
-                },
-                "pull_number": {
-                  "optionalPositiveInteger": true
-                },
-                "pull_request_repo": {
-                  "type": "string",
-                  "maxLength": 256
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                }
-              },
-              "customValidation": "requiresOneOf:issue_number,pull_number"
             },
             "missing_data": {
               "defaultMax": 20,
@@ -522,9 +475,27 @@ jobs:
                   "maxLength": 1024
                 }
               }
+            },
+            "submit_pull_request_review": {
+              "defaultMax": 1,
+              "fields": {
+                "body": {
+                  "type": "string",
+                  "sanitize": true,
+                  "maxLength": 65000
+                },
+                "event": {
+                  "type": "string",
+                  "enum": [
+                    "APPROVE",
+                    "REQUEST_CHANGES",
+                    "COMMENT"
+                  ]
+                }
+              }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ed04246b0e783ec3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b9de8969dc0b5a65_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -594,7 +565,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3e2fd8424f7fdd3b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_fde74565c7c46a59_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -604,7 +575,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "issues"
+                  "GITHUB_TOOLSETS": "pull_requests,issues"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -635,7 +606,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e2fd8424f7fdd3b_EOF
+          GH_AW_MCP_CONFIG_fde74565c7c46a59_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -717,12 +688,11 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN,PIPELINE_GITHUB_TOKEN'
+          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
           SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SECRET_PIPELINE_GITHUB_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       - name: Append agent step summary
         if: always()
         run: bash ${RUNNER_TEMP}/gh-aw/actions/append_agent_step_summary.sh
@@ -845,7 +815,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-issue-triage"
+      group: "gh-aw-conclusion-service-ref-review"
       cancel-in-progress: false
     outputs:
       incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
@@ -880,7 +850,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -897,7 +867,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -911,7 +881,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -925,16 +895,14 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Issue Triage"
+          GH_AW_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "issue-triage"
+          GH_AW_WORKFLOW_ID: "service-ref-review"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
-          GH_AW_ASSIGNMENT_ERRORS: ${{ needs.safe_outputs.outputs.assign_to_agent_assignment_errors }}
-          GH_AW_ASSIGNMENT_ERROR_COUNT: ${{ needs.safe_outputs.outputs.assign_to_agent_assignment_error_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
@@ -1027,7 +995,7 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Issue Triage"
+          WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
           WORKFLOW_DESCRIPTION: "No description provided"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1111,16 +1079,13 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/issue-triage"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/service-ref-review"
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_WORKFLOW_ID: "issue-triage"
-      GH_AW_WORKFLOW_NAME: "Issue Triage"
+      GH_AW_WORKFLOW_ID: "service-ref-review"
+      GH_AW_WORKFLOW_NAME: "[Experiment] Service Reference PR Review"
     outputs:
-      assign_to_agent_assigned: ${{ steps.assign_to_agent.outputs.assigned }}
-      assign_to_agent_assignment_error_count: ${{ steps.assign_to_agent.outputs.assignment_error_count }}
-      assign_to_agent_assignment_errors: ${{ steps.assign_to_agent.outputs.assignment_errors }}
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
       comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
@@ -1137,7 +1102,6 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
-          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1169,31 +1133,13 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"new-service\",\"pricing-inaccuracy\",\"service-update\",\"needs-info\",\"duplicate\",\"good first issue\",\"question\",\"invalid\",\"enhancement\"],\"max\":2},\"assign_to_agent\":{\"base-branch\":\"dev\",\"custom-agent\":\"service-reference\",\"github-token\":\"${{ secrets.PIPELINE_GITHUB_TOKEN }}\",\"max\":1,\"model\":\"claude-opus-4.6\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/safe_output_handler_manager.cjs');
-            await main();
-      - name: Assign to Agent
-        id: assign_to_agent
-        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'assign_to_agent')
-        continue-on-error: true
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_AGENT_MAX_COUNT: 1
-          GH_AW_AGENT_DEFAULT_MODEL: "claude-opus-4.6"
-          GH_AW_AGENT_DEFAULT_CUSTOM_AGENT: "service-reference"
-          GH_AW_AGENT_BASE_BRANCH: "dev"
-        with:
-          github-token: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/assign_to_agent.cjs');
             await main();
       - name: Upload Safe Output Items
         if: always()

--- a/.github/workflows/service-ref-review.lock.yml
+++ b/.github/workflows/service-ref-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b137ed9562c764c7bd21b00f1ec4094fdd20af6c9cf52767561b65fdebe7f585","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27ebc9e82fa0d36c537e644e144a15d8152143d68f42f06a37b51a263d9d6c52","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -90,7 +90,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["github"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '[]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.13"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -163,14 +163,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
+          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
           <system>
-          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
+          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
+          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
           <safe-output-tools>
           Tools: add_comment, submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -202,12 +202,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
+          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7f380ec495ebc7e7_EOF'
+          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
           </system>
           {{#runtime-import .github/workflows/service-ref-review.md}}
-          GH_AW_PROMPT_7f380ec495ebc7e7_EOF
+          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -351,16 +351,13 @@ jobs:
           GH_HOST: github.com
       - name: Install AWF binary
         run: bash ${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh v0.25.13
-      - name: Determine automatic lockdown mode for GitHub MCP Server
-        id: determine-automatic-lockdown
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - name: Parse integrity filter lists
+        id: parse-guard-vars
         env:
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
-        with:
-          script: |
-            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
-            await determineAutomaticLockdown(github, context, core);
+          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
+          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
+          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.14 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -368,12 +365,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_465f656fbefb834a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_807fd84396428e44_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_465f656fbefb834a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_807fd84396428e44_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2404b49f67ef1dc1_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_1afda1abea8a3013_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
@@ -382,8 +379,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_2404b49f67ef1dc1_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b9de8969dc0b5a65_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_1afda1abea8a3013_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_181ab9c57d4a26c9_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -495,7 +492,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_b9de8969dc0b5a65_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_181ab9c57d4a26c9_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -543,8 +540,6 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
-          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
-          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -565,7 +560,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_fde74565c7c46a59_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_89da36f02f2516a1_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,8 +574,13 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
-                    "repos": "$GITHUB_MCP_GUARD_REPOS"
+                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
+                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
+                    "min-integrity": "approved",
+                    "repos": [
+                      "ahmadabdalla/azure-cost-calculator"
+                    ],
+                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
                 }
               },
@@ -593,7 +593,7 @@ jobs:
                 "guard-policies": {
                   "write-sink": {
                     "accept": [
-                      "*"
+                      "private:ahmadabdalla/azure-cost-calculator"
                     ]
                   }
                 }
@@ -606,7 +606,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fde74565c7c46a59_EOF
+          GH_AW_MCP_CONFIG_89da36f02f2516a1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -623,7 +623,7 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.13 --skip-pull --enable-api-proxy \
+          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.13 --skip-pull --enable-api-proxy --ssl-bump --allow-urls 'https://github.com/ahmadabdalla/azure-cost-calculator/*,https://api.github.com/repos/ahmadabdalla/azure-cost-calculator/*' \
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -709,7 +709,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -781,6 +781,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
@@ -1130,7 +1132,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"max\":1}}"

--- a/.github/workflows/service-ref-review.lock.yml
+++ b/.github/workflows/service-ref-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27ebc9e82fa0d36c537e644e144a15d8152143d68f42f06a37b51a263d9d6c52","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96cffe1d262cec60611cebb348d8c95b6f17e88dc2cbe9693745d04e3158ec90","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -90,7 +90,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '[]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["github"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.13"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -163,14 +163,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
+          cat << 'GH_AW_PROMPT_c721ef584bc35719_EOF'
           <system>
-          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
+          GH_AW_PROMPT_c721ef584bc35719_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
+          cat << 'GH_AW_PROMPT_c721ef584bc35719_EOF'
           <safe-output-tools>
           Tools: add_comment, submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -202,12 +202,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
+          GH_AW_PROMPT_c721ef584bc35719_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a4975e64d0cf7d10_EOF'
+          cat << 'GH_AW_PROMPT_c721ef584bc35719_EOF'
           </system>
           {{#runtime-import .github/workflows/service-ref-review.md}}
-          GH_AW_PROMPT_a4975e64d0cf7d10_EOF
+          GH_AW_PROMPT_c721ef584bc35719_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -365,12 +365,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_807fd84396428e44_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_70b1d39a435cbb5b_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_807fd84396428e44_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_70b1d39a435cbb5b_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_1afda1abea8a3013_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_b7a725196512d142_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
@@ -379,8 +379,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_1afda1abea8a3013_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_181ab9c57d4a26c9_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_b7a725196512d142_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_068626d131caf4fe_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -492,7 +492,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_181ab9c57d4a26c9_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_068626d131caf4fe_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -560,7 +560,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_89da36f02f2516a1_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_13a5bceced4b8820_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -606,7 +606,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_89da36f02f2516a1_EOF
+          GH_AW_MCP_CONFIG_13a5bceced4b8820_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -623,7 +623,7 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.13 --skip-pull --enable-api-proxy --ssl-bump --allow-urls 'https://github.com/ahmadabdalla/azure-cost-calculator/*,https://api.github.com/repos/ahmadabdalla/azure-cost-calculator/*' \
+          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.13 --skip-pull --enable-api-proxy \
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -709,7 +709,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -1132,7 +1132,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,codeload.github.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,lfs.github.com,objects.githubusercontent.com,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"max\":1}}"

--- a/.github/workflows/service-ref-review.md
+++ b/.github/workflows/service-ref-review.md
@@ -1,0 +1,175 @@
+---
+name: "[Experiment] Service Reference PR Review"
+on:
+  pull_request:
+    types: [labeled]
+    names: [experiment-pipeline]
+  roles: all
+engine: copilot
+permissions: read-all
+network:
+  allowed:
+    - github
+tools:
+  bash: true
+  github:
+    toolsets:
+      - pull_requests
+      - issues
+safe-outputs:
+  add-comment:
+    max: 1
+  submit-pull-request-review:
+    max: 1
+concurrency:
+  group: "service-ref-review-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+---
+
+# [Experiment] Service Reference PR Review Agent
+
+You are a PR review agent for service reference changes in the Azure Cost Calculator skill repository. You review pull requests that create, update, or fix service reference files by checking structural compliance, running validation scripts, and verifying consistency with routing and catalog files.
+
+> **Experiment scope (issue #688):** This workflow only runs on PRs with the `experiment-pipeline` label. It is not part of the production review process.
+
+## Safety Rules
+
+These constraints are absolute and override all other instructions:
+
+- **Never** modify files in the PR branch. You are a reviewer, not an author.
+- **Never** close, merge, or edit the pull request.
+- **Never** share secrets, tokens, or internal URLs.
+- You may post a **maximum of 1 comment** and submit a **maximum of 1 formal review**.
+
+## Phase 1: Identify Changed Service Reference Files
+
+List the files changed in this PR. Filter for files matching `skills/azure-cost-calculator/references/services/**/*.md`. Also note changes to `skills/azure-cost-calculator/references/service-routing.md` and `docs/service-catalog.md`.
+
+If no service reference files are changed, call `noop`. This workflow is only relevant for service reference PRs.
+
+## Phase 2: Read Context
+
+Read the following files to understand conventions:
+
+- `CONTRIBUTING.md`: contributor guide, hard rules
+- `docs/TEMPLATE.md`: canonical file structure and formatting rules
+- `skills/azure-cost-calculator/references/pitfalls.md`: known API traps
+- `skills/azure-cost-calculator/references/shared.md`: category index, constants
+- `skills/azure-cost-calculator/references/service-routing.md`: implemented services
+
+Read each changed service reference file in full. For each file, note:
+
+- The service name (from YAML `serviceName` and H1 title)
+- The category (from YAML `category` and file path)
+- All query patterns (ServiceName, ProductName, SkuName, MeterName values)
+- All traps and warnings
+- The cost formula
+- Whether this is a new file, an update, or a fix
+
+## Phase 3: Run Validation
+
+### 3.1 - Validation script
+
+For each changed service reference file, run:
+
+```bash
+pwsh tests/Validate-ServiceReference.ps1 -Path "{filepath}" -CheckAliasUniqueness -CheckRoutingFileSync
+```
+
+Record pass/fail status and all failure messages.
+
+### 3.2 - Eval coverage check
+
+For each changed service reference file, run:
+
+```bash
+bash tests/check-eval-coverage.sh {filepath}
+```
+
+If the script produces output, the service has no happy-path eval task. This is a **Blocking** issue.
+
+### 3.3 - Structural rules
+
+Manually verify against key rules from `CONTRIBUTING.md`:
+
+- First query pattern starts within lines 1-45
+- Total file length under 100 lines
+- No hardcoded dollar amounts outside Known Rates tables
+- No "verified" dates
+- At least one query uses `InstanceCount` or `Quantity` for scaling
+- YAML front matter fields match schema (types, lengths, allowed values, elision rule)
+
+### 3.4 - Routing and catalog consistency
+
+If the PR modifies `service-routing.md` or `service-catalog.md`:
+
+- New services must be added to the routing map and removed from the catalog
+- Entries must be in alphabetical order within their category section
+- Aliases must be unique across all services
+
+## Phase 4: Compile Review
+
+### Severity levels
+
+| Severity     | Meaning                                                                                          | Action required                     |
+| ------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| **Blocking** | Incorrect API filter values, wrong billing model, validation failures, missing required sections | Must fix before merge               |
+| **Warning**  | Missing edge cases, incomplete meter coverage, suboptimal query patterns, minor formatting issues | Should fix, but not a merge blocker |
+| **Info**     | Suggestions for improvement, alternative approaches, additional context                          | Optional enhancement                |
+
+### Review format
+
+Structure your review comment as:
+
+```markdown
+## [Experiment] Service Reference PR Review
+
+**PR:** #{number} ({title})
+**Service(s):** {service name(s)}
+**Review method:** Automated structural compliance check (experiment, issue #688)
+
+### Summary
+
+{1-2 sentence overall assessment}
+
+### Blocking Issues
+
+{List each blocking issue with:}
+- **What:** {description}
+- **Evidence:** {validation output or rule reference}
+- **Fix:** {specific fix recommendation}
+
+{Or: "None found."}
+
+### Warnings
+
+{List each warning with:}
+- **What:** {description}
+- **Suggestion:** {recommended improvement}
+
+{Or: "None found."}
+
+### Informational
+
+{List each info item, or "None."}
+
+### Validation Results
+
+- Script: {pass/fail + details}
+- Line count: {N}/100
+- First query line: {N}/45
+- Routing/catalog: {consistent/issues found}
+- Eval coverage: {covered/missing}
+
+> Note: This review covers structural compliance only. Pricing accuracy verification (API queries, billing model checks) is not performed by this workflow.
+```
+
+## Phase 5: Submit Review
+
+Post the compiled review as a PR comment using `add-comment`.
+
+Then submit a formal review:
+
+- If there are **blocking issues**: submit with `REQUEST_CHANGES` and body "Blocking issues found. See review comment for details."
+- If there are **warnings but no blocking issues**: submit with `COMMENT` and body "No blocking issues. See review comment for warnings."
+- If there are **no issues at all**: submit with `APPROVE` and body "Structural compliance verified. See review comment for details."

--- a/.github/workflows/service-ref-review.md
+++ b/.github/workflows/service-ref-review.md
@@ -8,14 +8,20 @@ on:
 engine: copilot
 permissions: read-all
 network:
-  allowed:
-    - github
+  firewall:
+    ssl-bump: true
+    allow-urls:
+      - "https://github.com/ahmadabdalla/azure-cost-calculator/*"
+      - "https://api.github.com/repos/ahmadabdalla/azure-cost-calculator/*"
 tools:
   bash: true
   github:
     toolsets:
       - pull_requests
       - issues
+    allowed-repos:
+      - "ahmadabdalla/azure-cost-calculator"
+    min-integrity: approved
 safe-outputs:
   add-comment:
     max: 1

--- a/.github/workflows/service-ref-review.md
+++ b/.github/workflows/service-ref-review.md
@@ -8,11 +8,8 @@ on:
 engine: copilot
 permissions: read-all
 network:
-  firewall:
-    ssl-bump: true
-    allow-urls:
-      - "https://github.com/ahmadabdalla/azure-cost-calculator/*"
-      - "https://api.github.com/repos/ahmadabdalla/azure-cost-calculator/*"
+  allowed:
+    - github
 tools:
   bash: true
   github:

--- a/.github/workflows/service-ref-review.md
+++ b/.github/workflows/service-ref-review.md
@@ -34,6 +34,8 @@ concurrency:
 You are a PR review agent for service reference changes in the Azure Cost Calculator skill repository. You review pull requests that create, update, or fix service reference files by checking structural compliance, running validation scripts, and verifying consistency with routing and catalog files.
 
 > **Experiment scope (issue #688):** This workflow only runs on PRs with the `experiment-pipeline` label. It is not part of the production review process.
+>
+> **Branch requirement:** This workflow must exist on the PR's base branch to trigger. Copilot coding agent PRs target `dev`, so this file must be synced to `dev` after merging to `main`.
 
 ## Safety Rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 prompts
 settings.local.json
 
+# Private operational notes (not for public repo)
+docs/ops/notes.md
+
 # Waza eval results and cache
 results/
 .waza-cache/


### PR DESCRIPTION
## Summary

Adds three experimental pipeline artifacts for automated service reference authoring, gated by an `experiment-pipeline` label. Nothing activates without the label; existing workflows are unaffected.

- **`issue-triage.md`**: adds `assign-to-agent` safe-output (Step 5) to assign Copilot coding agent on labeled `new-service` issues; triggers on both `opened` and `labeled` events
- **`promote-copilot-drafts.yml`**: scheduled workflow (every 2h) that marks idle Copilot draft PRs as ready and applies the experiment label
- **`service-ref-review.md`**: gh-aw structural compliance reviewer triggered by `experiment-pipeline` label on PRs

Security hardening applied: `allowed-repos` locks GitHub tools to this repo, `min-integrity: approved` on both gh-aw workflows, domain-level network restriction (`allowed: [github]`). URL path-level filtering (`allow-urls` with SSL bump) was attempted but removed due to AWF container limitation on current runners; documented in security notes for future revisit. See #688 for full threat model.

Requires `PIPELINE_GITHUB_TOKEN` secret (fine-grained PAT, this repo only, Issues + PRs write). Workflows no-op gracefully until configured.

Closes #688

## Test plan

- [ ] `gh aw compile` passes for both `.md` workflows (verified locally)
- [ ] Create `PIPELINE_GITHUB_TOKEN` with minimum permissions
- [ ] Open test issue with `experiment-pipeline` label, observe triage + agent assignment
- [ ] Verify promote workflow runs on schedule (or manual dispatch)
- [ ] Verify review workflow triggers on label application to a Copilot PR
- [ ] Confirm no impact on issues/PRs without the `experiment-pipeline` label

> **Note:** This PR targets `main` (not `dev`) because `issues` and `schedule` triggers only fire from the default branch. The label gate ensures zero impact until explicitly opted in. After merge, `dev` must be synced from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
