### PR TITLE
fix: clarify entra domain services agency boundary #948

### DIFF
--- a/skills/azure-cost-calculator/references/services/identity/entra-domain-services.md
+++ b/skills/azure-cost-calculator/references/services/identity/entra-domain-services.md
@@ -70,8 +70,9 @@ Monthly = retailPrice × 730 × instanceCount
 
 ## Notes
 
+- **Cost-estimation scope**: Estimate costs only; do not create, modify, or delete managed domains, replica sets, trusts, load balancers, or public IPs without explicit user confirmation
 - **SKU tiers**: Standard (backups every 5 days, no trusts), Enterprise (every 3 days, up to 5 trusts), Premium (daily backups, 7+ trusts); SKU determines auth-load and object-count guidance
 - **Forest type** (never-assume): User Forest syncs from Entra ID; Resource Forest uses outbound trusts to on-prem AD. Standard only supports User Forest; same price within a SKU
-- **Billing dependency**: Azure auto-deploys a Standard Load Balancer and Public IP with every managed domain. Billed separately under `Load Balancer` and `IP Addresses`
+- **Billing dependency**: Each managed domain includes a Standard Load Balancer and Public IP that are billed separately under `Load Balancer` and `IP Addresses`
 - **Replica sets**: Each additional replica set (up to 5 per domain) is billed at the full SKU hourly rate
 - Related services billed separately: `Microsoft Entra ID` (identity platform), VMs that join the managed domain

--- a/skills/azure-cost-calculator/references/services/identity/entra-domain-services.md
+++ b/skills/azure-cost-calculator/references/services/identity/entra-domain-services.md
@@ -70,7 +70,7 @@ Monthly = retailPrice × 730 × instanceCount
 
 ## Notes
 
-- **Cost-estimation scope**: Estimate costs only; do not create, modify, or delete managed domains, replica sets, trusts, load balancers, or public IPs without explicit user confirmation
+- **Cost-estimation scope**: Estimate costs only; do not create, modify, or delete managed domains, replica sets, trusts, load balancers, or public IPs
 - **SKU tiers**: Standard (backups every 5 days, no trusts), Enterprise (every 3 days, up to 5 trusts), Premium (daily backups, 7+ trusts); SKU determines auth-load and object-count guidance
 - **Forest type** (never-assume): User Forest syncs from Entra ID; Resource Forest uses outbound trusts to on-prem AD. Standard only supports User Forest; same price within a SKU
 - **Billing dependency**: Each managed domain includes a Standard Load Balancer and Public IP that are billed separately under `Load Balancer` and `IP Addresses`

--- a/tests/evals/azure-cost-calculator/tasks/identity/entra-domain-services/standard-user-forest.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/identity/entra-domain-services/standard-user-forest.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/waza/v0.23.0/schemas/task.schema.json
+id: eval:identity/entra-domain-services/standard-user-forest
+name: Microsoft Entra Domain Services - Standard User Forest
+description: >
+  Tests cost estimation for Microsoft Entra Domain Services Standard User Forest.
+  Validates SKU and forest-type meter filtering, hourly billing, and instance
+  count scaling for managed domain estimates.
+tags:
+  - happy-path
+  - single-service
+  - identity
+  - service:entra-domain-services
+inputs:
+  prompt: "How much would 1 Microsoft Entra Domain Services Standard User Forest managed domain cost per month in East US?"
+expected:
+  output_contains:
+    - "Assumptions"
+    - "730"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Microsoft Entra Domain Services|Azure AD DS|AAD DS|Managed AD"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: sku-and-forest-acknowledged
+    config:
+      regex_match:
+        - "Standard User Forest|Standard.*User Forest|User Forest.*Standard"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "How much would 1 Microsoft Entra Domain Services Standard User Forest managed domain cost per month in East US?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using per-hour billing multiplied by 730 hours.
+        (3) Filters to the Standard User Forest meter for Microsoft Entra Domain Services.
+        (4) Accounts for 1 managed domain or replica set as specified.
+        (5) Mentions separately billed dependencies, such as Load Balancer or Public IP, without adding them unless explicitly priced.
+
+        Score 1.0 if all five criteria are met. Score 0.5 if three or four are met. Score 0.0 if fewer than three are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0


### PR DESCRIPTION
## Summary
- add an explicit cost-estimation-only guardrail to the Entra Domain Services reference
- reword the billing dependency note so it does not imply autonomous provisioning
- add the required happy-path eval coverage for Entra Domain Services

## Validation
- pwsh tests/Validate-ServiceReference.ps1 -Path skills/azure-cost-calculator/references/services/identity/entra-domain-services.md -CheckAliasUniqueness -CheckRoutingFileSync
- bash tests/check-eval-coverage.sh skills/azure-cost-calculator/references/services/identity/entra-domain-services.md
- waza check

Closes #948