### PR TITLE
version: v1.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-cost-calculator",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "Real-time Azure cost estimation using the Azure Retail Prices API",
   "author": {
     "name": "ahmadabdalla"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 <!-- versions -->
 
+## [1.8.0] - 2026-06-03
+
+### Added
+
+- Microsoft Discovery (`discovery.md`): new service reference for the Microsoft Discovery scientific platform
+- `SKILL.md`: new optional front matter field `queryServiceNames` for declaring additional allowed `ServiceName` values in query patterns
+- `service-routing.md`: routing entry and aliases for Microsoft Discovery
+- `pitfalls.md`: documented unsupported OData `not()` negation in the Retail Prices API (returns HTTP 400)
+- Azure AI Translator (`translator.md`): undocumented Translator (Global) meters and hourly billing formula
+- Azure Document Intelligence (`document-intelligence.md`): missing S0 batch meters
+- Azure App Service (`app-service.md`): Meter Names section
+- Azure Functions (`functions.md`): Key Fields section
+- Azure Container Apps (`container-apps.md`): Key Fields section
+- Azure Cosmos DB (`cosmos-db.md`): free-tier formula branch
+- Azure Cosmos DB Garnet Cache (`cosmos-db-garnet-cache.md`): missing General Purpose Burstable meter
+- Azure Kubernetes Service (`kubernetes-service.md`): Public IP billing dependency note
+
+### Changed
+
+- Azure AI Content Understanding (`ai-content-understanding.md`): meter name word-order fix, YAML cleanup, audited for happy-path eval
+- Azure AI Foundry Agents (`foundry-agents.md`): metadata refactor replacing cross-service markers
+- Azure Bot Service (`bot-service.md`): global-only trap expanded to include US Gov sovereign regions
+- Azure Machine Learning (`machine-learning.md`): trap wording refreshed, missing meters added, `primaryCost` shortened
+- Azure Machine Learning Studio (`machine-learning-studio.md`): stale regions list refreshed
+- Azure OpenAI Service (`openai-service.md`): YAML convention fix, undocumented products added, mixed-units trap clarified
+- Azure Managed Grafana (`managed-grafana.md`): audited and aligned with happy-path eval
+- Azure Managed Airflow (`managed-airflow.md`): audited and aligned with happy-path eval
+- Azure DNS Private Resolver (`dns-private-resolver.md`): audited for happy-path eval
+- Azure DNS Security Policy (`dns-security-policy.md`): audited for happy-path eval
+- Azure Private DNS (`private-dns.md`): audited for happy-path eval
+- Azure Virtual Network Manager (`virtual-network-manager.md`): audited for happy-path eval
+- Azure Public IP Addresses (`ip-addresses.md`): audited for happy-path eval
+- Microsoft Purview (`purview.md`): audited for happy-path eval
+- Microsoft Defender EASM (`defender-easm.md`): audited for happy-path eval
+- Azure Data Box Gateway (`data-box-gateway.md`): audited for happy-path eval
+- Azure Health Bot (`health-bot.md`): audited for happy-path eval
+- Azure Monitor SCOM Managed Instance (`scom-managed-instance.md`): audited for happy-path eval
+- Microsoft Entra Domain Services (`entra-domain-services.md`): clarified agency boundary
+- Service reference files across `ai-ml/`, `compute/`, `databases/`, `monitoring/`, `networking/`, `storage/`, `web/`: replaced cross-service comment markers with front matter metadata for consistency
+
+### Fixed
+
+- Azure Virtual Desktop (`windows-virtual-desktop.md`): H1 aligned with `serviceName`, missing billing caveats added
+- Azure Database for PostgreSQL (`database-for-postgresql.md`): stale Single Server status corrected
+- Azure Database for MySQL (`database-for-mysql.md`): retired Single Server wording removed, RI query guidance added
+- Azure Database for MariaDB (`database-for-mariadb.md`): updated to reflect retired status
+- Azure Redis Cache (`redis-cache.md`): title, Key Fields, Meter Names, and Cost Formula corrected
+- Azure SQL Managed Instance (`sql-managed-instance.md`): PAYG/AHUB formula double-counting fixed
+- Azure Database Migration Service (`database-migration-service.md`): clarified paid vs free meters and Premium free-period model
+- HorizonDB (`horizondb.md`): replaced underspecified limited-preview guidance
+- PowerShell scripts (`Get-AzurePricing.ps1`, `Explore-AzurePricing.ps1`, `lib/Build-ODataFilter.ps1`, `lib/Get-MonthlyMultiplier.ps1`, `lib/Invoke-RetailPricesQuery.ps1`): stripped UTF-8 BOM that broke `pwsh` execution on some platforms
+
 ## [1.7.3] - 2026-05-02
 
 ### Changed

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
 metadata:
   author: ahmadabdalla
-  version: "1.7.3"
+  version: "1.8.0"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
## Summary

Minor release: 1.7.3 → 1.8.0.

Bumps version, updates `CHANGELOG.md`, `.claude-plugin/plugin.json`, and `skills/azure-cost-calculator/SKILL.md`.

Mimics the `weekly-release` agent workflow (currently broken) per `docs/ops/weekly-release.md`. Stage 2 (`create-release-pr.yml`) and Stage 3 (`create-release.yml`) should run automatically once this merges to `dev`.

## Version bump rationale

**Minor (1.7.3 → 1.8.0)**: any `Added` entry triggers a minor bump under the project's SemVer rules.

- New service reference: Microsoft Discovery
- New optional `SKILL.md` front matter field: `queryServiceNames` (additive, backwards-compatible — existing files without it still work, so not `Breaking`)
- New cross-cutting pitfall: OData `not()` negation
- Plus many service reference fixes and improvements across `ai-ml/`, `compute/`, `databases/`, `networking/`, `monitoring/`, `storage/`

## Stats

- 39 commits ahead of `main`
- 1 service added, ~30 service references modified
- 5 PowerShell scripts fixed (BOM strip)

## Changelog entry

### Added

- Microsoft Discovery (`discovery.md`): new service reference for the Microsoft Discovery scientific platform
- `SKILL.md`: new optional front matter field `queryServiceNames` for declaring additional allowed `ServiceName` values in query patterns
- `service-routing.md`: routing entry and aliases for Microsoft Discovery
- `pitfalls.md`: documented unsupported OData `not()` negation in the Retail Prices API (returns HTTP 400)
- Azure AI Translator (`translator.md`): undocumented Translator (Global) meters and hourly billing formula
- Azure Document Intelligence (`document-intelligence.md`): missing S0 batch meters
- Azure App Service (`app-service.md`): Meter Names section
- Azure Functions (`functions.md`): Key Fields section
- Azure Container Apps (`container-apps.md`): Key Fields section
- Azure Cosmos DB (`cosmos-db.md`): free-tier formula branch
- Azure Cosmos DB Garnet Cache (`cosmos-db-garnet-cache.md`): missing General Purpose Burstable meter
- Azure Kubernetes Service (`kubernetes-service.md`): Public IP billing dependency note

### Changed

- Azure AI Content Understanding (`ai-content-understanding.md`): meter name word-order fix, YAML cleanup, audited for happy-path eval
- Azure AI Foundry Agents (`foundry-agents.md`): metadata refactor replacing cross-service markers
- Azure Bot Service (`bot-service.md`): global-only trap expanded to include US Gov sovereign regions
- Azure Machine Learning (`machine-learning.md`): trap wording refreshed, missing meters added, `primaryCost` shortened
- Azure Machine Learning Studio (`machine-learning-studio.md`): stale regions list refreshed
- Azure OpenAI Service (`openai-service.md`): YAML convention fix, undocumented products added, mixed-units trap clarified
- Azure Managed Grafana (`managed-grafana.md`): audited and aligned with happy-path eval
- Azure Managed Airflow (`managed-airflow.md`): audited and aligned with happy-path eval
- Azure DNS Private Resolver (`dns-private-resolver.md`): audited for happy-path eval
- Azure DNS Security Policy (`dns-security-policy.md`): audited for happy-path eval
- Azure Private DNS (`private-dns.md`): audited for happy-path eval
- Azure Virtual Network Manager (`virtual-network-manager.md`): audited for happy-path eval
- Azure Public IP Addresses (`ip-addresses.md`): audited for happy-path eval
- Microsoft Purview (`purview.md`): audited for happy-path eval
- Microsoft Defender EASM (`defender-easm.md`): audited for happy-path eval
- Azure Data Box Gateway (`data-box-gateway.md`): audited for happy-path eval
- Azure Health Bot (`health-bot.md`): audited for happy-path eval
- Azure Monitor SCOM Managed Instance (`scom-managed-instance.md`): audited for happy-path eval
- Microsoft Entra Domain Services (`entra-domain-services.md`): clarified agency boundary
- Service reference files across `ai-ml/`, `compute/`, `databases/`, `monitoring/`, `networking/`, `storage/`, `web/`: replaced cross-service comment markers with front matter metadata for consistency

### Fixed

- Azure Virtual Desktop (`windows-virtual-desktop.md`): H1 aligned with `serviceName`, missing billing caveats added
- Azure Database for PostgreSQL (`database-for-postgresql.md`): stale Single Server status corrected
- Azure Database for MySQL (`database-for-mysql.md`): retired Single Server wording removed, RI query guidance added
- Azure Database for MariaDB (`database-for-mariadb.md`): updated to reflect retired status
- Azure Redis Cache (`redis-cache.md`): title, Key Fields, Meter Names, and Cost Formula corrected
- Azure SQL Managed Instance (`sql-managed-instance.md`): PAYG/AHUB formula double-counting fixed
- Azure Database Migration Service (`database-migration-service.md`): clarified paid vs free meters and Premium free-period model
- HorizonDB (`horizondb.md`): replaced underspecified limited-preview guidance
- PowerShell scripts (`Get-AzurePricing.ps1`, `Explore-AzurePricing.ps1`, `lib/Build-ODataFilter.ps1`, `lib/Get-MonthlyMultiplier.ps1`, `lib/Invoke-RetailPricesQuery.ps1`): stripped UTF-8 BOM that broke `pwsh` execution on some platforms

---

Issue references: #945, #946, #948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.8.0

* **Bug Fixes**
  * Fixed PowerShell script execution failures on certain platforms.

* **Chores**
  * Version bumped to 1.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->