### PR TITLE
fix: strip PowerShell script BOMs (#945)

### DIFF
--- a/skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1
+++ b/skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Discovers available Azure pricing filter values for unknown or new resource types.
 

--- a/skills/azure-cost-calculator/scripts/Get-AzurePricing.ps1
+++ b/skills/azure-cost-calculator/scripts/Get-AzurePricing.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Queries the Azure Retail Prices API and calculates estimated monthly costs.
 

--- a/skills/azure-cost-calculator/scripts/lib/Build-ODataFilter.ps1
+++ b/skills/azure-cost-calculator/scripts/lib/Build-ODataFilter.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Builds an OData $filter string from an ordered hashtable of field/value pairs.
     Supports equality filters and contains() operators.

--- a/skills/azure-cost-calculator/scripts/lib/Get-MonthlyMultiplier.ps1
+++ b/skills/azure-cost-calculator/scripts/lib/Get-MonthlyMultiplier.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Maps a unitOfMeasure string to a monthly multiplier.
     Hourly units return $HoursMonth; daily units return 30; everything else returns 1.

--- a/skills/azure-cost-calculator/scripts/lib/Invoke-RetailPricesQuery.ps1
+++ b/skills/azure-cost-calculator/scripts/lib/Invoke-RetailPricesQuery.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Queries the Azure Retail Prices API with OData filter, handling pagination.
     Returns an array of pricing items.


### PR DESCRIPTION
## Summary
- Strip the leading UTF-8 BOM from the five affected PowerShell scripts under the skill.
- Leave script content and behavior unchanged.

## Validation
- pwsh tests/unit/Run-PesterTests.ps1
- pwsh -NoLogo -NoProfile -File skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1 -ServiceName 'Virtual Machines' -Region 'eastus' -Top 1 | jq -e 'length == 1 and .[0].ServiceName == "Virtual Machines"' >/dev/null
- pwsh -NoLogo -NoProfile -File skills/azure-cost-calculator/scripts/Get-AzurePricing.ps1 -ServiceName 'Virtual Machines' -ArmSkuName 'Standard_B1s' -Region 'eastus' -OutputFormat Compact | jq -e '.results | length > 0' >/dev/null
- git diff --check
- Verified no .ps1 files under skills/azure-cost-calculator start with EF BB BF

Closes #945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed encoding issues in PowerShell scripts to ensure proper compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->