### PR TITLE
docs: update automated-pipeline ops guide post PR #749

### DIFF
--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -282,8 +282,6 @@ Push-triggered workflows with `github.actor == 'Copilot'` (i.e. `app/copilot-swe
 
 The scheduled approach queries the Copilot cloud agent workflow API directly to detect whether Copilot is still active on a branch (`in_progress` or `queued` runs). This gives an accurate idle signal without relying on a timer proxy. Worst-case latency is up to 1 hour (next scheduled tick after Copilot goes idle), which is acceptable for this pipeline.
 
-The full discovery trail for this decision, including the push-triggered regression and intermediate attempts, is tracked in issue #732.
-
 ### Why @copilot comment instead of a gh-aw review workflow
 
 The Copilot coding agent triggered via `@copilot` comment can both review and remediate (commit fixes to the branch). A gh-aw review workflow is read-only with writes limited to safe-outputs (comments and reviews). The `@copilot` approach provides a more complete automated loop.

--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -128,6 +128,8 @@ Steps:
 5. Check idempotency (paginated comment scan for `service-ref-pr-reviewer`). Skip if already triggered.
 6. Post `@copilot` review comment via `PIPELINE_GITHUB_TOKEN`.
 
+Steps 1-2 use `github.token` (overridden at the step level), not `PIPELINE_GITHUB_TOKEN`. The Actions API requires `actions: read`; `PIPELINE_GITHUB_TOKEN` only carries Issues/PRs write. `PIPELINE_GITHUB_TOKEN` is used only in step 6, where the comment must be attributed to a user account to activate the coding agent.
+
 `timeout-minutes: 10` bounds the job. A `concurrency` group with `cancel-in-progress: false` serializes overlapping runs (unlikely with a 1-hour interval, but safe).
 
 **Dry-run mode** (`dry_run=true`): runs the full idle-check logic (API calls, active-branch cross-reference, idempotency scan) but logs what it would do instead of posting comments. Use this to validate the logic after a code change without waiting for the next hourly tick and without posting real comments on open PRs.
@@ -167,7 +169,7 @@ The job scans all PR comments (paginated, `jq -s` to merge pages) for the string
 - `schedule` trigger runs as `github-actions[bot]`. No actor-based approval gate applies.
 - All GitHub Actions context values (`github.repository`) are passed through `env:` blocks and referenced as shell variables. No context values are interpolated directly into `run:` script bodies.
 - Comment body is hardcoded (not derived from PR content or branch name).
-- Workflow-level `permissions: {}` with write only scoped to the job that needs it (`pull-requests: write`).
+- Workflow-level `permissions: {}`. `scheduled-idle-check` holds `contents: read` and `actions: read` only. `manual-trigger` holds `contents: read` only. Neither job holds `pull-requests: write` on `github.token`; all PR writes go through `PIPELINE_GITHUB_TOKEN`.
 - No code checkout. The workflow only reads repo metadata via the GitHub API and posts a comment.
 - `workflow_dispatch.branch` is user input, validated (`^copilot/.+` plus `git check-ref-format --branch`) and used as a quoted shell variable before any `PIPELINE_GITHUB_TOKEN`-authorized calls.
 
@@ -255,7 +257,7 @@ After Copilot is assigned to an issue, the session is visible in the GitHub UI u
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)                                             | Check agent job logs for which condition was not met                                                                                            |
 | Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                                               | Rotate token (see above)                                                                                                                        |
-| Copilot creates PR but no review trigger            | Scheduled run has not fired yet; Copilot still active on branch; idempotency guard already matched | Wait up to 1hr for the next scheduled run; check `gh run list --workflow=trigger-copilot-review.yml`; use manual trigger for immediate recovery |
+| Copilot creates PR but no review trigger            | Scheduled run has not fired yet; Copilot still active on branch; idempotency guard already matched | Wait up to 1hr for the next scheduled run; check `gh run list --workflow=trigger-copilot-review.yml`; use manual trigger for immediate recovery; run `gh workflow run trigger-copilot-review.yml --field dry_run=true` to validate idle-check logic without posting comments |
 | Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account                                    | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                                          |
 | Duplicate review trigger comments                   | Idempotency guard failed (pagination issue or comment body changed)                                | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer`                           |
 | PR missed by scheduled run (tick delayed or skipped) | Copilot reported active at tick time; platform scheduling delay                                   | Wait for next hourly tick; use manual trigger: `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>`                       |
@@ -279,6 +281,8 @@ The `markPullRequestReadyForReview` GraphQL mutation is blocked for both fine-gr
 Push-triggered workflows with `github.actor == 'Copilot'` (i.e. `app/copilot-swe-agent` as the triggering actor) are blocked by GitHub's first-time contributor approval gate. GitHub Apps are permanently classified as first-time contributors regardless of merged PRs. Changing the trigger type (push, pull_request, workflow_run) does not help: the gate is on the actor, not the event. Only triggers whose actor is `github-actions[bot]` -- schedule and repository_dispatch -- bypass the gate.
 
 The scheduled approach queries the Copilot cloud agent workflow API directly to detect whether Copilot is still active on a branch (`in_progress` or `queued` runs). This gives an accurate idle signal without relying on a timer proxy. Worst-case latency is up to 1 hour (next scheduled tick after Copilot goes idle), which is acceptable for this pipeline.
+
+The full discovery trail for this decision, including the push-triggered regression and intermediate attempts, is tracked in issue #732.
 
 ### Why @copilot comment instead of a gh-aw review workflow
 


### PR DESCRIPTION
## Summary

- Fixes stale permissions claim in security model section (`pull-requests: write` was removed in PR #749; correct scopes are `contents: read` + `actions: read` on `scheduled-idle-check`, `contents: read` on `manual-trigger`)
- Documents the intra-job token split in trigger workflow details: `github.token` is used for Actions API reads (steps 1-2), `PIPELINE_GITHUB_TOKEN` only for the comment (step 6)
- Adds a reference to issue #732 in the design decisions section as the discovery trail for the scheduled idle-check approach
- Adds the dry-run command to the troubleshooting table row for the no-review-trigger failure mode

## Test plan

- [ ] Doc-only change; no runtime behavior affected
- [ ] Verify permissions table matches current `trigger-copilot-review.yml` job blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure API Management documentation to clarify v2 pricing behavior and add workspace gateway tier details.
  * Enhanced Service Bus documentation with expanded billing model including base hourly charges and tiered operations/connections.
  * Added clarification that NAT Gateway pricing is global-only (USD pricing, region-specific queries return zero).

* **Tests**
  * Added evaluation tests for API Management Standard v2 units.
  * Added evaluation tests for Service Bus Standard namespace billing.
  * Added evaluation tests for NAT Gateway data processing costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->