### PR TITLE
chore: merge main into dev (trigger workflow fix #745)

### DIFF
--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -1,103 +1,182 @@
 name: "[Pipeline] Trigger Copilot Review"
 
 on:
-  schedule:
-    - cron: "0 */2 * * *" # every 2 hours
+  push:
+    branches: ["copilot/**"]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "copilot/** branch to trigger review on (e.g. copilot/fix-storage-ref)"
+        required: true
+        type: string
 
 permissions: {}
 
-concurrency:
-  group: trigger-copilot-review
-  cancel-in-progress: true
-
 jobs:
-  trigger:
-    name: Trigger review on idle Copilot drafts
+  # Fires on each Copilot push to a copilot/** branch. cancel-in-progress resets
+  # the quiet period on every new push; the comment is posted only after 15
+  # uninterrupted minutes, meaning Copilot has gone idle.
+  debounce:
+    name: Wait for Copilot to go idle then trigger review
+    # Skip pushes that include reviewer-agent remediation commits (identified by
+    # the marker in commit messages). These are zero-value triggers -- review is
+    # already done. The filter is a dependency: do not edit reviewer commit
+    # messages in a way that removes the substring 'service-ref-pr-reviewer'.
+    if: >
+      github.event_name == 'push' &&
+      github.actor == 'Copilot' &&
+      !contains(join(github.event.commits.*.message, ' '), 'service-ref-pr-reviewer')
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    concurrency:
+      group: copilot-quiet-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      BRANCH: ${{ github.ref_name }}
+      TRIGGER_MARKER: "service-ref-pr-reviewer"
     steps:
-      - name: Find and trigger review on idle drafts
-        env:
-          GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
+      - name: Wait for quiet period
+        # Each new Copilot push cancels the previous run via cancel-in-progress,
+        # resetting this timer. The comment is only posted after 15 uninterrupted
+        # minutes -- meaning Copilot has gone idle.
+        run: sleep 900
+
+      - name: Find Copilot draft PR for this branch
+        id: find-pr
         run: |
           set -euo pipefail
-
-          REPO="${{ github.repository }}"
-          IDLE_MINUTES=120  # 2 hours
-          TRIGGER_MARKER="service-ref-pr-reviewer"
-
-          echo "::group::Listing Copilot draft PRs"
-          DRAFT_PRS=$(gh pr list \
+          PR_NUMBER=$(gh pr list \
             --repo "$REPO" \
+            --head "$BRANCH" \
             --author "app/copilot-swe-agent" \
             --draft \
-            --json number,headRefName,updatedAt \
-            --jq '.')
-
-          COUNT=$(echo "$DRAFT_PRS" | jq 'length')
-          echo "Found $COUNT Copilot draft PR(s)"
-          echo "::endgroup::"
-
-          if [ "$COUNT" -eq 0 ]; then
-            echo "No Copilot draft PRs found. Nothing to do."
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No Copilot draft PR found for branch $BRANCH. Exiting."
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-          NOW=$(date -u +%s)
+      - name: Check idempotency
+        id: idempotency
+        if: steps.find-pr.outputs.found == 'true'
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # --paginate emits one JSON array per page; jq -s merges all pages
+          # before filtering so we get a single count, not one per page.
+          # --arg passes TRIGGER_MARKER safely without shell interpolation into jq source.
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            | jq -s --arg marker "$TRIGGER_MARKER" \
+                '[.[][] | select(.body | contains($marker))] | length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Review already triggered ($EXISTING existing comment(s) with marker). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-          echo "$DRAFT_PRS" | jq -c '.[]' | while read -r PR; do
-            NUMBER=$(echo "$PR" | jq -r '.number')
-            BRANCH=$(echo "$PR" | jq -r '.headRefName')
-            UPDATED=$(echo "$PR" | jq -r '.updatedAt')
+      - name: Post review trigger comment
+        if: steps.find-pr.outputs.found == 'true' && steps.idempotency.outputs.skip == 'false'
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Random jitter (0-29s) reduces the chance of a duplicate post if two
+          # debounce runs wake up within the same second after a near-simultaneous
+          # cancellation race.
+          sleep $((RANDOM % 30))
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO" \
+            --body "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
+          echo "Posted @copilot review trigger on PR #$PR_NUMBER"
 
-            echo "::group::PR #$NUMBER ($BRANCH)"
+  # Manual recovery path: accepts a branch name input, finds the PR, and posts
+  # the review comment without debounce sleep. Manual runs for the same branch
+  # are serialized to prevent duplicate-comment races.
+  manual-trigger:
+    name: Manually trigger review on a branch
+    if: github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: copilot-quiet-refs/heads/${{ inputs.branch }}
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      BRANCH: ${{ inputs.branch }}
+      TRIGGER_MARKER: "service-ref-pr-reviewer"
+    steps:
+      - name: Validate branch input
+        run: |
+          set -euo pipefail
+          if [[ ! "$BRANCH" =~ ^copilot/.+ ]]; then
+            echo "Branch '$BRANCH' does not match copilot/** pattern. Exiting."
+            exit 1
+          fi
+          if ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch '$BRANCH' is not a valid git branch name. Exiting."
+            exit 1
+          fi
 
-            # Check last commit time on the branch (more accurate than updatedAt)
-            LAST_COMMIT_DATE=$(gh api \
-              "repos/$REPO/commits?sha=$BRANCH&per_page=1" \
-              --jq '.[0].commit.committer.date' 2>/dev/null || true)
+      - name: Find Copilot draft PR for this branch
+        id: find-pr
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list \
+            --repo "$REPO" \
+            --head "$BRANCH" \
+            --author "app/copilot-swe-agent" \
+            --draft \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No Copilot draft PR found for branch $BRANCH. Exiting."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-            # Fall back to PR updatedAt if commit date is empty or null
-            if [ -z "$LAST_COMMIT_DATE" ] || [ "$LAST_COMMIT_DATE" = "null" ]; then
-              LAST_COMMIT_DATE="$UPDATED"
-            fi
+      - name: Check idempotency
+        id: idempotency
+        if: steps.find-pr.outputs.found == 'true'
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            | jq -s --arg marker "$TRIGGER_MARKER" \
+                '[.[][] | select(.body | contains($marker))] | length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Review already triggered ($EXISTING existing comment(s) with marker). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            # Ubuntu runner: GNU date with -d flag
-            LAST_EPOCH=$(date -u -d "$LAST_COMMIT_DATE" +%s)
-            IDLE_SECONDS=$(( NOW - LAST_EPOCH ))
-            IDLE_MINS=$(( IDLE_SECONDS / 60 ))
-
-            echo "Last activity: ${IDLE_MINS}m ago (threshold: ${IDLE_MINUTES}m)"
-
-            if [ "$IDLE_MINS" -lt "$IDLE_MINUTES" ]; then
-              echo "Still active. Skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # Idempotency: skip if a review trigger comment was already posted.
-            # --paginate emits one JSON array per page; jq -s merges all pages
-            # before filtering so we get a single count, not one per page.
-            EXISTING=$(gh api "repos/$REPO/issues/$NUMBER/comments" \
-              --paginate \
-              | jq -s "[.[][] | select(.body | contains(\"$TRIGGER_MARKER\"))] | length")
-
-            if [ "$EXISTING" -gt 0 ]; then
-              echo "Review already triggered (found $EXISTING existing comment(s) with marker). Skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            echo "Idle for ${IDLE_MINS}m. Triggering review..."
-
-            gh pr comment "$NUMBER" --repo "$REPO" --body \
-              "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
-
-            echo "Posted @copilot review trigger on PR #$NUMBER"
-            echo "::endgroup::"
-          done
-
-          echo "Done."
+      - name: Post review trigger comment
+        if: steps.find-pr.outputs.found == 'true' && steps.idempotency.outputs.skip == 'false'
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO" \
+            --body "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
+          echo "Posted @copilot review trigger on PR #$PR_NUMBER"

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -1,114 +1,125 @@
 name: "[Pipeline] Trigger Copilot Review"
 
 on:
-  push:
-    branches: ["copilot/**"]
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
+      dry_run:
+        description: "Run scheduled-idle-check logic without posting comments (for testing)"
+        required: false
+        type: boolean
+        default: false
       branch:
-        description: "copilot/** branch to trigger review on (e.g. copilot/fix-storage-ref)"
-        required: true
+        description: "copilot/** branch to trigger review on (manual-trigger only, ignored when dry_run=true)"
+        required: false
         type: string
 
 permissions: {}
 
 jobs:
-  # Fires on each Copilot push to a copilot/** branch. cancel-in-progress resets
-  # the quiet period on every new push; the comment is posted only after 15
-  # uninterrupted minutes, meaning Copilot has gone idle.
-  debounce:
-    name: Wait for Copilot to go idle then trigger review
-    # Skip pushes that include reviewer-agent remediation commits (identified by
-    # the marker in commit messages). These are zero-value triggers -- review is
-    # already done. The filter is a dependency: do not edit reviewer commit
-    # messages in a way that removes the substring 'service-ref-pr-reviewer'.
-    if: >
-      github.event_name == 'push' &&
-      github.actor == 'Copilot' &&
-      !contains(join(github.event.commits.*.message, ' '), 'service-ref-pr-reviewer')
+  # Fires every hour. Looks up which Copilot draft PRs are idle (no in_progress
+  # or queued Copilot cloud agent run on that branch) and posts the review trigger
+  # comment. Runs as github-actions[bot] -- never blocked by the first-time
+  # contributor approval gate that fires when the actor is app/copilot-swe-agent.
+  scheduled-idle-check:
+    name: Post review trigger on idle Copilot PRs
+    if: github.event_name == 'schedule' || inputs.dry_run == true
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 10
     concurrency:
-      group: copilot-quiet-${{ github.ref }}
-      cancel-in-progress: true
+      group: copilot-scheduled-idle-check
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
-      BRANCH: ${{ github.ref_name }}
       TRIGGER_MARKER: "service-ref-pr-reviewer"
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
-      - name: Wait for quiet period
-        # Each new Copilot push cancels the previous run via cancel-in-progress,
-        # resetting this timer. The comment is only posted after 15 uninterrupted
-        # minutes -- meaning Copilot has gone idle.
-        run: sleep 900
-
-      - name: Find Copilot draft PR for this branch
-        id: find-pr
+      - name: Get active Copilot branches
+        id: active-branches
         run: |
           set -euo pipefail
-          PR_NUMBER=$(gh pr list \
+          # Look up the Copilot cloud agent workflow ID by name -- no hardcode.
+          # --paginate without --jq emits one JSON object per page; jq -s slurps
+          # all pages before filtering so the select spans the full result set.
+          WORKFLOW_ID=$(gh api --paginate "repos/$REPO/actions/workflows" \
+            | jq -s '[.[].workflows[] | select(.name == "Copilot cloud agent") | .id] | first')
+          if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
+            echo "::error::Copilot cloud agent workflow not found. Cannot determine active branches -- refusing to post review triggers."
+            exit 1
+          fi
+          IN_PROGRESS=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs" \
+            --field status=in_progress \
+            --field per_page=100 \
+            --jq '[.workflow_runs[].head_branch]')
+          QUEUED=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs" \
+            --field status=queued \
+            --field per_page=100 \
+            --jq '[.workflow_runs[].head_branch]')
+          # Merge in_progress and queued into a single deduplicated JSON array.
+          # -c produces compact single-line JSON required for $GITHUB_OUTPUT key=value form.
+          ACTIVE_BRANCHES=$(jq -cn --argjson a "$IN_PROGRESS" --argjson b "$QUEUED" '$a + $b | unique')
+          echo "Active branches: $ACTIVE_BRANCHES"
+          echo "active_branches=$ACTIVE_BRANCHES" >> "$GITHUB_OUTPUT"
+
+      - name: Find and process idle Copilot draft PRs
+        env:
+          ACTIVE_BRANCHES: ${{ steps.active-branches.outputs.active_branches }}
+        run: |
+          set -euo pipefail
+          DRAFT_PRS=$(gh pr list \
             --repo "$REPO" \
-            --head "$BRANCH" \
             --author "app/copilot-swe-agent" \
             --draft \
-            --json number \
-            --jq '.[0].number // empty')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No Copilot draft PR found for branch $BRANCH. Exiting."
-            echo "found=false" >> "$GITHUB_OUTPUT"
+            --limit 100 \
+            --json number,headRefName)
+          PR_COUNT=$(echo "$DRAFT_PRS" | jq 'length')
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "No Copilot draft PRs found."
             exit 0
           fi
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-      - name: Check idempotency
-        id: idempotency
-        if: steps.find-pr.outputs.found == 'true'
-        env:
-          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: |
-          set -euo pipefail
-          # --paginate emits one JSON array per page; jq -s merges all pages
-          # before filtering so we get a single count, not one per page.
-          # --arg passes TRIGGER_MARKER safely without shell interpolation into jq source.
-          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --paginate \
-            | jq -s --arg marker "$TRIGGER_MARKER" \
-                '[.[][] | select(.body | contains($marker))] | length')
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "Review already triggered ($EXISTING existing comment(s) with marker). Skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Post review trigger comment
-        if: steps.find-pr.outputs.found == 'true' && steps.idempotency.outputs.skip == 'false'
-        env:
-          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-        run: |
-          set -euo pipefail
-          # Random jitter (0-29s) reduces the chance of a duplicate post if two
-          # debounce runs wake up within the same second after a near-simultaneous
-          # cancellation race.
-          sleep $((RANDOM % 30))
-          gh pr comment "$PR_NUMBER" \
-            --repo "$REPO" \
-            --body "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
-          echo "Posted @copilot review trigger on PR #$PR_NUMBER"
+          echo "Found $PR_COUNT Copilot draft PR(s)."
+          echo "$DRAFT_PRS" | jq -c '.[]' | while IFS= read -r pr; do
+            PR_NUMBER=$(echo "$pr" | jq -r '.number')
+            BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            # Skip if Copilot is still active on this branch.
+            IS_ACTIVE=$(echo "$ACTIVE_BRANCHES" | jq --arg b "$BRANCH" 'index($b) != null')
+            if [ "$IS_ACTIVE" = "true" ]; then
+              echo "PR #$PR_NUMBER ($BRANCH): Copilot is active. Skipping."
+              continue
+            fi
+            # --paginate emits one JSON array per page; jq -s merges all pages
+            # before filtering so we get a single count, not one per page.
+            EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --paginate \
+              | jq -s --arg marker "$TRIGGER_MARKER" \
+                  '[.[][] | select(.body | contains($marker))] | length')
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "PR #$PR_NUMBER ($BRANCH): review already triggered ($EXISTING comment(s)). Skipping."
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would post @copilot review trigger on PR #$PR_NUMBER ($BRANCH)."
+            else
+              gh pr comment "$PR_NUMBER" \
+                --repo "$REPO" \
+                --body "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
+              echo "Posted @copilot review trigger on PR #$PR_NUMBER ($BRANCH)."
+            fi
+          done
 
   # Manual recovery path: accepts a branch name input, finds the PR, and posts
-  # the review comment without debounce sleep. Manual runs for the same branch
-  # are serialized to prevent duplicate-comment races.
+  # the review comment without any sleep. Manual runs for the same branch are
+  # serialized to prevent duplicate-comment races.
   manual-trigger:
     name: Manually trigger review on a branch
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run != true
     concurrency:
-      group: copilot-quiet-refs/heads/${{ inputs.branch }}
+      group: copilot-manual-trigger-refs/heads/${{ inputs.branch }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -19,8 +19,10 @@ End-to-end pipeline that automates the lifecycle of service reference issues: fr
 [USER] Open [Service] issue with Type = Fix existing service
   -> [AUTO] Triage: applies pricing-inaccuracy + automatic-existing,
            assigns Copilot with service-reference agent (single run)
-  -> [AUTO] Copilot: creates draft PR on dev branch
-  -> [AUTO] Trigger (2h idle): posts @copilot review comment
+  -> [AUTO] Copilot: creates draft PR on dev branch, commits work
+  -> [AUTO] Trigger (push-triggered debounce): each Copilot push resets
+           a 15-minute timer; fires @copilot review comment after
+           15 minutes of silence (Copilot idle)
   -> [AUTO] Copilot: runs service-ref-pr-reviewer, validates against
            live Azure Retail Prices API, remediates if needed
   -> [USER] Review + merge
@@ -34,8 +36,10 @@ No manual intervention between issue creation and the finished draft PR with rev
 [USER] Open [Service] issue with Type = New service
   -> [AUTO] Triage: applies new-service + good first issue
   -> [USER] Manually assign Copilot with service-reference agent
-  -> [AUTO] Copilot: creates draft PR on dev branch
-  -> [AUTO] Trigger (2h idle): posts @copilot review comment
+  -> [AUTO] Copilot: creates draft PR on dev branch, commits work
+  -> [AUTO] Trigger (push-triggered debounce): each Copilot push resets
+           a 15-minute timer; fires @copilot review comment after
+           15 minutes of silence (Copilot idle)
   -> [AUTO] Copilot: runs service-ref-pr-reviewer, validates, remediates
   -> [USER] Review + merge
 ```
@@ -46,12 +50,12 @@ The manual step exists because new service issues may be claimed by contributors
 
 ## Pipeline artifacts
 
-| Artifact                     | Type            | Trigger                                    | Purpose                                                              |
-| ---------------------------- | --------------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| `issue-triage-v2.md`         | gh-aw (Copilot) | `issues: [opened]`                         | Classifies issues, applies labels, assigns Copilot for Fix existing  |
-| `trigger-copilot-review.yml` | Standard YAML   | `schedule: every 2h` + `workflow_dispatch` | Posts `@copilot` review comment on idle Copilot draft PRs            |
-| `service-reference.md`       | Custom agent    | Copilot assigned to issue                  | Multi-agent consensus workflow for authoring service reference files |
-| `service-ref-pr-reviewer.md` | Custom agent    | `@copilot` comment on PR                   | Dual-investigation review and remediation of service reference PRs   |
+| Artifact                     | Type            | Trigger                                                      | Purpose                                                              |
+| ---------------------------- | --------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `issue-triage-v2.md`         | gh-aw (Copilot) | `issues: [opened]`                                           | Classifies issues, applies labels, assigns Copilot for Fix existing  |
+| `trigger-copilot-review.yml` | Standard YAML   | `push: copilot/**` (debounce) + `workflow_dispatch` (manual) | Posts `@copilot` review comment after Copilot goes idle              |
+| `service-reference.md`       | Custom agent    | Copilot assigned to issue                                    | Multi-agent consensus workflow for authoring service reference files |
+| `service-ref-pr-reviewer.md` | Custom agent    | `@copilot` comment on PR                                     | Dual-investigation review and remediation of service reference PRs   |
 
 Supporting agents (invoked by the orchestrators, not directly):
 
@@ -112,25 +116,40 @@ The `assign-to-agent` safe-output passes three parameters to the Copilot coding 
 
 ## Trigger workflow details
 
-`.github/workflows/trigger-copilot-review.yml` runs on a 2-hour schedule. It:
+`.github/workflows/trigger-copilot-review.yml` has two jobs with separate trigger paths.
 
-1. Lists draft PRs authored by `app/copilot-swe-agent`.
-2. For each draft, checks the last commit timestamp.
-3. Skips PRs with activity in the last 2 hours (agent may still be working).
-4. Skips PRs that already have a review trigger comment (idempotency guard).
-5. Posts `@copilot trigger a review using the .github/agents/service-ref-pr-reviewer.md custom agent` via `PIPELINE_GITHUB_TOKEN`.
+### `debounce` job
+
+Triggered by `push` events to `copilot/**` branches. Only runs when the actor is `Copilot` (the GitHub Copilot coding agent) and none of the pushed commit messages contains `service-ref-pr-reviewer`.
+
+Uses `concurrency: cancel-in-progress: true` scoped to the branch ref as a debounce mechanism: each new Copilot push cancels the previous run and restarts the 15-minute quiet period. Once Copilot stops committing, the timer completes and the review comment is posted.
+
+Steps:
+1. Sleep 900 seconds (15-minute quiet period; resets on each new Copilot push via cancellation).
+2. Find the Copilot draft PR for this branch.
+3. Check idempotency (paginated comment scan for `service-ref-pr-reviewer`).
+4. Apply a short random jitter (0-29s) before posting, to reduce duplicate-post risk from near-simultaneous cancellation races.
+5. Post `@copilot` review comment via `PIPELINE_GITHUB_TOKEN`.
+
+`timeout-minutes: 25` bounds the job in case of a hung API call or runner issue.
+
+### `manual-trigger` job
+
+Triggered by `workflow_dispatch` only. Accepts a `branch` input (must match `copilot/**`) and posts the review comment without a debounce sleep once the run acquires its concurrency slot. Use this for manual recovery when the push path misses a PR (runner failure, skipped push event).
+
+```bash
+gh workflow run trigger-copilot-review.yml --field branch=copilot/fix-storage-ref
+```
+
+Steps: validate branch pattern and git ref format, find PR, check idempotency, post comment. `manual-trigger` uses the same per-branch concurrency group as `debounce` (`copilot-quiet-refs/heads/<branch>`) with `cancel-in-progress: false`, serializing runs on the same branch to avoid duplicate-comment races from cancellation timing.
+
+### Commit-message filter
+
+The job `if:` condition filters out pushes when any pushed commit message contains `service-ref-pr-reviewer` (`join(github.event.commits.*.message, ' ')`). The reviewer agent includes this string in its commit messages, so remediation pushes are zero-cost skips (no runner spun up, no 15-minute sleep). This is a dependency: do not edit the reviewer agent's commit messages in a way that removes this substring, or the filter will stop working and remediation pushes will spin runners.
 
 ### Idempotency
 
-The workflow checks all PR comments (paginated) for the string `service-ref-pr-reviewer`. If found, it skips the PR. This prevents duplicate review triggers on subsequent schedule runs.
-
-### Platform scheduling behavior
-
-GitHub Actions scheduled workflows have known timing variability:
-
-- Runs may be delayed by up to ~50 minutes from the cron time.
-- Runs can be skipped entirely during periods of high platform load.
-- `workflow_dispatch` is available for manual triggering if a scheduled run is missed.
+The job scans all PR comments (paginated, `jq -s` to merge pages) for the string `service-ref-pr-reviewer` before posting. If the string is found, the PR is skipped. The string appears in the comment body because the agent path contains it: `.github/agents/service-ref-pr-reviewer.md`. Do not edit the comment body in a way that removes this substring, or the idempotency check will break.
 
 ---
 
@@ -146,10 +165,12 @@ GitHub Actions scheduled workflows have known timing variability:
 
 ### Trigger workflow
 
-- No attacker-controlled input: processes only `app/copilot-swe-agent` PRs.
-- Comment body is hardcoded (not derived from PR content).
-- Job-level permissions: `contents: read`, `pull-requests: write`.
-- `PIPELINE_GITHUB_TOKEN` never touches user-supplied data.
+- `push` trigger is scoped to `copilot/**` branches. Forks cannot trigger upstream workflows; the residual risk is a collaborator-created branch named `copilot/*`, mitigated by the actor gate.
+- Actor gate (`github.actor == 'Copilot'`) on the `debounce` job prevents non-Copilot pushes from running the job.
+- All GitHub Actions context values (`github.repository`, `github.ref_name`) are passed through `env:` blocks and referenced as shell variables. No context values are interpolated directly into `run:` script bodies.
+- Comment body is hardcoded (not derived from PR content or branch name).
+- Workflow-level `permissions: {}` with write only scoped to the job that needs it (`pull-requests: write`).
+- No code checkout. The workflow only reads repo metadata and posts a comment. `workflow_dispatch.branch` is user input, but it is validated (`^copilot/.+` plus `git check-ref-format --branch`) and used as a quoted shell variable before `PIPELINE_GITHUB_TOKEN`-authorized calls.
 
 ### Custom agents
 
@@ -220,6 +241,9 @@ gh run list --workflow=issue-triage-v2.lock.yml --limit 10
 
 # Review trigger
 gh run list --workflow=trigger-copilot-review.yml --limit 10
+
+# Review trigger push-triggered runs only
+gh run list --workflow=trigger-copilot-review.yml --event push --limit 10
 ```
 
 ### Inspecting Copilot agent sessions
@@ -228,15 +252,17 @@ After Copilot is assigned to an issue, the session is visible in the GitHub UI u
 
 ### Common failure modes
 
-| Symptom                                             | Likely cause                                                    | Fix                                                                                                    |
-| --------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)          | Check agent job logs for which condition was not met                                                   |
-| Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions            | Rotate token (see above)                                                                               |
-| Copilot creates PR but no review trigger            | Trigger workflow schedule was skipped or delayed                | Run `gh workflow run trigger-copilot-review.yml` manually                                              |
-| Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                 |
-| Duplicate review trigger comments                   | Idempotency guard failed (pagination issue)                     | Check that `--paginate \| jq -s` pattern is intact in the workflow                                     |
-| MCP servers blocked by policy                       | Copilot CLI version mismatch                                    | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                      |
-| `markPullRequestReadyForReview` error               | Known platform restriction                                      | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts. |
+| Symptom                                             | Likely cause                                                                    | Fix                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)                          | Check agent job logs for which condition was not met                                                                  |
+| Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                            | Rotate token (see above)                                                                                              |
+| Copilot creates PR but no review trigger            | Actor gate evaluated false; commit-message filter matched; actor string changed | Check push event actor via `gh api repos/{owner}/{repo}/events`; check pushed commit messages for filter match         |
+| `debounce` job never runs despite Copilot push      | Actor is not `Copilot` or branch does not match `copilot/**`                    | Inspect the workflow run triggered by the push; check `github.actor` value in logs                                    |
+| Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account                 | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                |
+| Duplicate review trigger comments                   | Idempotency guard failed (pagination issue or comment body changed)             | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer` |
+| PR missed by push path (runner failure etc.)        | Transient runner or push event issue                                            | Run `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>` manually                               |
+| MCP servers blocked by policy                       | Copilot CLI version mismatch                                                    | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                                     |
+| `markPullRequestReadyForReview` error               | Known platform restriction                                                      | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts.                |
 
 ---
 
@@ -249,6 +275,18 @@ Labels applied by `github-actions[bot]` (via `GITHUB_TOKEN`) do not trigger down
 ### Why PRs stay as drafts
 
 The `markPullRequestReadyForReview` GraphQL mutation is blocked for both fine-grained PATs and `GITHUB_TOKEN`. There is no REST API alternative. Only user-level OAuth tokens (classic PATs with `repo` scope, which GitHub is deprecating) can call it. The pipeline works around this by triggering review via `@copilot` comment instead of requiring ready-for-review status.
+
+### Why push-triggered debounce instead of a schedule-only trigger
+
+The original scheduled trigger (every 2 hours) had a worst-case latency of ~5 hours: Copilot works for up to 1 hour, then a 2-hour idle threshold, then up to a 2-hour poll gap (plus platform scheduling variability). The primary contributor is the poll gap, not the idle threshold.
+
+The push-triggered approach eliminates the poll gap entirely. Each Copilot push fires an event, the `concurrency: cancel-in-progress: true` group cancels any in-flight run and resets the quiet period. After 15 minutes of silence (Copilot idle), the review comment posts. Worst case is now ~75 minutes (60-min Copilot work + 15-min quiet period).
+
+There is no scheduled fallback. `workflow_dispatch` is sufficient for manual recovery; push events are reliable and observable. Fewer trigger paths means less surface area to maintain.
+
+### Why the commit-message filter
+
+After the review comment is posted, the reviewer agent runs, produces findings, and commits fixes back to the branch. Each of those commits triggers a push event. Without the filter, remediation pushes would spin a runner, sleep 15 minutes, then exit (no-op, because the idempotency check would catch it). The commit-message filter eliminates that runner cost at the `if:` layer before any runner is allocated.
 
 ### Why @copilot comment instead of a gh-aw review workflow
 

--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -20,9 +20,8 @@ End-to-end pipeline that automates the lifecycle of service reference issues: fr
   -> [AUTO] Triage: applies pricing-inaccuracy + automatic-existing,
            assigns Copilot with service-reference agent (single run)
   -> [AUTO] Copilot: creates draft PR on dev branch, commits work
-  -> [AUTO] Trigger (push-triggered debounce): each Copilot push resets
-           a 15-minute timer; fires @copilot review comment after
-           15 minutes of silence (Copilot idle)
+  -> [AUTO] Trigger (hourly scheduled idle-check): fires @copilot review
+           comment when no Copilot cloud agent run is active on the branch
   -> [AUTO] Copilot: runs service-ref-pr-reviewer, validates against
            live Azure Retail Prices API, remediates if needed
   -> [USER] Review + merge
@@ -37,9 +36,8 @@ No manual intervention between issue creation and the finished draft PR with rev
   -> [AUTO] Triage: applies new-service + good first issue
   -> [USER] Manually assign Copilot with service-reference agent
   -> [AUTO] Copilot: creates draft PR on dev branch, commits work
-  -> [AUTO] Trigger (push-triggered debounce): each Copilot push resets
-           a 15-minute timer; fires @copilot review comment after
-           15 minutes of silence (Copilot idle)
+  -> [AUTO] Trigger (hourly scheduled idle-check): fires @copilot review
+           comment when no Copilot cloud agent run is active on the branch
   -> [AUTO] Copilot: runs service-ref-pr-reviewer, validates, remediates
   -> [USER] Review + merge
 ```
@@ -50,12 +48,12 @@ The manual step exists because new service issues may be claimed by contributors
 
 ## Pipeline artifacts
 
-| Artifact                     | Type            | Trigger                                                      | Purpose                                                              |
-| ---------------------------- | --------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
-| `issue-triage-v2.md`         | gh-aw (Copilot) | `issues: [opened]`                                           | Classifies issues, applies labels, assigns Copilot for Fix existing  |
-| `trigger-copilot-review.yml` | Standard YAML   | `push: copilot/**` (debounce) + `workflow_dispatch` (manual) | Posts `@copilot` review comment after Copilot goes idle              |
-| `service-reference.md`       | Custom agent    | Copilot assigned to issue                                    | Multi-agent consensus workflow for authoring service reference files |
-| `service-ref-pr-reviewer.md` | Custom agent    | `@copilot` comment on PR                                     | Dual-investigation review and remediation of service reference PRs   |
+| Artifact                     | Type            | Trigger                                           | Purpose                                                              |
+| ---------------------------- | --------------- | ------------------------------------------------- | -------------------------------------------------------------------- |
+| `issue-triage-v2.md`         | gh-aw (Copilot) | `issues: [opened]`                                | Classifies issues, applies labels, assigns Copilot for Fix existing  |
+| `trigger-copilot-review.yml` | Standard YAML   | `schedule: hourly` + `workflow_dispatch` (manual) | Posts `@copilot` review comment after Copilot goes idle              |
+| `service-reference.md`       | Custom agent    | Copilot assigned to issue                         | Multi-agent consensus workflow for authoring service reference files |
+| `service-ref-pr-reviewer.md` | Custom agent    | `@copilot` comment on PR                          | Dual-investigation review and remediation of service reference PRs   |
 
 Supporting agents (invoked by the orchestrators, not directly):
 
@@ -118,34 +116,35 @@ The `assign-to-agent` safe-output passes three parameters to the Copilot coding 
 
 `.github/workflows/trigger-copilot-review.yml` has two jobs with separate trigger paths.
 
-### `debounce` job
+### `scheduled-idle-check` job
 
-Triggered by `push` events to `copilot/**` branches. Only runs when the actor is `Copilot` (the GitHub Copilot coding agent) and none of the pushed commit messages contains `service-ref-pr-reviewer`.
-
-Uses `concurrency: cancel-in-progress: true` scoped to the branch ref as a debounce mechanism: each new Copilot push cancels the previous run and restarts the 15-minute quiet period. Once Copilot stops committing, the timer completes and the review comment is posted.
+Triggered by `schedule` (every hour on the hour) or by `workflow_dispatch` with `dry_run=true`. Runs as `github-actions[bot]`, which is never subject to the first-time contributor approval gate. The gate fires when the triggering actor is classified as a first-time contributor; GitHub Apps (`app/copilot-swe-agent`) are permanently in that class regardless of merged PRs.
 
 Steps:
-1. Sleep 900 seconds (15-minute quiet period; resets on each new Copilot push via cancellation).
-2. Find the Copilot draft PR for this branch.
-3. Check idempotency (paginated comment scan for `service-ref-pr-reviewer`).
-4. Apply a short random jitter (0-29s) before posting, to reduce duplicate-post risk from near-simultaneous cancellation races.
-5. Post `@copilot` review comment via `PIPELINE_GITHUB_TOKEN`.
+1. Look up the Copilot cloud agent workflow ID by name (`"Copilot cloud agent"`) via the Actions API. No hardcoded ID. Fails the job if the workflow is not found rather than silently treating all branches as idle.
+2. Query `in_progress` and `queued` runs for that workflow. Merge the two into a deduplicated set of active branch names.
+3. List all Copilot (`app/copilot-swe-agent`) draft PRs.
+4. For each draft PR, skip if the branch appears in the active set (Copilot still working).
+5. Check idempotency (paginated comment scan for `service-ref-pr-reviewer`). Skip if already triggered.
+6. Post `@copilot` review comment via `PIPELINE_GITHUB_TOKEN`.
 
-`timeout-minutes: 25` bounds the job in case of a hung API call or runner issue.
+`timeout-minutes: 10` bounds the job. A `concurrency` group with `cancel-in-progress: false` serializes overlapping runs (unlikely with a 1-hour interval, but safe).
+
+**Dry-run mode** (`dry_run=true`): runs the full idle-check logic (API calls, active-branch cross-reference, idempotency scan) but logs what it would do instead of posting comments. Use this to validate the logic after a code change without waiting for the next hourly tick and without posting real comments on open PRs.
+
+```bash
+gh workflow run trigger-copilot-review.yml --field dry_run=true
+```
 
 ### `manual-trigger` job
 
-Triggered by `workflow_dispatch` only. Accepts a `branch` input (must match `copilot/**`) and posts the review comment without a debounce sleep once the run acquires its concurrency slot. Use this for manual recovery when the push path misses a PR (runner failure, skipped push event).
+Triggered by `workflow_dispatch` only. Accepts a `branch` input (must match `copilot/**`) and posts the review comment immediately. Use this for manual recovery when the scheduled path has not yet fired or was skipped.
 
 ```bash
 gh workflow run trigger-copilot-review.yml --field branch=copilot/fix-storage-ref
 ```
 
-Steps: validate branch pattern and git ref format, find PR, check idempotency, post comment. `manual-trigger` uses the same per-branch concurrency group as `debounce` (`copilot-quiet-refs/heads/<branch>`) with `cancel-in-progress: false`, serializing runs on the same branch to avoid duplicate-comment races from cancellation timing.
-
-### Commit-message filter
-
-The job `if:` condition filters out pushes when any pushed commit message contains `service-ref-pr-reviewer` (`join(github.event.commits.*.message, ' ')`). The reviewer agent includes this string in its commit messages, so remediation pushes are zero-cost skips (no runner spun up, no 15-minute sleep). This is a dependency: do not edit the reviewer agent's commit messages in a way that removes this substring, or the filter will stop working and remediation pushes will spin runners.
+Steps: validate branch pattern and git ref format, find PR, check idempotency, post comment. Uses a per-branch concurrency group with `cancel-in-progress: false`, serializing runs on the same branch to avoid duplicate-comment races.
 
 ### Idempotency
 
@@ -165,12 +164,12 @@ The job scans all PR comments (paginated, `jq -s` to merge pages) for the string
 
 ### Trigger workflow
 
-- `push` trigger is scoped to `copilot/**` branches. Forks cannot trigger upstream workflows; the residual risk is a collaborator-created branch named `copilot/*`, mitigated by the actor gate.
-- Actor gate (`github.actor == 'Copilot'`) on the `debounce` job prevents non-Copilot pushes from running the job.
-- All GitHub Actions context values (`github.repository`, `github.ref_name`) are passed through `env:` blocks and referenced as shell variables. No context values are interpolated directly into `run:` script bodies.
+- `schedule` trigger runs as `github-actions[bot]`. No actor-based approval gate applies.
+- All GitHub Actions context values (`github.repository`) are passed through `env:` blocks and referenced as shell variables. No context values are interpolated directly into `run:` script bodies.
 - Comment body is hardcoded (not derived from PR content or branch name).
 - Workflow-level `permissions: {}` with write only scoped to the job that needs it (`pull-requests: write`).
-- No code checkout. The workflow only reads repo metadata and posts a comment. `workflow_dispatch.branch` is user input, but it is validated (`^copilot/.+` plus `git check-ref-format --branch`) and used as a quoted shell variable before `PIPELINE_GITHUB_TOKEN`-authorized calls.
+- No code checkout. The workflow only reads repo metadata via the GitHub API and posts a comment.
+- `workflow_dispatch.branch` is user input, validated (`^copilot/.+` plus `git check-ref-format --branch`) and used as a quoted shell variable before any `PIPELINE_GITHUB_TOKEN`-authorized calls.
 
 ### Custom agents
 
@@ -242,8 +241,8 @@ gh run list --workflow=issue-triage-v2.lock.yml --limit 10
 # Review trigger
 gh run list --workflow=trigger-copilot-review.yml --limit 10
 
-# Review trigger push-triggered runs only
-gh run list --workflow=trigger-copilot-review.yml --event push --limit 10
+# Review trigger scheduled runs only
+gh run list --workflow=trigger-copilot-review.yml --event schedule --limit 10
 ```
 
 ### Inspecting Copilot agent sessions
@@ -252,17 +251,16 @@ After Copilot is assigned to an issue, the session is visible in the GitHub UI u
 
 ### Common failure modes
 
-| Symptom                                             | Likely cause                                                                    | Fix                                                                                                                   |
-| --------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)                          | Check agent job logs for which condition was not met                                                                  |
-| Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                            | Rotate token (see above)                                                                                              |
-| Copilot creates PR but no review trigger            | Actor gate evaluated false; commit-message filter matched; actor string changed | Check push event actor via `gh api repos/{owner}/{repo}/events`; check pushed commit messages for filter match         |
-| `debounce` job never runs despite Copilot push      | Actor is not `Copilot` or branch does not match `copilot/**`                    | Inspect the workflow run triggered by the push; check `github.actor` value in logs                                    |
-| Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account                 | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                |
-| Duplicate review trigger comments                   | Idempotency guard failed (pagination issue or comment body changed)             | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer` |
-| PR missed by push path (runner failure etc.)        | Transient runner or push event issue                                            | Run `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>` manually                               |
-| MCP servers blocked by policy                       | Copilot CLI version mismatch                                                    | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                                     |
-| `markPullRequestReadyForReview` error               | Known platform restriction                                                      | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts.                |
+| Symptom                                             | Likely cause                                                                                       | Fix                                                                                                                                             |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)                                             | Check agent job logs for which condition was not met                                                                                            |
+| Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                                               | Rotate token (see above)                                                                                                                        |
+| Copilot creates PR but no review trigger            | Scheduled run has not fired yet; Copilot still active on branch; idempotency guard already matched | Wait up to 1hr for the next scheduled run; check `gh run list --workflow=trigger-copilot-review.yml`; use manual trigger for immediate recovery |
+| Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account                                    | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                                          |
+| Duplicate review trigger comments                   | Idempotency guard failed (pagination issue or comment body changed)                                | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer`                           |
+| PR missed by scheduled run (tick delayed or skipped) | Copilot reported active at tick time; platform scheduling delay                                   | Wait for next hourly tick; use manual trigger: `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>`                       |
+| MCP servers blocked by policy                       | Copilot CLI version mismatch                                                                       | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                                                               |
+| `markPullRequestReadyForReview` error               | Known platform restriction                                                                         | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts.                                          |
 
 ---
 
@@ -276,17 +274,11 @@ Labels applied by `github-actions[bot]` (via `GITHUB_TOKEN`) do not trigger down
 
 The `markPullRequestReadyForReview` GraphQL mutation is blocked for both fine-grained PATs and `GITHUB_TOKEN`. There is no REST API alternative. Only user-level OAuth tokens (classic PATs with `repo` scope, which GitHub is deprecating) can call it. The pipeline works around this by triggering review via `@copilot` comment instead of requiring ready-for-review status.
 
-### Why push-triggered debounce instead of a schedule-only trigger
+### Why scheduled idle-check instead of push-triggered debounce
 
-The original scheduled trigger (every 2 hours) had a worst-case latency of ~5 hours: Copilot works for up to 1 hour, then a 2-hour idle threshold, then up to a 2-hour poll gap (plus platform scheduling variability). The primary contributor is the poll gap, not the idle threshold.
+Push-triggered workflows with `github.actor == 'Copilot'` (i.e. `app/copilot-swe-agent` as the triggering actor) are blocked by GitHub's first-time contributor approval gate. GitHub Apps are permanently classified as first-time contributors regardless of merged PRs. Changing the trigger type (push, pull_request, workflow_run) does not help: the gate is on the actor, not the event. Only triggers whose actor is `github-actions[bot]` -- schedule and repository_dispatch -- bypass the gate.
 
-The push-triggered approach eliminates the poll gap entirely. Each Copilot push fires an event, the `concurrency: cancel-in-progress: true` group cancels any in-flight run and resets the quiet period. After 15 minutes of silence (Copilot idle), the review comment posts. Worst case is now ~75 minutes (60-min Copilot work + 15-min quiet period).
-
-There is no scheduled fallback. `workflow_dispatch` is sufficient for manual recovery; push events are reliable and observable. Fewer trigger paths means less surface area to maintain.
-
-### Why the commit-message filter
-
-After the review comment is posted, the reviewer agent runs, produces findings, and commits fixes back to the branch. Each of those commits triggers a push event. Without the filter, remediation pushes would spin a runner, sleep 15 minutes, then exit (no-op, because the idempotency check would catch it). The commit-message filter eliminates that runner cost at the `if:` layer before any runner is allocated.
+The scheduled approach queries the Copilot cloud agent workflow API directly to detect whether Copilot is still active on a branch (`in_progress` or `queued` runs). This gives an accurate idle signal without relying on a timer proxy. Worst-case latency is up to 1 hour (next scheduled tick after Copilot goes idle), which is acceptable for this pipeline.
 
 ### Why @copilot comment instead of a gh-aw review workflow
 


### PR DESCRIPTION
Brings the trigger workflow fix from #747 forward onto \`dev\`.

Both branches diverged from the same ancestor on two files; conflicts resolved by taking \`main\`'s version:

- \`.github/workflows/trigger-copilot-review.yml\`: replaces the broken push-triggered debounce with the scheduled idle-check
- \`docs/ops/automated-pipeline.md\`: updated ops guide reflecting the new design

No other files are affected. The six \`dev\`-only changes (service refs, evals) merge cleanly.