### PR TITLE
docs: add experiment sections to ops guides

### DIFF
--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -251,16 +251,16 @@ After Copilot is assigned to an issue, the session is visible in the GitHub UI u
 
 ### Common failure modes
 
-| Symptom                                             | Likely cause                                                                                       | Fix                                                                                                                                             |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Triage runs but Copilot not assigned                | Agent verification failed (title, Type, or file check)                                             | Check agent job logs for which condition was not met                                                                                            |
-| Copilot assigned but no session starts              | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                                               | Rotate token (see above)                                                                                                                        |
-| Copilot creates PR but no review trigger            | Scheduled run has not fired yet; Copilot still active on branch; idempotency guard already matched | Wait up to 1hr for the next scheduled run; check `gh run list --workflow=trigger-copilot-review.yml`; use manual trigger for immediate recovery |
-| Review trigger posts comment but Copilot ignores it | Comment posted by `github-actions[bot]` instead of user account                                    | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                                          |
-| Duplicate review trigger comments                   | Idempotency guard failed (pagination issue or comment body changed)                                | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer`                           |
-| PR missed by scheduled run (tick delayed or skipped) | Copilot reported active at tick time; platform scheduling delay                                   | Wait for next hourly tick; use manual trigger: `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>`                       |
-| MCP servers blocked by policy                       | Copilot CLI version mismatch                                                                       | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                                                               |
-| `markPullRequestReadyForReview` error               | Known platform restriction                                                                         | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts.                                          |
+| Symptom                                              | Likely cause                                                                                       | Fix                                                                                                                                             |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Triage runs but Copilot not assigned                 | Agent verification failed (title, Type, or file check)                                             | Check agent job logs for which condition was not met                                                                                            |
+| Copilot assigned but no session starts               | `PIPELINE_GITHUB_TOKEN` expired or lacks permissions                                               | Rotate token (see above)                                                                                                                        |
+| Copilot creates PR but no review trigger             | Scheduled run has not fired yet; Copilot still active on branch; idempotency guard already matched | Wait up to 1hr for the next scheduled run; check `gh run list --workflow=trigger-copilot-review.yml`; use manual trigger for immediate recovery |
+| Review trigger posts comment but Copilot ignores it  | Comment posted by `github-actions[bot]` instead of user account                                    | Verify `PIPELINE_GITHUB_TOKEN` is a user-owned PAT, not `GITHUB_TOKEN`                                                                          |
+| Duplicate review trigger comments                    | Idempotency guard failed (pagination issue or comment body changed)                                | Check that `--paginate \| jq -s` pattern is intact and that the comment body still contains `service-ref-pr-reviewer`                           |
+| PR missed by scheduled run (tick delayed or skipped) | Copilot reported active at tick time; platform scheduling delay                                    | Wait for next hourly tick; use manual trigger: `gh workflow run trigger-copilot-review.yml --field branch=copilot/<name>`                       |
+| MCP servers blocked by policy                        | Copilot CLI version mismatch                                                                       | Recompile with latest gh-aw: `gh extension upgrade github/gh-aw && gh aw compile`                                                               |
+| `markPullRequestReadyForReview` error                | Known platform restriction                                                                         | This mutation is blocked for all non-OAuth tokens. The pipeline does not use it; PRs remain as drafts.                                          |
 
 ---
 
@@ -283,6 +283,16 @@ The scheduled approach queries the Copilot cloud agent workflow API directly to 
 ### Why @copilot comment instead of a gh-aw review workflow
 
 The Copilot coding agent triggered via `@copilot` comment can both review and remediate (commit fixes to the branch). A gh-aw review workflow is read-only with writes limited to safe-outputs (comments and reviews). The `@copilot` approach provides a more complete automated loop.
+
+---
+
+## Experiments
+
+Historical record of research, experiments, and design decisions. Issues and PRs are linked for full context.
+
+| Issue                                                                                                                                                        | PR                                                                     | Status | Summary                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#732: Improve PR review automation: second-pass nudge and CodeRabbit trigger diagnostics](https://github.com/ahmadabdalla/azure-cost-calculator/issues/732) | [#749](https://github.com/ahmadabdalla/azure-cost-calculator/pull/749) | Merged | Investigated push-triggered debounce, hit approval-gate regression; replaced with API-backed scheduled idle-check that queries Copilot cloud agent runs directly. Validated end-to-end on #752. |
 
 ---
 

--- a/docs/ops/evals.md
+++ b/docs/ops/evals.md
@@ -2,15 +2,16 @@
 
 Automated evaluation of the Azure Cost Calculator skill using [Waza](https://github.com/microsoft/waza), a CLI for benchmarking AI agent skills. Validates behavior that deterministic tests (Pester, bats, YAML validation) cannot cover: prompt handling, disambiguation, service routing, and trigger specificity.
 
-| Item             | Detail                                                                                                                 |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Waza version     | `v0.23.0` — see "Upgrading Waza" in Known limitations for all files that must change on version bump                   |
-| Workflow         | `.github/workflows/eval.yml`                                                                                           |
-| Composite action | `.github/actions/install-waza/action.yml`                                                                              |
-| Eval suite       | `tests/evals/azure-cost-calculator/eval.yaml` (copilot-sdk), `tests/evals/azure-cost-calculator/eval-mock.yaml` (mock) |
-| Task files       | `tests/evals/azure-cost-calculator/tasks/*/*.yaml` and `tests/evals/azure-cost-calculator/tasks/*/*/*.yaml`            |
-| Project config   | `.waza.yaml`                                                                                                           |
-| Auth secret      | `COPILOT_GITHUB_TOKEN` (fine-grained PAT, "Copilot Requests" permission)                                               |
+| Item             | Detail                                                                                                                                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Waza version     | `v0.23.0` — see "Upgrading Waza" in Known limitations for all files that must change on version bump                                                                                                        |
+| Workflow         | `.github/workflows/eval.yml`                                                                                                                                                                                |
+| Composite action | `.github/actions/install-waza/action.yml`                                                                                                                                                                   |
+| Eval suite       | `tests/evals/azure-cost-calculator/eval.yaml` (copilot-sdk), `tests/evals/azure-cost-calculator/eval-mock.yaml` (mock)                                                                                      |
+| Task files       | `tests/evals/azure-cost-calculator/tasks/*/*.yaml` and `tests/evals/azure-cost-calculator/tasks/*/*/*.yaml`                                                                                                 |
+| Project config   | `.waza.yaml`                                                                                                                                                                                                |
+| Auth secret      | `COPILOT_GITHUB_TOKEN` (fine-grained PAT, "Copilot Requests" permission)                                                                                                                                    |
+| External API     | [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices) (public, unauthenticated; called by `get-azure-pricing.sh` during happy-path tasks) |
 
 ## Quick start
 
@@ -97,6 +98,63 @@ The mock executor is configured in `eval-mock.yaml` alongside `eval.yaml`. Both 
 ### Copilot SDK executor
 
 Runs real AI evaluations. Auth priority: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`. Results are uploaded as artifacts (30-day retention) and displayed in the Actions Step Summary.
+
+## Execution architecture
+
+Each `copilot-sdk` eval trial runs in two phases. Understanding both is essential for diagnosing timeouts, interpreting token costs, and reasoning about grader behavior.
+
+### Skill execution phase
+
+The Copilot SDK opens a fresh session per trial, loads the entire `skills/azure-cost-calculator/` directory as system context, sends the user prompt, and runs the agent to completion. No state carries forward between trials.
+
+The skill directory is approximately 677 KB (~170K tokens). This context is prepended to every LLM call within a trial. A clean trial (e.g., a disambiguation task where the agent asks a question and stops) makes 3 LLM calls across 3 tool-use turns. A full estimation trial (agent runs `get-azure-pricing.sh`, builds a price table) makes 6-11 tool calls, each compounding the conversation history from prior turns.
+
+The Azure Retail Prices API is called during this phase via `get-azure-pricing.sh`. It is public and requires no authentication, but it is an external network dependency. If the API is down or the CI runner restricts outbound HTTPS, happy-path tasks will fail.
+
+### Grading phase
+
+After execution completes, each grader runs in sequence. Deterministic graders (`text`, `tool_constraint`, `trigger`, `skill_invocation`) evaluate the response locally with no additional LLM calls.
+
+Prompt graders (`prompt` type) make a separate LLM call using the model specified by `judge_model` in the eval config. When `continue_session: true` is set, the judge reattaches to the existing skill session via `ResumeSessionWithOptions()` and sees the full conversation exchange, not just the final output. The judge scores by invoking one of two Waza-intercepted tools: `set_waza_grade_pass` or `set_waza_grade_fail`.
+
+Both execution and grading calls go through the same Copilot API, authenticated by the same token, and billed identically. Premium request counts in results include both phases combined. There is currently no breakdown of execution vs. grading cost in the results JSON.
+
+### Model resolution for judging
+
+Judge model priority (highest to lowest):
+
+1. Per-grader `model` field in `promptGraderConfig`
+2. Eval-level `judge_model`
+3. Fallback to `config.model`
+
+Both `model` and `judge_model` are set to `claude-sonnet-4.6` in the current eval configs.
+
+## Cost and resource budget
+
+Eval runs consume premium requests through the Copilot API. The cost is dominated by the 677 KB skill directory loaded as system context on every LLM call, not by the task prompt itself.
+
+### Per-task cost (empirical, claude-sonnet-4.6)
+
+| Scenario                                    | Premium requests | Input tokens | Notes                                 |
+| ------------------------------------------- | ---------------- | ------------ | ------------------------------------- |
+| Clean disambiguation (agent asks and stops) | ~9               | ~194K        | 3 execution turns + grading           |
+| Full estimation (agent runs pricing script) | 15-23            | 370K-600K    | Multi-turn tool use compounds history |
+
+These numbers are from controlled experiments with `trials_per_task: 3` (issue [#632](https://github.com/ahmadabdalla/azure-cost-calculator/issues/632)). With the default `trials_per_task: 1`, divide by 3 for a rough single-trial estimate.
+
+### Full suite cost
+
+With 33 tasks at `trials_per_task: 1`, expect approximately 100-200 premium requests for a full unfiltered run. Use `--tags` filtering to scope runs to what you actually need:
+
+```bash
+# Run only the service you changed
+waza run --tags "service:virtual-machines" --output results/results.json
+
+# Run smoke tests only
+waza run --tags smoke --output results/results.json
+```
+
+The CI workflow (`evaluate-critical`) already does this automatically: it detects which files changed and maps them to tags so only relevant tasks run. Unfiltered runs should only happen via manual `workflow_dispatch` when a full suite assessment is needed.
 
 ## Graders
 
@@ -282,6 +340,40 @@ The `validate-eval-schema` job enforces this: if a PR changes a service referenc
 | `argument-hint` frontmatter diverges from agentskills.io spec                                            | Project convention; not blocking for evals                                                                                                                                                                                                                                                                                                    |
 | `waza suggest` diverges from project conventions and fails intermittently                                | Do not use `waza suggest`; author tasks directly following the task contract and exemplars in this doc                                                                                                                                                                                                                                        |
 
+## Results interpretation
+
+Eval results are saved as JSON artifacts (30-day retention in CI) and can be generated locally with `--output results.json`.
+
+### Score calculation
+
+Each task produces a score from 0.0 to 1.0. The score is the weighted average across all graders on that task. The aggregate score across the full run is the unweighted average of all task scores.
+
+A task with three graders scoring (0, 1, 1) with equal weights produces a task score of 0.67, not 0.00. This means a single critical grader scoring 0 can be masked by passing graders that test unrelated properties. When diagnosing a score, always check per-grader results, not just the aggregate.
+
+### Key fields in results JSON
+
+| Field                               | What it tells you                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| `summary.aggregate_score`           | Overall pass rate across all tasks                                          |
+| `tasks[].stats.avg_score`           | Average score for a specific task across trials                             |
+| `tasks[].stats.std_dev_score`       | Score variance across trials (zero when `trials_per_task: 1`)               |
+| `tasks[].stats.ci95_lo` / `ci95_hi` | 95% confidence interval bounds (only meaningful with `trials_per_task > 1`) |
+| `tasks[].graders[].score`           | Per-grader score for each trial                                             |
+
+### Reading per-grader results
+
+When a task score is unexpected, check which grader moved:
+
+1. Look at `tasks[].graders[]` for the task in question.
+2. Identify which grader scored 0 or below threshold.
+3. Check whether that grader is testing the behavior you care about or an unrelated property.
+
+Global graders (defined in `eval.yaml` under `graders:`) apply to every task. If a global grader tests something irrelevant to a specific task, it adds noise to that task's score. The current global grader `no-summary-format` checks that the response does not contain "Summary format"; this is unrelated to most task behaviors and can inflate scores when paired with a failing critical grader.
+
+### Comparing results
+
+`waza compare <before.json> <after.json>` shows score deltas between two runs. Limitations: it does not surface confidence interval bands, does not flag whether a delta is within noise, and exits 0 on success regardless of whether scores improved or regressed. With `trials_per_task: 1`, any score delta between two runs could be signal or LLM variance; there is no way to distinguish them from a single trial.
+
 ## Troubleshooting
 
 | Symptom                                                                 | Fix                                                                                                                                                                                                  |
@@ -308,6 +400,14 @@ The `validate-eval-schema` job enforces this: if a PR changes a service referenc
 2. If upgrading Waza, update all pinned schema URLs in eval docs and YAML files.
 3. Review `Known limitations` and remove stale mitigations.
 4. Review flaky prompt graders and convert high-value checks to deterministic graders where possible.
+
+## Experiments
+
+Historical record of research, experiments, and design decisions. Issues and PRs are linked for full context.
+
+| Issue                                                                                                                          | PR                                                                     | Status    | Summary                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [#632: Disciplined skill experimentation using waza compare](https://github.com/ahmadabdalla/azure-cost-calculator/issues/632) | [#635](https://github.com/ahmadabdalla/azure-cost-calculator/pull/635) | Discarded | Investigated applying the Karpathy autoresearch pattern (autonomous mutate-measure-keep/revert) to iterative `SKILL.md` improvement. Built `eval-experiment.yaml` with `trials_per_task: 3` and a `compare-experiment.sh` script for ci95 band overlap comparison. |
 
 ## References
 

--- a/docs/ops/issue-triage.md
+++ b/docs/ops/issue-triage.md
@@ -2,13 +2,13 @@
 
 Automated triage of newly opened issues using [GitHub Agentic Workflows (gh-aw)](https://github.com/github/gh-aw) with the **Copilot** engine. For "Fix existing service" issues, the triage workflow also assigns the Copilot coding agent automatically.
 
-| Item            | Detail                                        |
-| --------------- | --------------------------------------------- |
-| Workflow source | `.github/workflows/issue-triage-v2.md`        |
-| Compiled lock   | `.github/workflows/issue-triage-v2.lock.yml`  |
-| Action pins     | `.github/aw/actions-lock.json`                |
-| Engine          | `copilot` (GitHub Copilot)                    |
-| Trigger         | `on: issues [opened]` (default branch only)   |
+| Item            | Detail                                       |
+| --------------- | -------------------------------------------- |
+| Workflow source | `.github/workflows/issue-triage-v2.md`       |
+| Compiled lock   | `.github/workflows/issue-triage-v2.lock.yml` |
+| Action pins     | `.github/aw/actions-lock.json`               |
+| Engine          | `copilot` (GitHub Copilot)                   |
+| Trigger         | `on: issues [opened]` (default branch only)  |
 
 ---
 
@@ -28,14 +28,14 @@ The agent never closes, locks, transfers, or removes labels from issues.
 
 The catalog (`docs/service-catalog.md`) lists all services. The routing map contains implemented services. A service in the catalog but not in the routing map is pending implementation.
 
-| Type         | In routing map? | File exists? | Labels                                     | Assign Copilot? | Action                                    |
-| ------------ | --------------- | ------------ | ------------------------------------------ | ---------------- | ----------------------------------------- |
-| New service  | Yes             | No           | `new-service`, `good first issue`          | No               | Welcome; point to CONTRIBUTING.md         |
-| New service  | Yes             | Yes          | `duplicate`                                | No               | Explain file exists; suggest fix issue    |
-| New service  | No (in catalog) | No           | `new-service`, `good first issue`          | No               | Pending service; add routing entry in PR  |
-| New service  | No (not found)  | -            | `needs-info`                               | No               | Ask for exact `serviceName` from API      |
-| Fix existing | -               | Yes          | `pricing-inaccuracy`, `automatic-existing` | **Yes**          | Assign Copilot with `service-reference` agent |
-| Fix existing | -               | No           | `needs-info`                               | No               | Ask to clarify service name               |
+| Type         | In routing map? | File exists? | Labels                                     | Assign Copilot? | Action                                        |
+| ------------ | --------------- | ------------ | ------------------------------------------ | --------------- | --------------------------------------------- |
+| New service  | Yes             | No           | `new-service`, `good first issue`          | No              | Welcome; point to CONTRIBUTING.md             |
+| New service  | Yes             | Yes          | `duplicate`                                | No              | Explain file exists; suggest fix issue        |
+| New service  | No (in catalog) | No           | `new-service`, `good first issue`          | No              | Pending service; add routing entry in PR      |
+| New service  | No (not found)  | -            | `needs-info`                               | No              | Ask for exact `serviceName` from API          |
+| Fix existing | -               | Yes          | `pricing-inaccuracy`, `automatic-existing` | **Yes**         | Assign Copilot with `service-reference` agent |
+| Fix existing | -               | No           | `needs-info`                               | No              | Ask to clarify service name                   |
 
 ### Copilot assignment conditions
 
@@ -55,12 +55,12 @@ If any condition is not met, the agent skips assignment. The `max: 1` cap on `as
 
 ## Prerequisites
 
-| Requirement                                | Notes                                                                                                                                      |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **`COPILOT_GITHUB_TOKEN`** repo secret     | Fine-grained PAT with the **Copilot Requests** account permission. Powers the Copilot engine.                                              |
-| **`PIPELINE_GITHUB_TOKEN`** repo secret    | Fine-grained PAT with **Issues: write** and **Pull Requests: write**. Powers the `assign-to-agent` safe-output. See [token details](automated-pipeline.md#tokens). |
-| **Labels**                                 | `new-service`, `pricing-inaccuracy`, `automatic-existing`, `service-update` must exist in the repo (others are GitHub defaults).            |
-| **gh-aw CLI**                              | Installed via `gh extension install github/gh-aw`. Only needed for compiling changes, not at runtime.                                      |
+| Requirement                             | Notes                                                                                                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`COPILOT_GITHUB_TOKEN`** repo secret  | Fine-grained PAT with the **Copilot Requests** account permission. Powers the Copilot engine.                                                                      |
+| **`PIPELINE_GITHUB_TOKEN`** repo secret | Fine-grained PAT with **Issues: write** and **Pull Requests: write**. Powers the `assign-to-agent` safe-output. See [token details](automated-pipeline.md#tokens). |
+| **Labels**                              | `new-service`, `pricing-inaccuracy`, `automatic-existing`, `service-update` must exist in the repo (others are GitHub defaults).                                   |
+| **gh-aw CLI**                           | Installed via `gh extension install github/gh-aw`. Only needed for compiling changes, not at runtime.                                                              |
 
 ---
 
@@ -111,15 +111,15 @@ gh run view <run-id> --log-failed
 
 ### Common failure modes
 
-| Symptom                                          | Likely cause                                                            | Fix                                                                                  |
-| ------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Workflow never triggers                          | Edited `.md` but forgot to compile, or changes not on default branch    | Run `gh aw compile`, merge to main                                                   |
-| `401 Unauthorized` in agent job                  | `COPILOT_GITHUB_TOKEN` expired or revoked                               | Rotate the PAT (see above)                                                           |
-| Agent applies wrong labels                       | Classification prompt needs tuning                                      | Edit the Decision Matrix in `issue-triage-v2.md`, recompile                          |
-| Agent leaves no comment                          | Issue matched "spam / invalid" path, or `add-comment` limit already hit | Check the agent job logs for reasoning                                               |
-| Copilot not assigned on Fix existing issue       | Agent verification failed on one of the three conditions                | Check agent logs; verify title, Type field, and file path                            |
-| Copilot assigned but no session starts           | `PIPELINE_GITHUB_TOKEN` expired or lacks required permissions           | Rotate; needs Issues:write and Pull Requests:write                                   |
-| MCP servers blocked by policy                    | Copilot CLI version mismatch (seen with CLI v1.0.22)                    | Recompile with latest gh-aw (`gh extension upgrade github/gh-aw && gh aw compile`)   |
+| Symptom                                          | Likely cause                                                            | Fix                                                                                                                         |
+| ------------------------------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Workflow never triggers                          | Edited `.md` but forgot to compile, or changes not on default branch    | Run `gh aw compile`, merge to main                                                                                          |
+| `401 Unauthorized` in agent job                  | `COPILOT_GITHUB_TOKEN` expired or revoked                               | Rotate the PAT (see above)                                                                                                  |
+| Agent applies wrong labels                       | Classification prompt needs tuning                                      | Edit the Decision Matrix in `issue-triage-v2.md`, recompile                                                                 |
+| Agent leaves no comment                          | Issue matched "spam / invalid" path, or `add-comment` limit already hit | Check the agent job logs for reasoning                                                                                      |
+| Copilot not assigned on Fix existing issue       | Agent verification failed on one of the three conditions                | Check agent logs; verify title, Type field, and file path                                                                   |
+| Copilot assigned but no session starts           | `PIPELINE_GITHUB_TOKEN` expired or lacks required permissions           | Rotate; needs Issues:write and Pull Requests:write                                                                          |
+| MCP servers blocked by policy                    | Copilot CLI version mismatch (seen with CLI v1.0.22)                    | Recompile with latest gh-aw (`gh extension upgrade github/gh-aw && gh aw compile`)                                          |
 | Confused `pricing-inaccuracy` / `service-update` | Both relate to existing references but have different scopes            | `pricing-inaccuracy` = wrong pricing data (Fix existing); `service-update` = structural improvements (improvement template) |
 
 ### Job architecture
@@ -147,6 +147,16 @@ gh aw compile
 ```
 
 Commit the updated lock files after upgrading.
+
+---
+
+## Experiments
+
+Historical record of research, experiments, and design decisions. Issues and PRs are linked for full context.
+
+| Issue                                                                                                                                                | PR                                                                     | Status | Summary                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#688: investigate: automated service-reference pipeline via Copilot coding agent](https://github.com/ahmadabdalla/azure-cost-calculator/issues/688) | [#711](https://github.com/ahmadabdalla/azure-cost-calculator/pull/711) | Merged | Investigated programmatic Copilot assignment, gh-aw trigger support, and PR review automation; built and shipped the end-to-end triage-assign-review pipeline. |
 
 ---
 


### PR DESCRIPTION
Add Experiments sections and minor updates to ops guides.

## Changes

- **automated-pipeline.md**: add Experiments table with #732/#749 (scheduled idle-check replacing push-triggered debounce)
- **issue-triage.md**: add Experiments table with #688/#711 (end-to-end triage-assign-review pipeline)
- **evals.md**: add External API row to summary table, content updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced operations documentation with improved formatting and organization.
  * Added new sections covering execution architecture, cost and resource budgets, and results interpretation for evaluation workflows.
  * Added historical experiment records linking related issues and pull requests across operational guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->