### PR TITLE
fix: replace cross-service markers with metadata #946

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ The file MUST follow these critical constraints:
 - **Total file length**: under 100 lines of markdown content.
 - **Use declarative `Key: Value` format** for query patterns (no code fences, no script names). Agents translate parameters to the detected runtime's syntax.
 - **ServiceName in every query block**: Always include `ServiceName:` in each individual query pattern block. Do not rely on "All patterns below use..." preambles - batch mode parses individual blocks.
+- **Declare every query serviceName in metadata**: `ServiceName:` values must match `serviceName`, `apiServiceName`, `billingNeeds`, or `queryServiceNames`. Use `queryServiceNames: [...]` only for additional query-only API service names.
 - **Never hardcode prices** - always reference `retailPrice` from the API query results. Exception: Known Rates tables for sub-cent pricing where the script shows `$0.00` may include published USD rates.
 - **Use 730 hours/month** for hourly billing, 30 days/month for daily billing.
 - **Query patterns for every variant**: If the service has platform/OS variants or alternate `productName` values with distinct meters, include a separate query pattern for each.
@@ -192,7 +193,7 @@ When a service reference file has incorrect pricing data or missing information 
 1. **Locate the file**: Find the existing reference in `skills/azure-cost-calculator/references/services/{category}/`.
 2. **Verify current API data**: Run the exploration script to check current pricing:
    ```powershell
-   skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1 -ServiceName '{apiServiceName if present, otherwise serviceName from file YAML}'
+   skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1 -ServiceName '{ServiceName value from the query block}'
    ```
 3. **Compare and update**: Compare API results against the file's query patterns, meter names, and key fields. Update any values that have changed.
 4. **Validate**: Run the validation script:

--- a/docs/TEMPLATE.md
+++ b/docs/TEMPLATE.md
@@ -48,6 +48,7 @@ billingConsiderations:
 # ── API Identity (optional) ──────────────────────────────
 # apiServiceName: { only when API serviceName ≠ display serviceName,
 #   e.g., VMware Solution → "Specialized Compute", Static Web Apps → "Azure App Service" }
+# queryServiceNames: [{ only when query blocks need additional ServiceName values }]
 
 # ── Pricing Profile ──────────────────────────────────────
 primaryCost:
@@ -103,6 +104,7 @@ primaryCost:
      - billingConsiderations (optional): Reserved Instances, Spot Pricing, Azure Hybrid Benefit,
        M365 / Windows per-user licensing. Omit if standard PAYG only.
      - apiServiceName (optional): Only when API serviceName differs from display name. Omit if identical.
+     - queryServiceNames (optional): Additional Retail Prices API ServiceName values used by query blocks. Omit unless a block must query a serviceName outside `serviceName`, `apiServiceName`, or `billingNeeds`.
      - primaryCost (required): One-line billing summary, max 120 chars.
      - hasMeters (optional, default: true): Set false for API-unavailable services. Omit when true.
      - pricingRegion (optional, default: regional): regional | global | empty-region | api-unavailable. Omit when regional.

--- a/docs/ops/service-routing-split.md
+++ b/docs/ops/service-routing-split.md
@@ -47,13 +47,16 @@ The routing file is self-contained and does not reference the catalog. Agents th
 
 Three related terms appear across documentation. Use these consistently:
 
-| Term                    | Meaning                                                                                                        | Example                         |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **Display name**        | Human-readable name in the routing map / catalog (before the colon)                                            | `Azure VMware Solution`         |
-| **API serviceName**     | Exact case-sensitive value for the Azure Retail Prices API `serviceName` filter                                | `Specialized Compute`           |
-| **`serviceName` field** | YAML front matter field; the primary service identifier, usually equals both display name and API serviceName | `serviceName: Virtual Machines` |
+| Term                          | Meaning                                                                                                       | Example                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Display name**              | Human-readable name in the routing map / catalog (before the colon)                                           | `Azure VMware Solution`              |
+| **API serviceName**           | Exact case-sensitive value for the Azure Retail Prices API `serviceName` filter                               | `Specialized Compute`                |
+| **`serviceName` field**       | YAML front matter field; the primary service identifier, usually equals both display name and API serviceName | `serviceName: Virtual Machines`      |
+| **`queryServiceNames` field** | Extra API `serviceName` values that are valid only for query pattern blocks                                   | `queryServiceNames: [Azure Monitor]` |
 
 For most services, display name ≈ API serviceName (e.g., `Virtual Machines`). For split-product services, they differ (e.g., display name `Azure VMware Solution` → API serviceName `Specialized Compute`). The `apiServiceName` YAML field bridges this gap when they differ.
+
+Use `queryServiceNames` only when a single reference must query additional API `serviceName` values beyond its primary `serviceName`, `apiServiceName`, or `billingNeeds` entries.
 
 ---
 

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -104,6 +104,7 @@ YAML front matter fields. Optional fields use default elision; omitted means the
 | `billingConsiderations` |    -     | omit       | Ask user about listed pricing factors before calculating                                |
 | `primaryCost`           |    ✔     | -          | One-line billing summary for quick cost context                                         |
 | `apiServiceName`        |    -     | omit       | Use instead of `serviceName` in API queries                                             |
+| `queryServiceNames`     |    -     | omit       | Additional allowed query pattern `ServiceName` values                                   |
 | `hasMeters`             |    -     | `true`     | `false` → skip API, use Known Rates table                                               |
 | `pricingRegion`         |    -     | `regional` | `global` → `Region: Global`; `api-unavailable` → skip API; `empty-region` → omit region |
 | `hasKnownRates`         |    -     | `false`    | `true` → file contains manual pricing table                                             |
@@ -127,6 +128,7 @@ When estimating **3 or more services**, use these rules to reduce token consumpt
    - `hasMeters: false` / `pricingRegion: api-unavailable` → skip API; use Known Rates or `primaryCost`
    - `pricingRegion: global` → `Region: Global`; `empty-region` → omit region
    - `apiServiceName` → use instead of `serviceName` in queries
+   - `queryServiceNames` → query blocks may use these additional `ServiceName` values
    - `hasFreeGrant: true` → apply grant deduction; `privateEndpoint: true` → add PE line item
 3. **Full read triggers**: no query pattern in partial read, non-default config, 0/unexpected results, or `billingConsiderations` applies.
 4. **Parallel queries**: run independent service queries in parallel, but limit to 3–5 concurrent requests to avoid API rate limiting. If querying more than 5 services, stagger starts in batches.

--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
@@ -20,7 +20,7 @@ privateEndpoint: true
 
 ### Standard document content extraction: 10K pages/month
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Content Understanding
 SkuName: Doc Content Extraction Standard
 MeterName: Doc Content Extraction Standard Pages
@@ -28,7 +28,7 @@ Quantity: 10 # 10 × 1K = 10,000 pages
 
 ### Audio content extraction: 50 hours
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Content Understanding
 SkuName: Audio Content Extraction
 MeterName: Audio Content Extraction
@@ -36,14 +36,14 @@ Quantity: 50 # total hours of audio processed per month
 
 ### Video content extraction
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Content Understanding
 SkuName: Video Content Extraction
 MeterName: Video Content Extraction
 
 ### Standard field extraction: input tokens (3 regions only)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Content Understanding
 SkuName: Std Field Extract Inp
 MeterName: Std Field Extract Inp Tokens

--- a/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
@@ -20,7 +20,7 @@ hasFreeGrant: true
 
 ### S1 premium channel messages (DirectLine/Web Chat)
 
-ServiceName: Azure Bot Service <!-- cross-service -->
+ServiceName: Azure Bot Service
 ProductName: Azure Bot Service
 SkuName: S1
 MeterName: S1 Premium Channel Messages
@@ -28,7 +28,7 @@ Quantity: 50 # thousands of messages per month
 
 ### Free tier (premium channels, 10K messages/month included)
 
-ServiceName: Azure Bot Service <!-- cross-service -->
+ServiceName: Azure Bot Service
 ProductName: Azure Bot Service
 SkuName: Free
 MeterName: Free Premium Channel Messages

--- a/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
@@ -20,7 +20,7 @@ privateEndpoint: true
 
 ### Text moderation: 50K records/month
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Standard
 MeterName: Standard Text Records
@@ -28,35 +28,35 @@ Quantity: 50 # 50 × 1K = 50,000 text records
 
 ### Image moderation: PAYG
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Standard
 MeterName: Standard Images
 
 ### Commitment tier: Text Azure 1M (base fee)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Commitment Tier Txt Azure 1M
 MeterName: Commitment Tier Txt Azure 1M Unit
 
 ### Commitment tier: Text Azure 1M (overage)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Commitment Tier Txt Azure 1M
 MeterName: Commitment Tier Txt Azure 1M CT Overage Transactions
 
 ### Commitment tier: Image Azure 250K (base fee)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Commitment Tier Image Azure 250K
 MeterName: Commitment Tier Image Azure 250K Unit
 
 ### Commitment tier: Image Azure 250K (overage)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Content Safety
 SkuName: Commitment Tier Image Azure 250K
 MeterName: Commitment Tier Image Azure 250K CT Overage Transactions

--- a/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
@@ -18,7 +18,7 @@ privateEndpoint: true
 
 ### Pre-built models (Invoice, Receipt, ID, W-2): 10K pages/month
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Document Intelligence
 SkuName: S0
 MeterName: S0 Pre-built Pages
@@ -26,7 +26,7 @@ Quantity: 10 # 10 × 1K = 10,000 pages
 
 ### Read (OCR/layout extraction)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Document Intelligence
 SkuName: S0
 MeterName: S0 Read Pages
@@ -34,14 +34,14 @@ Quantity: 1 # 1 × 1K = 1,000 pages; tiered at 1M
 
 ### Custom extraction models
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Document Intelligence
 SkuName: S0
 MeterName: S0 Custom Pages
 
 ### Commitment tier: Pre-Built Azure 100K (monthly fee)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Document Intelligence
 SkuName: Commitment Tier Pre-Built Azure 100K
 MeterName: Commitment Tier Pre-Built Azure 100K Unit # flat monthly fee, unitOfMeasure: 1/Month

--- a/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
@@ -19,7 +19,7 @@ primaryCost: "Hosted compute (vCPU + memory × 730 hrs/mo) + skills execution + 
 
 ### Hosted agent compute: vCPU
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Foundry Agents
 SkuName: Hosted
 MeterName: Hosted vCPU Usage
@@ -27,7 +27,7 @@ Quantity: 4 # vCPUs allocated
 
 ### Hosted agent compute: memory
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Foundry Agents
 SkuName: Hosted
 MeterName: Hosted Memory Usage
@@ -35,7 +35,7 @@ Quantity: 8 # GBs of memory
 
 ### Skills execution container
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Foundry Agents
 SkuName: Skills Execution
 MeterName: Skills Execution Container
@@ -43,7 +43,7 @@ Quantity: 2 # container-hours consumed
 
 ### SRE Agent Unit
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Agent Unit
 SkuName: SRE
 MeterName: SRE Agent Unit

--- a/skills/azure-cost-calculator/references/services/ai-ml/language.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/language.md
@@ -23,7 +23,7 @@ privateEndpoint: true
 
 ### Standard text analytics (NER, Sentiment, PII): 100K records
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Language
 SkuName: Standard
 MeterName: Standard Text Records
@@ -31,21 +31,21 @@ Quantity: 100 # 100 × 1K = 100K records
 
 ### CLU inference
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Language
 SkuName: Standard
 MeterName: Standard CLU Text Records
 
 ### CLU / custom model training
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Language
 SkuName: Standard
 MeterName: Standard CLU Advanced Training Unit
 
 ### LUIS (legacy)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Language Understanding
 SkuName: S1
 MeterName: S1 Transactions

--- a/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
@@ -30,21 +30,21 @@ Run explore with `SearchTerm: Azure OpenAI` and `Top: 20` to discover current mo
 
 ### Chat / completion model: substitute discovered values
 
-ServiceName: Foundry Models <!-- cross-service -->
+ServiceName: Foundry Models
 ProductName: {productName from discovery}
 SkuName: {model} {direction} {deployment}
 Quantity: 100 # units of unitOfMeasure; 100M tokens when UoM is 1M
 
 ### Embeddings: Global/Regional (substitute discovered embedding skuName)
 
-ServiceName: Foundry Models <!-- cross-service -->
+ServiceName: Foundry Models
 ProductName: Azure OpenAI
 SkuName: {embedding model} {deployment}
 Quantity: 500 # units of unitOfMeasure; 500K tokens when UoM is 1K
 
 ### Embeddings: Data Zone text-embedding-3 (separate product)
 
-ServiceName: Foundry Models <!-- cross-service -->
+ServiceName: Foundry Models
 ProductName: Azure OpenAI Embedding
 SkuName: {text embedding 3 model} DZ
 Quantity: 500 # units of unitOfMeasure; 500K tokens when UoM is 1K

--- a/skills/azure-cost-calculator/references/services/ai-ml/speech.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/speech.md
@@ -20,7 +20,7 @@ privateEndpoint: true
 
 ### Speech to Text: standard PAYG
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Speech
 SkuName: S1
 MeterName: S1 Speech To Text
@@ -28,7 +28,7 @@ Quantity: 100 # audio hours
 
 ### Neural Text to Speech: standard PAYG
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Speech
 SkuName: S1
 MeterName: S1 Neural Text To Speech Characters
@@ -36,14 +36,14 @@ Quantity: 10 # units of 1M characters
 
 ### Commitment tier: STT Azure 2K (base fee)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Speech
 SkuName: Commitment Tier Speech to Text Azure 2K
 MeterName: Commitment Tier Speech to Text Azure 2K Unit
 
 ### Fast Transcription
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Speech
 SkuName: Fast Transcription
 MeterName: Fast Transcription Speech To Text

--- a/skills/azure-cost-calculator/references/services/ai-ml/translator.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/translator.md
@@ -20,7 +20,7 @@ privateEndpoint: true
 
 ### S1 standard text translation: 10M characters/month
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Translator Text
 SkuName: S1
 MeterName: S1 Characters
@@ -28,21 +28,21 @@ Quantity: 10 # millions of characters
 
 ### S1 document translation
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Translator Text
 SkuName: S1
 MeterName: S1 Document Characters
 
 ### Commitment tier (Azure 250M chars/month)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Translator Text
 SkuName: Commitment Tier Azure 250M
 MeterName: Commitment Tier Azure 250M Unit
 
 ### S1 standard text translation (Global product)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Translator
 SkuName: S1 Standard
 MeterName: S1 Standard Characters

--- a/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
@@ -18,39 +18,39 @@ privateEndpoint: true
 ## Query Pattern
 
 ### Basic Audio Indexing: 1,000 minutes/month
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Basic Audio Indexing Analysis
 MeterName: Basic Audio Indexing Analysis Input Content Minutes
 Quantity: 1000 # minutes of audio content
 ### Basic Video Indexing: 1,000 minutes/month
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Basic Video Indexing Analysis
 MeterName: Basic Video Indexing Analysis Input Content Minutes
 Quantity: 1000 # minutes of video content
 ### Standard Audio Indexing
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Standard Audio Indexing Analysis
 MeterName: Standard Audio Indexing Analysis Input Content Minutes
 ### Standard Video Indexing
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Standard Video Indexing Analysis
 MeterName: Standard Video Indexing Analysis Input Content Minutes
 ### Advanced Audio Indexing
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Advanced Audio Indexing Analysis
 MeterName: Advanced Audio Indexing Analysis Input Content Minutes
 ### Advanced Video Indexing
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Advanced Video Indexing Analysis
 MeterName: Advanced Video Indexing Analysis Input Content Minutes
 ### Video Modification (face redaction / encoding)
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Video Indexer
 SkuName: Video Modification
 MeterName: Video Modification Input Content Minutes

--- a/skills/azure-cost-calculator/references/services/ai-ml/vision.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/vision.md
@@ -20,14 +20,14 @@ privateEndpoint: true
 
 ### Image Analysis: PAYG (most common)
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Vision
 SkuName: Image Analysis Group 1
 MeterName: Image Analysis Group 1 Transactions
 
 ### Face API: 50K transactions/month
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Vision - Face
 SkuName: Standard
 MeterName: Standard Transactions
@@ -35,7 +35,7 @@ Quantity: 50 # 50 × 1K = 50,000 transactions
 
 ### Spatial Analysis: per camera-hour
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Vision
 SkuName: Spatial Analysis
 MeterName: Spatial Analysis Video Stream Edge
@@ -43,7 +43,7 @@ InstanceCount: 3 # 3 cameras
 
 ### Video Retrieval: ingestion
 
-ServiceName: Foundry Tools <!-- cross-service -->
+ServiceName: Foundry Tools
 ProductName: Azure Vision
 SkuName: Video Retrieval and Description - Ingestion
 MeterName: Video Retrieval and Description - Ingestion Vision

--- a/skills/azure-cost-calculator/references/services/analytics/managed-airflow.md
+++ b/skills/azure-cost-calculator/references/services/analytics/managed-airflow.md
@@ -18,14 +18,14 @@ primaryCost: "vCore hourly rate × 730 per Airflow environment (Small or Large S
 
 ### Small environment: per vCore-hour
 
-ServiceName: Azure Data Factory v2 <!-- cross-service -->
+ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2 - Managed Airflow
 SkuName: Small
 MeterName: vCore
 
 ### Large environment: multiple Airflow environments
 
-ServiceName: Azure Data Factory v2 <!-- cross-service -->
+ServiceName: Azure Data Factory v2
 ProductName: Azure Data Factory v2 - Managed Airflow
 SkuName: Large
 MeterName: vCore

--- a/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
+++ b/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
@@ -17,7 +17,7 @@ primaryCost: "Per-host hourly rate × node count × 730 hours/month"
 
 ### Host Node
 
-ServiceName: Specialized Compute <!-- cross-service -->
+ServiceName: Specialized Compute
 ProductName: Specialized Compute Azure VMware Solution
 SkuName: AV36P VCF BYOL
 MeterName: AV36P VCF BYOL Node
@@ -25,7 +25,7 @@ InstanceCount: 3
 
 ### Reservation
 
-ServiceName: Specialized Compute <!-- cross-service -->
+ServiceName: Specialized Compute
 ProductName: Specialized Compute Azure VMware Solution
 SkuName: AV36P VCF BYOL
 PriceType: Reservation

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db-for-postgresql.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db-for-postgresql.md
@@ -19,14 +19,14 @@ privateEndpoint: true
 
 ### Coordinator node compute (e.g., 8 vCores)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Cosmos DB for PostgreSQL Compute- Coordinator Node
 SkuName: vCore
 MeterName: vCore
 
 ### Worker node compute (e.g., 4 vCores × 3 workers)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Cosmos DB for PostgreSQL Compute- Worker Node
 SkuName: vCore
 MeterName: vCore
@@ -34,7 +34,7 @@ InstanceCount: 3 # number of worker nodes
 
 ### General Purpose storage (e.g., 512 GiB)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Cosmos DB for PostgreSQL General Purpose Storage
 SkuName: General Purpose
 MeterName: General Purpose Data Stored
@@ -80,7 +80,7 @@ Total               = Coordinator Compute + Worker Compute + Storage
 
 ## Reserved Instance Pricing
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Cosmos DB for PostgreSQL Compute- Coordinator Node
 SkuName: vCore
 MeterName: vCore

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
@@ -14,7 +14,7 @@ primaryCost: "vCPU-hours per tier × 730 + Premium SSD disk per GB × 730"
 
 ### Compute: General Purpose v6 (e.g., 4 vCPUs)
 
-ServiceName: Azure Cosmos DB <!-- cross-service -->
+ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB Garnet Cache
 SkuName: General Purpose v6
 MeterName: General Purpose v6 vCore
@@ -22,7 +22,7 @@ Quantity: 4 # number of vCPUs
 
 ### Disk storage (e.g., 128 GB)
 
-ServiceName: Azure Cosmos DB <!-- cross-service -->
+ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB Garnet Cache
 SkuName: Premium SSD Managed Disk
 MeterName: Premium SSD Managed Disk

--- a/skills/azure-cost-calculator/references/services/databases/horizondb.md
+++ b/skills/azure-cost-calculator/references/services/databases/horizondb.md
@@ -16,7 +16,7 @@ primaryCost: "vCore hourly rate × 730 + storage per-GB/month + backup per-GB/mo
 
 ### Compute (4 vCores)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure Database for PostgreSQL HorizonDB Compute
 SkuName: 1 vCore
 MeterName: 1 vCore
@@ -24,7 +24,7 @@ InstanceCount: 4 # vCore count
 
 ### Storage (100 GB)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure HorizonDB storage
 SkuName: HorizonDB storage
 MeterName: HorizonDB storage Data Stored
@@ -32,7 +32,7 @@ Quantity: 100 # storage size in GB
 
 ### Backup storage (50 GB)
 
-ServiceName: Azure Database for PostgreSQL <!-- cross-service -->
+ServiceName: Azure Database for PostgreSQL
 ProductName: Azure HorizonDB Backup Storage
 SkuName: HorizonDB Backup Storage
 MeterName: HorizonDB Backup Storage Data Stored

--- a/skills/azure-cost-calculator/references/services/developer-tools/managed-grafana.md
+++ b/skills/azure-cost-calculator/references/services/developer-tools/managed-grafana.md
@@ -17,7 +17,7 @@ privateEndpoint: true
 
 ### Standard X1 instance: most common production config
 
-ServiceName: Azure Grafana Service <!-- cross-service -->
+ServiceName: Azure Grafana Service
 ProductName: Azure Managed Grafana
 SkuName: Standard
 MeterName: Standard Node
@@ -25,14 +25,14 @@ Quantity: 2
 
 ### Standard zone redundancy (additive to node cost)
 
-ServiceName: Azure Grafana Service <!-- cross-service -->
+ServiceName: Azure Grafana Service
 ProductName: Azure Managed Grafana
 SkuName: Standard
 MeterName: Standard Zone Redundancy
 
 ### Standard active users
 
-ServiceName: Azure Grafana Service <!-- cross-service -->
+ServiceName: Azure Grafana Service
 ProductName: Azure Managed Grafana
 SkuName: Standard
 MeterName: Standard User

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -2,6 +2,7 @@
 serviceName: Log Analytics
 category: monitoring
 aliases: [OMS, LA, Workspace, Logs, Log Analytics Workspace, Azure Monitor Logs, Operations Management Suite]
+queryServiceNames: [Azure Monitor]
 primaryCost: "Data ingestion per-GB + retention beyond free period (90 days Sentinel / 31 days standard)"
 hasFreeGrant: true
 privateEndpoint: true
@@ -32,7 +33,7 @@ MeterName: Analytics Logs Data Retention
 
 ### Commitment tier (100+ GB/day): uses ServiceName: Azure Monitor
 
-ServiceName: Azure Monitor <!-- cross-service -->
+ServiceName: Azure Monitor
 SkuName: 100 GB Commitment Tier
 MeterName: 100 GB Commitment Tier Capacity Reservation
 

--- a/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
@@ -19,7 +19,7 @@ hasFreeGrant: true
 
 ### Paid endpoint (InstanceCount = number of non-Azure endpoints)
 
-ServiceName: Azure Monitor <!-- cross-service -->
+ServiceName: Azure Monitor
 ProductName: Azure Monitor SCOM Managed Instance
 SkuName: Basic
 MeterName: Basic Endpoint
@@ -28,7 +28,7 @@ InstanceCount: 10 # billable non-Azure endpoints
 
 ### Free Azure-benefit endpoint (zero cost)
 
-ServiceName: Azure Monitor <!-- cross-service -->
+ServiceName: Azure Monitor
 ProductName: Azure Monitor SCOM Managed Instance
 SkuName: Free Benefit- Azure
 MeterName: Free Benefit- Azure Endpoint

--- a/skills/azure-cost-calculator/references/services/networking/application-gateway-for-containers.md
+++ b/skills/azure-cost-calculator/references/services/networking/application-gateway-for-containers.md
@@ -18,27 +18,27 @@ Substitute `{Variant}` with `Application Gateway for Containers` (Standard) or `
 
 ### {Variant}: AGC resource (fixed hourly)
 
-ServiceName: Application Gateway <!-- cross-service -->
+ServiceName: Application Gateway
 ProductName: {Variant}
 MeterName: Standard AGC
 
 ### {Variant}: frontend (Quantity = number of frontends)
 
-ServiceName: Application Gateway <!-- cross-service -->
+ServiceName: Application Gateway
 ProductName: {Variant}
 MeterName: Standard Frontend
 Quantity: 2
 
 ### {Variant}: association (Quantity = number of associations)
 
-ServiceName: Application Gateway <!-- cross-service -->
+ServiceName: Application Gateway
 ProductName: {Variant}
 MeterName: Standard Association
 Quantity: 1
 
 ### {Variant}: capacity units (Quantity = estimated average CUs)
 
-ServiceName: Application Gateway <!-- cross-service -->
+ServiceName: Application Gateway
 ProductName: {Variant}
 MeterName: Standard Capacity Units
 Quantity: 10

--- a/skills/azure-cost-calculator/references/services/networking/dns-private-resolver.md
+++ b/skills/azure-cost-calculator/references/services/networking/dns-private-resolver.md
@@ -24,7 +24,7 @@ Fields: meterName, unitPrice, unitOfMeasure
 
 ### Inbound endpoints (Quantity = number of endpoints)
 
-ServiceName: Azure DNS <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: Private Resolver
 MeterName: Private Resolver Inbound Endpoint
 Region: Zone 1
@@ -32,14 +32,14 @@ Quantity: 2
 
 ### Outbound endpoints
 
-ServiceName: Azure DNS <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: Private Resolver
 MeterName: Private Resolver Outbound Endpoint
 Region: Zone 1
 
 ### DNS forwarding rulesets
 
-ServiceName: Azure DNS <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: Private Resolver
 MeterName: Private Resolver DNS Forwarding Ruleset
 Region: Zone 1

--- a/skills/azure-cost-calculator/references/services/networking/dns-security-policy.md
+++ b/skills/azure-cost-calculator/references/services/networking/dns-security-policy.md
@@ -18,7 +18,7 @@ primaryCost: "Per 1K managed domains/month + per million DNS security queries"
 
 ### Managed domains (1 unit = 1,000 domains)
 
-ServiceName: Azure DNS  <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: DNS Security Policy Domains
 MeterName: DNS Security Policy Domains Managed Domain
 Region: Zone 1
@@ -26,7 +26,7 @@ Quantity: 5
 
 ### DNS security queries (per million)
 
-ServiceName: Azure DNS  <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: DNS Security Policy Queries
 MeterName: DNS Security Policy Queries
 Region: Zone 1

--- a/skills/azure-cost-calculator/references/services/networking/expressroute-gateway.md
+++ b/skills/azure-cost-calculator/references/services/networking/expressroute-gateway.md
@@ -17,20 +17,20 @@ primaryCost: "Gateway SKU hourly rate × 730; ErGwScale bills per scale unit"
 
 ### Zone-redundant gateway: substitute {GatewaySku} from Meter Names table
 
-ServiceName: ExpressRoute <!-- cross-service -->
+ServiceName: ExpressRoute
 ProductName: ExpressRoute Gateway
 MeterName: {GatewaySku} Gateway
 
 ### ErGwScale gateway: multiply by scale unit count
 
-ServiceName: ExpressRoute <!-- cross-service -->
+ServiceName: ExpressRoute
 ProductName: ExpressRoute Gateway
 MeterName: ErGwScale Unit
 InstanceCount: 4
 
 ### Legacy gateway: substitute {Tier} from Meter Names table
 
-ServiceName: ExpressRoute <!-- cross-service -->
+ServiceName: ExpressRoute
 ProductName: ExpressRoute {Tier} Gateway
 MeterName: {Tier} Gateway
 

--- a/skills/azure-cost-calculator/references/services/networking/ip-addresses.md
+++ b/skills/azure-cost-calculator/references/services/networking/ip-addresses.md
@@ -16,7 +16,7 @@ primaryCost: "Per-hour IPv4 rate × 730 × ipCount"
 
 ### Standard Static Public IP (InstanceCount = number of IPs)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: IP Addresses
 SkuName: Standard
 MeterName: Standard IPv4 Static Public IP
@@ -24,14 +24,14 @@ InstanceCount: 3
 
 ### Basic Dynamic Public IP
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: IP Addresses
 SkuName: Basic
 MeterName: Basic IPv4 Dynamic Public IP
 
 ### Global Static Public IP (cross-region services like Front Door)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: IP Addresses
 SkuName: Global
 MeterName: Global IPv4 Static Public IP

--- a/skills/azure-cost-calculator/references/services/networking/private-dns.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-dns.md
@@ -29,7 +29,7 @@ Fields: meterName, unitPrice, unitOfMeasure
 
 ### Script workaround (Zone 1)
 
-ServiceName: Azure DNS  <!-- cross-service -->
+ServiceName: Azure DNS
 SkuName: Private
 MeterName: Private Zone
 Region: Zone 1

--- a/skills/azure-cost-calculator/references/services/networking/private-link.md
+++ b/skills/azure-cost-calculator/references/services/networking/private-link.md
@@ -21,7 +21,7 @@ pricingRegion: global
 
 ### Endpoint hourly cost
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Virtual Network Private Link
 SkuName: Standard
 MeterName: Standard Private Endpoint
@@ -29,7 +29,7 @@ Region: Global
 
 ### Multi-endpoint deployment (InstanceCount = number of private endpoints)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Virtual Network Private Link
 SkuName: Standard
 MeterName: Standard Private Endpoint
@@ -38,7 +38,7 @@ InstanceCount: 5
 
 ### Data processed: substitute {direction} with Ingress or Egress
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Virtual Network Private Link
 SkuName: Standard
 MeterName: Standard Data Processed - {direction}
@@ -46,7 +46,7 @@ Region: Global
 
 ### Private Link Service (provider-side hourly cost)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Virtual Network Private Link
 SkuName: Service endpoint Standard
 MeterName: Service endpoint Standard Virtual Network

--- a/skills/azure-cost-calculator/references/services/networking/virtual-network-manager.md
+++ b/skills/azure-cost-calculator/references/services/networking/virtual-network-manager.md
@@ -19,7 +19,7 @@ pricingRegion: global
 
 ### VNet-based billing: new default (InstanceCount = managed VNets)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Azure Virtual Network Manager
 SkuName: Standard
 MeterName: Standard Virtual Network
@@ -28,7 +28,7 @@ InstanceCount: 10
 
 ### Subscription-based billing: legacy (InstanceCount = managed subscriptions)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Azure Virtual Network Manager
 SkuName: Standard
 MeterName: Standard Subscription
@@ -37,7 +37,7 @@ InstanceCount: 3
 
 ### IPAM: per active managed IP address
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Azure Virtual Network Manager
 SkuName: Managed IP
 MeterName: Managed IP Management
@@ -45,7 +45,7 @@ Region: Global
 
 ### Network Verifier: per analysis run (Quantity = runs/month)
 
-ServiceName: Virtual Network <!-- cross-service -->
+ServiceName: Virtual Network
 ProductName: Azure Virtual Network Manager
 SkuName: Reachability Analysis
 MeterName: Reachability Analysis Diagnostic Tool API

--- a/skills/azure-cost-calculator/references/services/security/defender-easm.md
+++ b/skills/azure-cost-calculator/references/services/security/defender-easm.md
@@ -16,7 +16,7 @@ primaryCost: "Per-asset daily rate × assetCount × 30 days/month"
 
 ### Standard: per billable asset per day
 
-ServiceName: Microsoft Defender for Cloud  <!-- cross-service -->
+ServiceName: Microsoft Defender for Cloud
 ProductName: Defender External Attack Surface Management
 SkuName: Defender EASM Standard
 MeterName: Defender EASM Standard Asset

--- a/skills/azure-cost-calculator/references/services/security/purview.md
+++ b/skills/azure-cost-calculator/references/services/security/purview.md
@@ -2,6 +2,7 @@
 serviceName: Microsoft Purview
 category: security
 aliases: [Data Governance, Data Catalog, Azure Purview, Purview Data Map, Data Estate Scanning]
+queryServiceNames: [Azure Purview]
 primaryCost: "Per-asset daily rates + per-unit processing (DSPU/DGPU) + hourly capacity units (classic)"
 hasFreeGrant: true
 privateEndpoint: true
@@ -41,7 +42,7 @@ MeterName: Standard Data Security Processing Unit
 
 ### Classic Data Map: capacity units (hourly)
 
-ServiceName: Azure Purview <!-- cross-service -->
+ServiceName: Azure Purview
 ProductName: Azure Purview Data Map
 SkuName: Standard
 MeterName: Standard Capacity Unit
@@ -51,7 +52,7 @@ InstanceCount: 2
 
 ### Classic Scanning: per vCore
 
-ServiceName: Azure Purview <!-- cross-service -->
+ServiceName: Azure Purview
 ProductName: Azure Purview Scanning Ingestion and Classification
 SkuName: Standard
 MeterName: Standard vCore

--- a/skills/azure-cost-calculator/references/services/specialist/health-bot.md
+++ b/skills/azure-cost-calculator/references/services/specialist/health-bot.md
@@ -20,20 +20,20 @@ privateEndpoint: true
 
 ### Health Bot: Agent Tier (per-action, recommended)
 
-ServiceName: Azure Bot Service <!-- cross-service -->
+ServiceName: Azure Bot Service
 ProductName: Microsoft Azure Health Bot
 SkuName: Agent Tier
 Quantity: 5000 # actions per month
 
 ### Health Bot: Standard tier (daily base + overage, legacy)
 
-ServiceName: Azure Bot Service <!-- cross-service -->
+ServiceName: Azure Bot Service
 ProductName: Microsoft Azure Health Bot
 SkuName: Standard
 
 ### Health Bot: Free tier
 
-ServiceName: Azure Bot Service <!-- cross-service -->
+ServiceName: Azure Bot Service
 ProductName: Microsoft Azure Health Bot
 SkuName: Free
 

--- a/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
@@ -17,7 +17,7 @@ primaryCost: "Standard daily service fee × 30 days/month; Azure Storage billed 
 
 ### Standard daily service fee: monthly total
 
-ServiceName: Data Box <!-- cross-service -->
+ServiceName: Data Box
 ProductName: Data Box Gateway
 SkuName: Standard
 MeterName: Standard Service Fee

--- a/skills/azure-cost-calculator/references/services/web/static-web-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/static-web-apps.md
@@ -22,14 +22,14 @@ privateEndpoint: true
 
 ### Standard plan: per-app monthly fee (use Region eastus2; eastus has no data)
 
-ServiceName: Azure App Service <!-- cross-service -->
+ServiceName: Azure App Service
 ProductName: Static Web Apps
 MeterName: Standard App
 Region: eastus2
 
 ### Bandwidth: pass Quantity with total GB to see per-tier unit prices
 
-ServiceName: Azure App Service <!-- cross-service -->
+ServiceName: Azure App Service
 ProductName: Static Web Apps
 MeterName: Standard Bandwidth Usage
 Quantity: 500
@@ -37,7 +37,7 @@ Region: eastus2
 
 ### Azure Front Door add-on (enterprise-grade edge, hourly)
 
-ServiceName: Azure App Service <!-- cross-service -->
+ServiceName: Azure App Service
 ProductName: Static Web Apps
 MeterName: Standard Azure Front Door Add-on
 Region: eastus2

--- a/tests/lib/validation/Test-ContentRule.ps1
+++ b/tests/lib/validation/Test-ContentRule.ps1
@@ -127,10 +127,45 @@ function Test-ContentRule {
                 -PassMessage 'No template instruction comments found' `
                 -FailMessage 'Found template instruction comments -- delete all <!-- INSTRUCTIONS FOR AUTHORS --> blocks before publishing'))
 
-    # Every ServiceName: in a query must match the YAML serviceName to avoid silent API mismatches
+    # Every ServiceName: in a query must match declared service metadata to avoid silent API mismatches
+    $parseServiceNameValues = {
+        param([AllowNull()][object]$Value)
+
+        if ($null -eq $Value) { return @() }
+
+        if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+            return @($Value | ForEach-Object {
+                    $_.ToString().Trim() -replace '^[''"]', '' -replace '[''"]$', ''
+                } | Where-Object { $_ })
+        }
+
+        $raw = $Value.ToString().Trim()
+        if (-not $raw) { return @() }
+
+        if ($raw -match '^\[(.*)\]$') {
+            return @($Matches[1] -split ',' | ForEach-Object {
+                    $_.Trim() -replace '^[''"]', '' -replace '[''"]$', ''
+                } | Where-Object { $_ })
+        }
+
+        @($raw -replace '^[''"]', '' -replace '[''"]$', '')
+    }
+
     $yamlValue = $null
+    $allowedServiceNames = [System.Collections.Generic.List[string]]::new()
     if ($FrontMatter.Found -and $FrontMatter.Fields.ContainsKey('serviceName')) {
         $yamlValue = $FrontMatter.Fields['serviceName'].Trim() -replace "^'|'$", ''
+        $allowedServiceNames.Add($yamlValue)
+    }
+    if ($FrontMatter.Found) {
+        foreach ($fieldName in @('apiServiceName', 'queryServiceNames', 'billingNeeds')) {
+            if (-not $FrontMatter.Fields.ContainsKey($fieldName)) { continue }
+            foreach ($serviceName in (& $parseServiceNameValues $FrontMatter.Fields[$fieldName])) {
+                if ($allowedServiceNames -notcontains $serviceName) {
+                    $allowedServiceNames.Add($serviceName)
+                }
+            }
+        }
     }
     $hasApiLines = @($Lines | Where-Object { $_ -match '^\s*API\s*:' }).Count -gt 0
     $serviceNameLines = [System.Collections.Generic.List[object]]::new()
@@ -159,18 +194,6 @@ function Test-ContentRule {
             $effective = $effective -replace '<!--.*$', ''
         }
         if ($effective -match '^\s*ServiceName\s*:\s*(.+)$') {
-            # cross-service ServiceName lines are intentionally different from YAML
-            if ($Lines[$i] -match '<!--\s*cross-service\s*-->') {
-                continue
-            }
-            # billingNeeds lists services billed under a different serviceName
-            if ($FrontMatter.Found -and $FrontMatter.Fields.ContainsKey('billingNeeds')) {
-                $rawNeeds = $FrontMatter.Fields['billingNeeds'] -replace '^\[|\]$', ''
-                $needsList = $rawNeeds -split ',' | ForEach-Object { $_.Trim() }
-                if ($needsList -contains $Matches[1].Trim()) {
-                    continue
-                }
-            }
             $serviceNameLines.Add(@{ Value = $Matches[1].Trim(); LineNum = $i + 1 })
         }
     }
@@ -193,20 +216,21 @@ function Test-ContentRule {
         $snMismatch = $null
         foreach ($entry in $serviceNameLines) {
             $queryValue = $entry.Value -replace "^'|'$", ''
-            if ($queryValue -ne $yamlValue) {
+            if ($allowedServiceNames -notcontains $queryValue) {
                 $snMismatch = @{ QueryValue = $queryValue; LineNum = $entry.LineNum; YamlValue = $yamlValue }
                 break
             }
         }
         if ($null -eq $snMismatch) {
             $checks.Add((New-ValidationCheck -Name 'servicename_consistency' -Pass $true `
-                        -PassMessage 'All ServiceName declarations match YAML front matter' `
+                        -PassMessage 'All ServiceName declarations match front matter service metadata' `
                         -FailMessage 'n/a'))
         }
         else {
+            $allowedDisplay = if ($allowedServiceNames.Count -gt 0) { $allowedServiceNames -join ', ' } else { 'none' }
             $checks.Add((New-ValidationCheck -Name 'servicename_consistency' -Pass $false `
                         -PassMessage 'n/a' `
-                        -FailMessage "ServiceName '$($snMismatch.QueryValue)' on line $($snMismatch.LineNum) does not match YAML serviceName '$($snMismatch.YamlValue)'"))
+                        -FailMessage "ServiceName '$($snMismatch.QueryValue)' on line $($snMismatch.LineNum) does not match allowed front matter service names: $allowedDisplay"))
         }
     }
 

--- a/tests/lib/validation/Test-FrontMatter.ps1
+++ b/tests/lib/validation/Test-FrontMatter.ps1
@@ -64,6 +64,7 @@ function Test-FrontMatter {
                         -FailMessage 'aliases field is present but empty - at least one alias is required'))
         }
 
+        # Validate category field if present: must be one of the allowed categories defined in config
         if ($FrontMatter.Fields.ContainsKey('category')) {
             $rawCategory = $FrontMatter.Fields['category'].Trim()
             $isValidCategory = $config.ValidCategories -contains $rawCategory
@@ -101,7 +102,24 @@ function Test-FrontMatter {
             if ($fieldName -in @('serviceName', 'category', 'aliases')) { continue }
             if (-not $FrontMatter.Fields.ContainsKey($fieldName)) { continue }
 
-            $rawValue = $FrontMatter.Fields[$fieldName].Trim() -replace '^[''"]', '' -replace '[''"]$', ''
+            $rawFieldValue = $FrontMatter.Fields[$fieldName].Trim()
+            $rawValue = $rawFieldValue -replace '^[''"]', '' -replace '[''"]$', ''
+
+            # Type: string vs array. String fields must not use array syntax; array fields must use it.
+            if ($fieldDef.Type -eq 'string') {
+                $isScalar = $rawFieldValue -notmatch '^\[.*\]$'
+                $checks.Add((New-ValidationCheck -Name "frontmatter_${fieldName}_type" -Pass $isScalar `
+                            -PassMessage "$fieldName is a scalar string" `
+                            -FailMessage "$fieldName must be a scalar string, got array syntax '$rawFieldValue'"))
+            }
+
+            # For array fields, check that value uses array syntax (e.g., [value1, value2])
+            if ($fieldDef.Type -eq 'array') {
+                $isArray = $rawFieldValue -match '^\[.*\]$'
+                $checks.Add((New-ValidationCheck -Name "frontmatter_${fieldName}_type" -Pass $isArray `
+                            -PassMessage "$fieldName uses array syntax" `
+                            -FailMessage "$fieldName must use array syntax like [value1, value2], got '$rawFieldValue'"))
+            }
 
             # Type: boolean. Must be 'true' or 'false'
             if ($fieldDef.Type -eq 'boolean') {

--- a/tests/schema/README.md
+++ b/tests/schema/README.md
@@ -29,11 +29,14 @@ This directory defines the YAML front matter schema for service reference files.
 
 ### API Identity (new)
 
-| Field            | Type   | Required | Default | Constraints | Description                                           |
-| ---------------- | ------ | :------: | ------- | ----------- | ----------------------------------------------------- |
-| `apiServiceName` | string |          | omit    | n/a         | API serviceName when it differs from the display name |
+| Field               | Type   | Required | Default | Constraints             | Description                                                     |
+| ------------------- | ------ | :------: | ------- | ----------------------- | --------------------------------------------------------------- |
+| `apiServiceName`    | string |          | omit    | n/a                     | API serviceName when it differs from the display name           |
+| `queryServiceNames` | array  |          | omit    | Free-form service names | Additional API serviceName values allowed in query pattern blocks |
 
 Use only when the Retail Prices API uses a different `serviceName` than the service's display name (e.g., VMware Solution → `Specialized Compute`, Static Web Apps → `Azure App Service`).
+
+Use `queryServiceNames` only when one service reference must include query blocks for additional Retail Prices API `ServiceName` values beyond `serviceName`, `apiServiceName`, or `billingNeeds`.
 
 ### Pricing Profile (new)
 
@@ -108,6 +111,7 @@ serviceName: Specialized Compute
 category: compute
 aliases: [Azure VMware Solution, AVS, VMware]
 apiServiceName: Specialized Compute
+queryServiceNames: [Related API Service]
 primaryCost: "Dedicated host hours (AV36P/AV48/AV52/AV64) × 730 × nodeCount"
 hasMeters: true
 pricingRegion: regional

--- a/tests/schema/frontmatter-schema.psd1
+++ b/tests/schema/frontmatter-schema.psd1
@@ -58,6 +58,11 @@
             Required    = $false
             Description = 'API serviceName when it differs from display serviceName (e.g., VMware Solution uses Specialized Compute)'
         }
+        queryServiceNames     = @{
+            Type        = 'array'
+            Required    = $false
+            Description = 'Additional API serviceName values allowed in query pattern ServiceName declarations'
+        }
 
         # ── Pricing Profile (new) ────────────────────────────────────────
         primaryCost           = @{
@@ -105,7 +110,7 @@
     FieldGroups        = @(
         @{ Name = 'Identity'; Fields = @('serviceName'; 'category'; 'aliases') }
         @{ Name = 'Billing Graph'; Fields = @('billingNeeds'; 'billingConsiderations') }
-        @{ Name = 'API Identity'; Fields = @('apiServiceName') }
+        @{ Name = 'API Identity'; Fields = @('apiServiceName'; 'queryServiceNames') }
         @{ Name = 'Pricing Profile'; Fields = @('primaryCost'; 'hasMeters'; 'pricingRegion'; 'hasKnownRates') }
         @{ Name = 'Service Capabilities'; Fields = @('hasFreeGrant'; 'privateEndpoint') }
     )

--- a/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
+++ b/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Test-ContentRule serviceName consistency' {
         function New-ServiceReferenceLines {
             param(
                 [string[]]$ExtraFrontMatter = @(),
-                [string[]]$QueryLines
+                [string[]]$QueryLines = @()
             )
 
             @(
@@ -36,7 +36,7 @@ Describe 'Test-ContentRule serviceName consistency' {
         function Invoke-ServiceNameConsistencyCheck {
             param(
                 [string[]]$ExtraFrontMatter = @(),
-                [string[]]$QueryLines
+                [string[]]$QueryLines = @()
             )
 
             $lines = New-ServiceReferenceLines -ExtraFrontMatter $ExtraFrontMatter -QueryLines $QueryLines

--- a/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
+++ b/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
@@ -1,0 +1,98 @@
+Describe 'Test-ContentRule serviceName consistency' {
+
+    BeforeAll {
+        $validationRoot = Join-Path $PSScriptRoot '../../../lib/validation'
+        . (Join-Path $validationRoot 'Get-FrontMatter.ps1')
+        . (Join-Path $validationRoot 'Test-ContentRule.ps1')
+
+        function New-ServiceReferenceLines {
+            param(
+                [string[]]$ExtraFrontMatter = @(),
+                [string[]]$QueryLines
+            )
+
+            @(
+                '---'
+                'serviceName: Display Service'
+                'category: compute'
+                'aliases: [Display Service]'
+            ) + $ExtraFrontMatter + @(
+                'primaryCost: "Hourly rate times quantity"'
+                '---'
+                '# Display Service'
+                ''
+                '## Query Pattern'
+            ) + $QueryLines + @(
+                'Quantity: 1'
+                ''
+                '## Cost Formula'
+                'Monthly = retailPrice * Quantity'
+                ''
+                '## Notes'
+                '- Test note'
+            )
+        }
+
+        function Invoke-ServiceNameConsistencyCheck {
+            param(
+                [string[]]$ExtraFrontMatter = @(),
+                [string[]]$QueryLines
+            )
+
+            $lines = New-ServiceReferenceLines -ExtraFrontMatter $ExtraFrontMatter -QueryLines $QueryLines
+            $frontMatter = Get-FrontMatter -Lines $lines
+            $checks = Test-ContentRule -Lines $lines -FrontMatter $frontMatter
+
+            foreach ($check in $checks) {
+                if ($check.Name -eq 'servicename_consistency') {
+                    return $check
+                }
+            }
+        }
+    }
+
+    It 'passes when ServiceName matches serviceName' {
+        $check = Invoke-ServiceNameConsistencyCheck -QueryLines @('ServiceName: Display Service')
+
+        $check.Pass | Should -BeTrue
+    }
+
+    It 'passes when ServiceName matches apiServiceName' {
+        $check = Invoke-ServiceNameConsistencyCheck `
+            -ExtraFrontMatter @('apiServiceName: API Service') `
+            -QueryLines @('ServiceName: API Service')
+
+        $check.Pass | Should -BeTrue
+    }
+
+    It 'passes when ServiceName matches queryServiceNames' {
+        $check = Invoke-ServiceNameConsistencyCheck `
+            -ExtraFrontMatter @('queryServiceNames: [Extra Service, Another Service]') `
+            -QueryLines @('ServiceName: Another Service')
+
+        $check.Pass | Should -BeTrue
+    }
+
+    It 'keeps allowing ServiceName values declared in billingNeeds' {
+        $check = Invoke-ServiceNameConsistencyCheck `
+            -ExtraFrontMatter @('billingNeeds: [Dependency Service]') `
+            -QueryLines @('ServiceName: Dependency Service')
+
+        $check.Pass | Should -BeTrue
+    }
+
+    It 'fails when ServiceName is not declared in front matter service metadata' {
+        $check = Invoke-ServiceNameConsistencyCheck -QueryLines @('ServiceName: Unknown Service')
+
+        $check.Pass | Should -BeFalse
+        $check.Message | Should -Match 'Unknown Service'
+    }
+
+    It 'does not treat the old cross-service comment as an override' {
+        $oldMarker = '<' + '!-- cross-service --' + '>'
+        $check = Invoke-ServiceNameConsistencyCheck -QueryLines @("ServiceName: Unknown Service $oldMarker")
+
+        $check.Pass | Should -BeFalse
+        $check.Message | Should -Match 'Unknown Service'
+    }
+}

--- a/tests/unit/powershell/validation/Test-FrontMatter.Tests.ps1
+++ b/tests/unit/powershell/validation/Test-FrontMatter.Tests.ps1
@@ -1,0 +1,76 @@
+Describe 'Test-FrontMatter schema type validation' {
+
+    BeforeAll {
+        $validationRoot = Join-Path $PSScriptRoot '../../../lib/validation'
+        . (Join-Path $validationRoot 'Get-FrontMatter.ps1')
+        . (Join-Path $validationRoot 'Test-FrontMatter.ps1')
+
+        function New-ServiceReferenceLines {
+            param(
+                [string[]]$ExtraFrontMatter = @()
+            )
+
+            @(
+                '---'
+                'serviceName: Display Service'
+                'category: compute'
+                'aliases: [Display Service]'
+            ) + $ExtraFrontMatter + @(
+                'primaryCost: "Hourly rate times quantity"'
+                '---'
+                '# Display Service'
+            )
+        }
+
+        function Invoke-FrontMatterChecks {
+            param(
+                [string[]]$ExtraFrontMatter = @()
+            )
+
+            $lines = New-ServiceReferenceLines -ExtraFrontMatter $ExtraFrontMatter
+            $frontMatter = Get-FrontMatter -Lines $lines
+            Test-FrontMatter `
+                -FrontMatter $frontMatter `
+                -FilePath 'skills/azure-cost-calculator/references/services/compute/display-service.md'
+        }
+
+        function Get-ValidationCheck {
+            param(
+                [object[]]$Checks,
+                [string]$Name
+            )
+
+            foreach ($check in $Checks) {
+                if ($check.Name -eq $Name) {
+                    return $check
+                }
+            }
+        }
+    }
+
+    It 'passes when apiServiceName is scalar and queryServiceNames is an array' {
+        $checks = Invoke-FrontMatterChecks -ExtraFrontMatter @(
+            'apiServiceName: API Service'
+            'queryServiceNames: [Extra Service]'
+        )
+
+        (Get-ValidationCheck -Checks $checks -Name 'frontmatter_apiServiceName_type').Pass | Should -BeTrue
+        (Get-ValidationCheck -Checks $checks -Name 'frontmatter_queryServiceNames_type').Pass | Should -BeTrue
+    }
+
+    It 'fails when apiServiceName uses array syntax' {
+        $checks = Invoke-FrontMatterChecks -ExtraFrontMatter @('apiServiceName: [API Service, Another API Service]')
+        $check = Get-ValidationCheck -Checks $checks -Name 'frontmatter_apiServiceName_type'
+
+        $check.Pass | Should -BeFalse
+        $check.Message | Should -Match 'scalar string'
+    }
+
+    It 'fails when queryServiceNames uses scalar syntax' {
+        $checks = Invoke-FrontMatterChecks -ExtraFrontMatter @('queryServiceNames: Extra Service')
+        $check = Get-ValidationCheck -Checks $checks -Name 'frontmatter_queryServiceNames_type'
+
+        $check.Pass | Should -BeFalse
+        $check.Message | Should -Match 'array syntax'
+    }
+}


### PR DESCRIPTION
## Summary
- replace inline cross-service HTML markers with frontmatter metadata
- add queryServiceNames support for query-only Retail Prices API ServiceName values
- update schema, template, docs, validation logic, and regression tests

## Issue #946 decision note
- Issue #946 originally framed suppression or baselining as the expected mitigation.
- During implementation planning, option 3 was selected instead: remove the HTML comment markers and preserve routing metadata through validated frontmatter.
- The issue acceptance criteria has been updated to match that approved mitigation.

## Validation
- pwsh tests/unit/Run-PesterTests.ps1 -OutputFormat Minimal
- pwsh tests/Validate-ServiceReference.ps1 -Path <changed service files> -CheckAliasUniqueness -CheckRoutingFileSync
- git diff --check
- service reference line-count check

Closes #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `queryServiceNames` field to service reference frontmatter for specifying additional allowed ServiceName values in pricing queries.

* **Documentation**
  * Standardized query pattern formatting across 30+ Azure service reference guides with explicit, consistent ServiceName specifications.
  * Updated contributing guidelines for service reference generation and query pattern rules.
  * Enhanced frontmatter schema documentation.

* **Tests**
  * Added unit test coverage for service name consistency validation rules.
  * Expanded frontmatter schema type validation test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
