### PR TITLE
chore: remove experiment-pipeline label and fix review trigger idempotency

### DIFF
--- a/.github/workflows/issue-assign-v2.md
+++ b/.github/workflows/issue-assign-v2.md
@@ -50,15 +50,14 @@ Do not call any other tools. In particular, do not call `get_issue_comments`, `l
 These rules are absolute.
 
 1. **If** `copilot-swe-agent[bot]` is already in the issue's assignees list: do nothing and finish. The Copilot coding agent has already been assigned by a previous run.
-2. **Else if** the issue has **both** the `experiment-pipeline` label **and** the `new-service` label: call `assign_to_agent` to assign the Copilot coding agent. Do nothing else.
-3. **Else if** the issue has the `automatic-existing` label: call `assign_to_agent` to assign the Copilot coding agent. Do nothing else.
-4. **Otherwise**: do nothing and finish. Produce no tool calls and no outputs.
+2. **Else if** the issue has the `automatic-existing` label: call `assign_to_agent` to assign the Copilot coding agent. Do nothing else.
+3. **Otherwise**: do nothing and finish. Produce no tool calls and no outputs.
 
 Do not classify the issue. Do not add or remove labels. Do not post comments.
 
 ## Why these rules exist
 
 - The upstream Pipeline Issue Triage workflow classifies issues and applies labels on the `opened` event.
-- For new services: a maintainer opts a triaged issue into the pipeline by adding `experiment-pipeline`. Both `experiment-pipeline` and `new-service` must be present because this workflow fires on every `labeled` event.
-- For existing service fixes: the triage workflow applies `automatic-existing` directly, bypassing the manual opt-in step. Rule 3 handles this path.
+- For existing service fixes: the triage workflow applies `automatic-existing` directly, triggering automatic assignment. Rule 2 handles this path.
+- For new services: automatic assignment is intentionally disabled. The triage workflow applies `new-service` but no assignment follows. Enable by adding a rule: if `new-service` label is present, call `assign_to_agent`.
 - The idempotency guard prevents re-assigning if a label is re-added on an already-assigned issue.

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -86,6 +86,7 @@ jobs:
 
             # Idempotency: skip if a review trigger comment was already posted.
             EXISTING=$(gh api "repos/$REPO/issues/$NUMBER/comments" \
+              --paginate \
               --jq "[.[] | select(.body | contains(\"$TRIGGER_MARKER\"))] | length")
 
             if [ "$EXISTING" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Removes the `experiment-pipeline` manual opt-in from the assign workflow. New service issues are triaged and labelled `new-service` but no automatic assignment follows until the `automatic-existing` path is validated end-to-end.
- Adds `--paginate` to the idempotency guard in `trigger-copilot-review.yml` so PRs with more than 30 comments are not re-triggered.

## Re-enabling new-service automation

When ready, add one rule back to `issue-assign-v2.md`:

> Else if the issue has the `new-service` label: call `assign_to_agent`.

Then recompile with `gh aw compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)