### PR TITLE
fix: Actions API reads in scheduled-idle-check

### DIFF
--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -49,6 +49,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          echo "=== Diagnostic: token length=${#GH_TOKEN}, GITHUB_TOKEN length=${#GITHUB_TOKEN}"
+          echo "=== Diagnostic: testing workflow list endpoint..."
+          gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>&1 || true
+          echo "=== Diagnostic: done"
           # Look up the Copilot cloud agent workflow ID by name -- no hardcode.
           # --paginate without --jq emits one JSON object per page; jq -s slurps
           # all pages before filtering so the select spans the full result set.

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -32,13 +32,12 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: read
-      pull-requests: write
       actions: read
     env:
       GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       TRIGGER_MARKER: "service-ref-pr-reviewer"
-      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Get active Copilot branches
         id: active-branches
@@ -60,10 +59,12 @@ jobs:
           fi
           # Use inline query params (not --field) -- --field sends a POST request,
           # which returns 404 on this GET-only endpoint.
-          IN_PROGRESS=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=in_progress&per_page=100" \
-            --jq '[.workflow_runs[].head_branch]')
-          QUEUED=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=queued&per_page=100" \
-            --jq '[.workflow_runs[].head_branch]')
+          # --paginate without --jq emits one JSON object per page; jq -s slurps
+          # all pages so no active runs are missed.
+          IN_PROGRESS=$(gh api --paginate "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=in_progress&per_page=100" \
+            | jq -s '[.[].workflow_runs[].head_branch]')
+          QUEUED=$(gh api --paginate "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=queued&per_page=100" \
+            | jq -s '[.[].workflow_runs[].head_branch]')
           # Merge in_progress and queued into a single deduplicated JSON array.
           # -c produces compact single-line JSON required for $GITHUB_OUTPUT key=value form.
           ACTIVE_BRANCHES=$(jq -cn --argjson a "$IN_PROGRESS" --argjson b "$QUEUED" '$a + $b | unique')
@@ -87,7 +88,10 @@ jobs:
             exit 0
           fi
           echo "Found $PR_COUNT Copilot draft PR(s)."
-          echo "$DRAFT_PRS" | jq -c '.[]' | while IFS= read -r pr; do
+          # Process substitution keeps the while loop in the parent shell so
+          # set -e applies to every command in the body and per-PR failures
+          # are not silently swallowed by a pipe subshell exit code.
+          while IFS= read -r pr; do
             PR_NUMBER=$(echo "$pr" | jq -r '.number')
             BRANCH=$(echo "$pr" | jq -r '.headRefName')
             # Skip if Copilot is still active on this branch.
@@ -114,7 +118,7 @@ jobs:
                 --body "@copilot trigger a review using the \`.github/agents/service-ref-pr-reviewer.md\` custom agent. Validate recommendations and remediate if necessary."
               echo "Posted @copilot review trigger on PR #$PR_NUMBER ($BRANCH)."
             fi
-          done
+          done < <(echo "$DRAFT_PRS" | jq -c '.[]')
 
   # Manual recovery path: accepts a branch name input, finds the PR, and posts
   # the review comment without any sleep. Manual runs for the same branch are
@@ -129,7 +133,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       REPO: ${{ github.repository }}

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -49,14 +49,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          echo "=== Diagnostic: testing workflow list endpoint..."
+          echo "=== Diagnostic: testing workflow list (no paginate)..."
           gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>&1 || true
-          echo "=== Diagnostic: done"
+          echo "=== Diagnostic: testing workflow list (--paginate)..."
+          gh api --paginate "repos/$REPO/actions/workflows" | jq -s '.[0].total_count' 2>&1 || true
           # Look up the Copilot cloud agent workflow ID by name -- no hardcode.
           # --paginate without --jq emits one JSON object per page; jq -s slurps
           # all pages before filtering so the select spans the full result set.
           WORKFLOW_ID=$(gh api --paginate "repos/$REPO/actions/workflows" \
             | jq -s '[.[].workflows[] | select(.name == "Copilot cloud agent") | .id] | first')
+          echo "=== Diagnostic: WORKFLOW_ID=${WORKFLOW_ID}"
+          echo "=== Diagnostic: testing runs endpoint (inline params)..."
+          gh api "repos/$REPO/actions/workflows/${WORKFLOW_ID}/runs?status=in_progress&per_page=1" --jq '.total_count' 2>&1 || true
+          echo "=== Diagnostic: testing runs endpoint (--field params)..."
+          gh api "repos/$REPO/actions/workflows/${WORKFLOW_ID}/runs" --field status=in_progress --field per_page=1 --jq '.total_count' 2>&1 || true
+          echo "=== Diagnostic: done"
           if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
             echo "::error::Copilot cloud agent workflow not found. Cannot determine active branches -- refusing to post review triggers."
             exit 1

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: read
     env:
       GH_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
@@ -41,6 +42,11 @@ jobs:
     steps:
       - name: Get active Copilot branches
         id: active-branches
+        # Actions API reads require actions:read. Use github.token (which has it
+        # via the job permissions block) rather than PIPELINE_GITHUB_TOKEN (which
+        # only has Issues:write and Pull Requests:write).
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # Look up the Copilot cloud agent workflow ID by name -- no hardcode.

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -49,32 +49,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          echo "=== Diagnostic: testing workflow list (no paginate)..."
-          gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>&1 || true
-          echo "=== Diagnostic: testing workflow list (--paginate)..."
-          gh api --paginate "repos/$REPO/actions/workflows" | jq -s '.[0].total_count' 2>&1 || true
           # Look up the Copilot cloud agent workflow ID by name -- no hardcode.
           # --paginate without --jq emits one JSON object per page; jq -s slurps
           # all pages before filtering so the select spans the full result set.
           WORKFLOW_ID=$(gh api --paginate "repos/$REPO/actions/workflows" \
             | jq -s '[.[].workflows[] | select(.name == "Copilot cloud agent") | .id] | first')
-          echo "=== Diagnostic: WORKFLOW_ID=${WORKFLOW_ID}"
-          echo "=== Diagnostic: testing runs endpoint (inline params)..."
-          gh api "repos/$REPO/actions/workflows/${WORKFLOW_ID}/runs?status=in_progress&per_page=1" --jq '.total_count' 2>&1 || true
-          echo "=== Diagnostic: testing runs endpoint (--field params)..."
-          gh api "repos/$REPO/actions/workflows/${WORKFLOW_ID}/runs" --field status=in_progress --field per_page=1 --jq '.total_count' 2>&1 || true
-          echo "=== Diagnostic: done"
           if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
             echo "::error::Copilot cloud agent workflow not found. Cannot determine active branches -- refusing to post review triggers."
             exit 1
           fi
-          IN_PROGRESS=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs" \
-            --field status=in_progress \
-            --field per_page=100 \
+          # Use inline query params (not --field) -- --field sends a POST request,
+          # which returns 404 on this GET-only endpoint.
+          IN_PROGRESS=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=in_progress&per_page=100" \
             --jq '[.workflow_runs[].head_branch]')
-          QUEUED=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs" \
-            --field status=queued \
-            --field per_page=100 \
+          QUEUED=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_ID/runs?status=queued&per_page=100" \
             --jq '[.workflow_runs[].head_branch]')
           # Merge in_progress and queued into a single deduplicated JSON array.
           # -c produces compact single-line JSON required for $GITHUB_OUTPUT key=value form.

--- a/.github/workflows/trigger-copilot-review.yml
+++ b/.github/workflows/trigger-copilot-review.yml
@@ -49,7 +49,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          echo "=== Diagnostic: token length=${#GH_TOKEN}, GITHUB_TOKEN length=${#GITHUB_TOKEN}"
           echo "=== Diagnostic: testing workflow list endpoint..."
           gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>&1 || true
           echo "=== Diagnostic: done"


### PR DESCRIPTION
## Summary

- `PIPELINE_GITHUB_TOKEN` only has `Issues:write` and `Pull Requests:write`. Fine-grained PATs require explicit `Actions:read` to call `/actions/workflows` -- without it the API returns 404, which is what the dry-run exposed.
- Adds `actions: read` to the `scheduled-idle-check` job permissions so `github.token` has the required scope.
- Overrides `GH_TOKEN` to `github.token` in the "Get active Copilot branches" step. `PIPELINE_GITHUB_TOKEN` stays in place for the PR comment post (required: `github-actions[bot]` comments do not trigger the Copilot coding agent).

Closes #745

## Test plan

- [ ] Merge to `main`
- [ ] Run `workflow_dispatch` with `dry_run=true`: confirm "Get active Copilot branches" step succeeds and the workflow ID is resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve reliability and security practices in automated review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->