### PR TITLE
feat: skill security scanning pipeline (NVIDIA SkillSpector)

### DIFF
--- a/.github/scripts/security/check-skillspector-threshold.sh
+++ b/.github/scripts/security/check-skillspector-threshold.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------
+# check-skillspector-threshold.sh
+# ---------------------------------------------------------
+# Parses a SkillSpector JSON report and exits non-zero when
+# the assessed severity meets or exceeds the failure threshold.
+#
+# Used as the gating step in .github/workflows/skill-security-scan.yml
+# because the SkillSpector CLI does not provide a --fail-on flag of
+# its own.
+#
+# Usage:
+#   check-skillspector-threshold.sh <path-to-skillspector.json>
+#
+# Optional env vars:
+#   SKILLSPECTOR_FAIL_ON  Comma-separated severities that cause exit 1.
+#                         Default: "HIGH,CRITICAL". Severities are matched
+#                         case-insensitively against risk_assessment.severity.
+#
+# Exit codes:
+#   0  severity is below the failure threshold (gate passes)
+#   1  severity meets or exceeds the failure threshold (gate fails)
+#   2  input error: missing file, invalid JSON, or missing field
+#
+# SkillSpector JSON schema (relevant fields):
+#   .risk_assessment.score          integer 0-100
+#   .risk_assessment.severity       "LOW" | "MEDIUM" | "HIGH" | "CRITICAL"
+#   .risk_assessment.recommendation "SAFE" | "CAUTION" | "DO_NOT_INSTALL"
+#   .issues                         array of findings
+# ---------------------------------------------------------
+
+set -euo pipefail
+
+REPORT_PATH="${1:-}"
+FAIL_ON="${SKILLSPECTOR_FAIL_ON:-HIGH,CRITICAL}"
+
+if [ -z "$REPORT_PATH" ]; then
+  echo "::error::Usage: check-skillspector-threshold.sh <path-to-skillspector.json>"
+  exit 2
+fi
+
+if [ ! -f "$REPORT_PATH" ]; then
+  echo "::error::Report file not found: $REPORT_PATH"
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required but not installed."
+  exit 2
+fi
+
+# Validate JSON parses before we try to read fields.
+if ! jq empty "$REPORT_PATH" >/dev/null 2>&1; then
+  echo "::error::Report is not valid JSON: $REPORT_PATH"
+  exit 2
+fi
+
+SEVERITY="$(jq -r '.risk_assessment.severity // empty' "$REPORT_PATH")"
+SCORE="$(jq -r '.risk_assessment.score // empty' "$REPORT_PATH")"
+RECOMMENDATION="$(jq -r '.risk_assessment.recommendation // empty' "$REPORT_PATH")"
+ISSUE_COUNT="$(jq -r '.issues | length // 0' "$REPORT_PATH")"
+
+if [ -z "$SEVERITY" ]; then
+  echo "::error::Missing field .risk_assessment.severity in $REPORT_PATH"
+  exit 2
+fi
+
+# Normalise to uppercase for comparison.
+SEVERITY_UPPER="$(printf '%s' "$SEVERITY" | tr '[:lower:]' '[:upper:]')"
+FAIL_ON_UPPER="$(printf '%s' "$FAIL_ON" | tr '[:lower:]' '[:upper:]')"
+
+# Match SEVERITY_UPPER against the comma-separated FAIL_ON list.
+FAIL=0
+IFS=',' read -r -a FAIL_LIST <<< "$FAIL_ON_UPPER"
+for entry in "${FAIL_LIST[@]}"; do
+  trimmed="$(printf '%s' "$entry" | tr -d '[:space:]')"
+  if [ "$SEVERITY_UPPER" = "$trimmed" ]; then
+    FAIL=1
+    break
+  fi
+done
+
+# Always print a human-readable summary so the job log is self-explanatory.
+echo "SkillSpector report: $REPORT_PATH"
+echo "  Score:          ${SCORE:-unknown}/100"
+echo "  Severity:       ${SEVERITY_UPPER}"
+echo "  Recommendation: ${RECOMMENDATION:-unknown}"
+echo "  Issues:         ${ISSUE_COUNT}"
+echo "  Fail threshold: ${FAIL_ON_UPPER}"
+
+# Write the same summary to the GitHub Actions step summary when available.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### SkillSpector security gate"
+    echo
+    echo "| Metric | Value |"
+    echo "|---|---|"
+    echo "| Score | ${SCORE:-unknown}/100 |"
+    echo "| Severity | ${SEVERITY_UPPER} |"
+    echo "| Recommendation | ${RECOMMENDATION:-unknown} |"
+    echo "| Issues | ${ISSUE_COUNT} |"
+    echo "| Fail threshold | ${FAIL_ON_UPPER} |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$FAIL" -eq 1 ]; then
+  echo "::error::SkillSpector severity ${SEVERITY_UPPER} meets fail threshold (${FAIL_ON_UPPER}). Blocking merge."
+  exit 1
+fi
+
+echo "SkillSpector gate passed."
+exit 0

--- a/.github/scripts/security/check-skillspector-threshold.sh
+++ b/.github/scripts/security/check-skillspector-threshold.sh
@@ -87,6 +87,18 @@ severity_rank() {
   esac
 }
 
+# Inverse of severity_rank: turn a numeric rank back into its severity name so
+# the log can show the effective gate, not just the configured FAIL_ON list.
+rank_severity() {
+  case "$1" in
+    1) printf 'LOW' ;;
+    2) printf 'MEDIUM' ;;
+    3) printf 'HIGH' ;;
+    4) printf 'CRITICAL' ;;
+    *) printf 'UNKNOWN' ;;
+  esac
+}
+
 SEVERITY_RANK="$(severity_rank "$SEVERITY_UPPER")"
 if [ "$SEVERITY_RANK" -eq 0 ]; then
   echo "::error::Unrecognized severity '${SEVERITY_UPPER}' in $REPORT_PATH"
@@ -114,6 +126,10 @@ if [ "$THRESHOLD_RANK" -eq 0 ]; then
   exit 2
 fi
 
+# Effective threshold severity (lowest-ranked entry in FAIL_ON). The gate fails
+# at this severity or higher, regardless of how FAIL_ON was written.
+THRESHOLD_LABEL="$(rank_severity "$THRESHOLD_RANK")"
+
 # Fail when the report severity is at or above the threshold.
 FAIL=0
 if [ "$SEVERITY_RANK" -ge "$THRESHOLD_RANK" ]; then
@@ -126,7 +142,7 @@ echo "  Score:          ${SCORE:-unknown}/100"
 echo "  Severity:       ${SEVERITY_UPPER}"
 echo "  Recommendation: ${RECOMMENDATION:-unknown}"
 echo "  Issues:         ${ISSUE_COUNT}"
-echo "  Fail threshold: ${FAIL_ON_UPPER}"
+echo "  Fail threshold: ${THRESHOLD_LABEL} or higher (configured: ${FAIL_ON_UPPER})"
 
 # Write the same summary to the GitHub Actions step summary when available.
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
@@ -139,12 +155,12 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| Severity | ${SEVERITY_UPPER} |"
     echo "| Recommendation | ${RECOMMENDATION:-unknown} |"
     echo "| Issues | ${ISSUE_COUNT} |"
-    echo "| Fail threshold | ${FAIL_ON_UPPER} |"
+    echo "| Fail threshold | ${THRESHOLD_LABEL} or higher (configured: ${FAIL_ON_UPPER}) |"
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
 if [ "$FAIL" -eq 1 ]; then
-  echo "::error::SkillSpector severity ${SEVERITY_UPPER} meets fail threshold (${FAIL_ON_UPPER}). Blocking merge."
+  echo "::error::SkillSpector severity ${SEVERITY_UPPER} meets fail threshold ${THRESHOLD_LABEL} or higher (configured: ${FAIL_ON_UPPER}). Blocking merge."
   exit 1
 fi
 

--- a/.github/scripts/security/check-skillspector-threshold.sh
+++ b/.github/scripts/security/check-skillspector-threshold.sh
@@ -13,14 +13,20 @@
 #   check-skillspector-threshold.sh <path-to-skillspector.json>
 #
 # Optional env vars:
-#   SKILLSPECTOR_FAIL_ON  Comma-separated severities that cause exit 1.
-#                         Default: "HIGH,CRITICAL". Severities are matched
-#                         case-insensitively against risk_assessment.severity.
+#   SKILLSPECTOR_FAIL_ON  Failure threshold (not an exact-match list). The gate
+#                         fails when the report severity rank is at or above the
+#                         lowest-ranked severity listed here. Accepts a single
+#                         severity ("HIGH") or a comma-separated list kept for
+#                         backward compatibility ("HIGH,CRITICAL"); the minimum
+#                         rank in the list is used as the threshold. Matched
+#                         case-insensitively. Default: "HIGH,CRITICAL".
+#                         Rank order: LOW < MEDIUM < HIGH < CRITICAL.
 #
 # Exit codes:
 #   0  severity is below the failure threshold (gate passes)
 #   1  severity meets or exceeds the failure threshold (gate fails)
-#   2  input error: missing file, invalid JSON, or missing field
+#   2  input error: missing file, invalid JSON, missing field, or an
+#      unrecognized severity in the report or in SKILLSPECTOR_FAIL_ON
 #
 # SkillSpector JSON schema (relevant fields):
 #   .risk_assessment.score          integer 0-100
@@ -69,16 +75,50 @@ fi
 SEVERITY_UPPER="$(printf '%s' "$SEVERITY" | tr '[:lower:]' '[:upper:]')"
 FAIL_ON_UPPER="$(printf '%s' "$FAIL_ON" | tr '[:lower:]' '[:upper:]')"
 
-# Match SEVERITY_UPPER against the comma-separated FAIL_ON list.
-FAIL=0
+# Rank severities so the threshold is an ordering, not exact membership.
+# Unknown severities return rank 0 and are treated as input errors.
+severity_rank() {
+  case "$1" in
+    LOW) printf '1' ;;
+    MEDIUM) printf '2' ;;
+    HIGH) printf '3' ;;
+    CRITICAL) printf '4' ;;
+    *) printf '0' ;;
+  esac
+}
+
+SEVERITY_RANK="$(severity_rank "$SEVERITY_UPPER")"
+if [ "$SEVERITY_RANK" -eq 0 ]; then
+  echo "::error::Unrecognized severity '${SEVERITY_UPPER}' in $REPORT_PATH"
+  exit 2
+fi
+
+# Threshold = lowest rank among the configured FAIL_ON severities.
+THRESHOLD_RANK=0
 IFS=',' read -r -a FAIL_LIST <<< "$FAIL_ON_UPPER"
 for entry in "${FAIL_LIST[@]}"; do
   trimmed="$(printf '%s' "$entry" | tr -d '[:space:]')"
-  if [ "$SEVERITY_UPPER" = "$trimmed" ]; then
-    FAIL=1
-    break
+  [ -z "$trimmed" ] && continue
+  rank="$(severity_rank "$trimmed")"
+  if [ "$rank" -eq 0 ]; then
+    echo "::error::Unrecognized severity '${trimmed}' in SKILLSPECTOR_FAIL_ON"
+    exit 2
+  fi
+  if [ "$THRESHOLD_RANK" -eq 0 ] || [ "$rank" -lt "$THRESHOLD_RANK" ]; then
+    THRESHOLD_RANK="$rank"
   fi
 done
+
+if [ "$THRESHOLD_RANK" -eq 0 ]; then
+  echo "::error::SKILLSPECTOR_FAIL_ON contains no recognized severity."
+  exit 2
+fi
+
+# Fail when the report severity is at or above the threshold.
+FAIL=0
+if [ "$SEVERITY_RANK" -ge "$THRESHOLD_RANK" ]; then
+  FAIL=1
+fi
 
 # Always print a human-readable summary so the job log is self-explanatory.
 echo "SkillSpector report: $REPORT_PATH"

--- a/.github/scripts/security/normalize-skillspector-sarif.sh
+++ b/.github/scripts/security/normalize-skillspector-sarif.sh
@@ -75,7 +75,7 @@ PREFIX="${PREFIX%/}"
 # satisfies this character class and carries no "..", so idempotent re-runs
 # stay safe, while a hostile prefixed uri carrying ".." is still rejected.
 # Everything else is hostile.
-UNSAFE="$(jq -r --arg p "$PREFIX" '
+UNSAFE="$(jq -r '
   [ .runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri
     | select(. != null and . != "")
     | select(

--- a/.github/scripts/security/normalize-skillspector-sarif.sh
+++ b/.github/scripts/security/normalize-skillspector-sarif.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------
+# normalize-skillspector-sarif.sh
+# ---------------------------------------------------------
+# Rewrites the artifactLocation.uri values in a SkillSpector
+# SARIF report so they are repository-relative instead of
+# skill-directory-relative.
+#
+# WHY THIS EXISTS
+# SkillSpector records component paths relative to the scanned
+# skill directory (see build_context.py: rel = item.relative_to(
+# skill_dir)). So a finding in skills/azure-cost-calculator/SKILL.md
+# is emitted as uri "SKILL.md", not "skills/azure-cost-calculator/
+# SKILL.md". GitHub code scanning resolves SARIF uris against the
+# repository root, so without this rewrite every alert lands on the
+# wrong path (or is dropped). This prepends the skill path to each
+# uri so alerts annotate the correct file on the PR diff.
+#
+# FAIL-CLOSED SANITISATION
+# The uri is the only fork-influenced value uploaded to code
+# scanning. A crafted uri (absolute path, URL scheme, backslash, or
+# ".." traversal) could mislocate an alert onto an unrelated victim
+# file. Any uri that is not a plain, in-tree relative path is
+# treated as hostile and the script exits non-zero (exit 3) so the
+# caller blocks rather than uploads a poisoned report.
+#
+# Usage:
+#   normalize-skillspector-sarif.sh <path-to.sarif> <path-prefix>
+#
+# Arguments:
+#   <path-to.sarif>  SARIF file to rewrite in place.
+#   <path-prefix>    Repo-relative skill directory, no trailing slash
+#                    (e.g. skills/azure-cost-calculator).
+#
+# Exit codes:
+#   0  rewrite succeeded (file modified in place)
+#   2  input error: missing args, missing file, invalid JSON, no jq
+#   3  unsafe uri detected: nothing written, caller must fail closed
+# ---------------------------------------------------------
+
+set -euo pipefail
+
+SARIF_PATH="${1:-}"
+PREFIX="${2:-}"
+
+if [ -z "$SARIF_PATH" ] || [ -z "$PREFIX" ]; then
+  echo "::error::Usage: normalize-skillspector-sarif.sh <path-to.sarif> <path-prefix>"
+  exit 2
+fi
+
+if [ ! -f "$SARIF_PATH" ]; then
+  echo "::error::SARIF file not found: $SARIF_PATH"
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required but not installed."
+  exit 2
+fi
+
+if ! jq empty "$SARIF_PATH" >/dev/null 2>&1; then
+  echo "::error::SARIF is not valid JSON: $SARIF_PATH"
+  exit 2
+fi
+
+# Strip any trailing slash so we control the single separator we add.
+PREFIX="${PREFIX%/}"
+
+# A uri is acceptable when it is EITHER already prefixed (idempotent
+# re-runs) OR a plain in-tree relative path: the safe character class
+# below excludes ":" (schemes), "\" (Windows separators), "%" (encoded
+# traversal) and leading "/" (absolute), and the second test rejects any
+# ".." path segment. Everything else is hostile.
+UNSAFE="$(jq -r --arg p "$PREFIX" '
+  [ .runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri
+    | select(. != null and . != "")
+    | select(
+        ( startswith($p + "/") )
+        or (
+          test("^[A-Za-z0-9._-][A-Za-z0-9._/-]*$")
+          and ( test("(^|/)\\.\\.(/|$)") | not )
+        )
+        | not
+      )
+  ] | unique | .[]
+' "$SARIF_PATH")"
+
+if [ -n "$UNSAFE" ]; then
+  echo "::error::Refusing to upload SkillSpector SARIF: unsafe artifact uri(s) detected:"
+  printf '%s\n' "$UNSAFE" | while IFS= read -r u; do
+    printf '::error::  %s\n' "$u"
+  done
+  exit 3
+fi
+
+TMP="$(mktemp)"
+jq --arg p "$PREFIX" '
+  ( .runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri ) |=
+    ( if (. == null or . == "") then .
+      elif startswith($p + "/") then .
+      else $p + "/" + . end )
+' "$SARIF_PATH" > "$TMP"
+mv "$TMP" "$SARIF_PATH"
+
+echo "Normalised SkillSpector SARIF uris under prefix: $PREFIX/"
+exit 0

--- a/.github/scripts/security/normalize-skillspector-sarif.sh
+++ b/.github/scripts/security/normalize-skillspector-sarif.sh
@@ -66,20 +66,21 @@ fi
 # Strip any trailing slash so we control the single separator we add.
 PREFIX="${PREFIX%/}"
 
-# A uri is acceptable when it is EITHER already prefixed (idempotent
-# re-runs) OR a plain in-tree relative path: the safe character class
-# below excludes ":" (schemes), "\" (Windows separators), "%" (encoded
-# traversal) and leading "/" (absolute), and the second test rejects any
-# ".." path segment. Everything else is hostile.
+# A uri is acceptable only when it is a plain in-tree relative path: the
+# safe character class below excludes ":" (schemes), "\" (Windows
+# separators), "%" (encoded traversal) and leading "/" (absolute), and the
+# second test rejects any ".." path segment. We deliberately do NOT let an
+# existing prefix short-circuit the traversal check: a legitimate
+# already-prefixed uri (e.g. skills/azure-cost-calculator/SKILL.md) still
+# satisfies this character class and carries no "..", so idempotent re-runs
+# stay safe, while a hostile prefixed uri carrying ".." is still rejected.
+# Everything else is hostile.
 UNSAFE="$(jq -r --arg p "$PREFIX" '
   [ .runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri
     | select(. != null and . != "")
     | select(
-        ( startswith($p + "/") )
-        or (
-          test("^[A-Za-z0-9._-][A-Za-z0-9._/-]*$")
-          and ( test("(^|/)\\.\\.(/|$)") | not )
-        )
+        ( test("^[A-Za-z0-9._-][A-Za-z0-9._/-]*$")
+          and ( test("(^|/)\\.\\.(/|$)") | not ) )
         | not
       )
   ] | unique | .[]

--- a/.github/workflows/skill-security-scan-upload.yml
+++ b/.github/workflows/skill-security-scan-upload.yml
@@ -90,7 +90,13 @@ jobs:
           # Resolve the PR number from the authoritative head sha. Strictly
           # filter so a shared sha or a closed/cross-base PR can never select
           # the wrong target; refuse to guess on zero or multiple matches.
-          pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" 2>/dev/null || echo '[]')"
+          # A non-zero exit here is a transport/permission failure, not a
+          # "no PR" signal (that endpoint returns an empty array with HTTP
+          # 200). Fail loud rather than fail open, consistent with line 82.
+          if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls")"; then
+            echo "::error::Failed to resolve pull requests for ${HEAD_SHA}."
+            exit 1
+          fi
           numbers="$(printf '%s' "$pulls" | jq -r \
             --arg sha "$HEAD_SHA" --arg repo "$REPO" --arg head "$HEAD_REPO" '
               [ .[]

--- a/.github/workflows/skill-security-scan-upload.yml
+++ b/.github/workflows/skill-security-scan-upload.yml
@@ -1,0 +1,140 @@
+# ---------------------------------------------------------
+# Skill Security Scan Upload (trusted SARIF publisher)
+# ---------------------------------------------------------
+# SECOND half of the two-workflow split. The scan workflow
+# (skill-security-scan.yml) runs in the untrusted PR context
+# and produces a normalised SARIF artifact. This workflow runs
+# in the TRUSTED base-repository context via workflow_run, so it
+# is the only place that holds security-events: write. It takes
+# the artifact and uploads it to code scanning.
+#
+# WHY A SEPARATE WORKFLOW
+# On pull_request from a fork, GITHUB_TOKEN is read-only and
+# security-events: write cannot be granted, so the scan workflow
+# cannot upload SARIF itself. workflow_run always runs with the
+# base repo's permissions regardless of the PR origin, which is
+# how fork PRs still get inline code scanning annotations.
+#
+# THREAT MODEL
+# This workflow has write scope and could be attacked via the
+# artifact it consumes. Mitigations:
+#   - It NEVER checks out or executes PR/fork code.
+#   - The PR head sha is taken from the authoritative workflow_run
+#     event (github.event.workflow_run.head_sha), never from the
+#     artifact, so it cannot be spoofed.
+#   - The PR number is resolved from the commit->PRs API and
+#     strictly filtered (open, head sha, head repo, base repo,
+#     base branch); ambiguous matches are skipped, never guessed.
+#   - The scan workflow only publishes the SARIF artifact after
+#     its normaliser has validated every uri, so a poisoned SARIF
+#     is never produced for this workflow to upload.
+#
+# OPERATIONAL DOCS: docs/ops/skill-security-scan.md
+# ---------------------------------------------------------
+
+name: Skill Security Scan Upload
+
+on:
+  workflow_run:
+    workflows: ["Skill Security Scan"]
+    types: [completed]
+
+# --- Security: write scope lives only here, in the trusted context ---
+permissions:
+  contents: read
+  actions: read # download the artifact from the triggering run
+  pull-requests: read # resolve the PR number from the head sha
+  security-events: write # upload SARIF to code scanning
+
+jobs:
+  upload-sarif:
+    name: Publish SkillSpector SARIF
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Only act on PR-triggered runs that actually finished a scan.
+    # success = gate passed; failure = gate blocked but we still want
+    # the findings visible. Other conclusions (cancelled/skipped/
+    # timed_out) have no SARIF worth publishing.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["success","failure"]'), github.event.workflow_run.conclusion)
+
+    env:
+      ARTIFACT_NAME: skillspector-sarif
+      SARIF_CATEGORY: skillspector
+
+    steps:
+      # --- Step 1: Resolve the PR and confirm the artifact exists ---
+      - name: Resolve PR and verify artifact
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          set -euo pipefail
+
+          # The SARIF artifact is absent when the scan was path-skipped or
+          # blocked before publishing. That is a clean no-op, not an error.
+          artifacts="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts")"
+          have="$(printf '%s' "$artifacts" | jq --arg n "$ARTIFACT_NAME" '[.artifacts[] | select(.name == $n)] | length')"
+          if [ "$have" -eq 0 ]; then
+            echo "No ${ARTIFACT_NAME} artifact on run ${RUN_ID}; nothing to publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Resolve the PR number from the authoritative head sha. Strictly
+          # filter so a shared sha or a closed/cross-base PR can never select
+          # the wrong target; refuse to guess on zero or multiple matches.
+          pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" 2>/dev/null || echo '[]')"
+          numbers="$(printf '%s' "$pulls" | jq -r \
+            --arg sha "$HEAD_SHA" --arg repo "$REPO" --arg head "$HEAD_REPO" '
+              [ .[]
+                | select(.state == "open")
+                | select(.head.sha == $sha)
+                | select(.head.repo.full_name == $head)
+                | select(.base.repo.full_name == $repo)
+                | select(.base.ref == "dev" or .base.ref == "main")
+                | .number ] | unique | .[]')"
+
+          count="$(printf '%s\n' "$numbers" | grep -c . || true)"
+          if [ "$count" -ne 1 ]; then
+            echo "::warning::Could not unambiguously resolve an open PR for ${HEAD_SHA} (matches: ${count}); skipping SARIF upload."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "skip=false"
+            echo "pr_number=${numbers}"
+            echo "head_sha=${HEAD_SHA}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #${numbers} at ${HEAD_SHA}."
+
+      # --- Step 2: Download the SARIF artifact from the triggering run ---
+      - name: Download SARIF artifact
+        if: steps.resolve.outputs.skip == 'false'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: skillspector-sarif
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: sarif
+
+      # --- Step 3: Publish to code scanning against the PR head ---
+      # ref + sha are an explicit, consistent pairing: head_sha is the tip
+      # of refs/pull/<n>/head and matches the commit the scan workflow
+      # checked out. No checkout here, so no fork code runs; uris are
+      # already repo-relative from the scan workflow's normaliser.
+      - name: Upload SARIF to code scanning
+        if: steps.resolve.outputs.skip == 'false'
+        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17 # v3
+        with:
+          sarif_file: sarif/skillspector.sarif
+          category: ${{ env.SARIF_CATEGORY }}
+          ref: refs/pull/${{ steps.resolve.outputs.pr_number }}/head
+          sha: ${{ steps.resolve.outputs.head_sha }}

--- a/.github/workflows/skill-security-scan.yml
+++ b/.github/workflows/skill-security-scan.yml
@@ -1,0 +1,175 @@
+# ---------------------------------------------------------
+# Skill Security Scan (scan + gate)
+# ---------------------------------------------------------
+# Runs SkillSpector (https://github.com/NVIDIA/skillspector)
+# against the azure-cost-calculator skill on every pull
+# request, blocking merge when the assessed severity meets
+# the fail threshold (HIGH or CRITICAL by default).
+#
+# This is the FIRST half of a two-workflow split. It runs in
+# the (potentially fork) PR context and therefore holds NO
+# elevated permissions and never uploads to code scanning
+# itself. It produces the SARIF as an artifact; the trusted
+# companion workflow skill-security-scan-upload.yml publishes
+# it to code scanning via workflow_run. See the ops doc for
+# why this split exists.
+#
+# HOW IT WORKS
+# 1. Triggered on EVERY pull request to dev/main (no top-level
+#    paths: filter; required so branch protection always sees a
+#    status). dorny/paths-filter exits early when nothing under
+#    skills/azure-cost-calculator/** changed.
+# 2. Checks out the PR HEAD commit (not the merge commit) so the
+#    scanned tree matches the head_sha the upload workflow will
+#    associate the results with.
+# 3. Installs SkillSpector pinned to a commit SHA so the gate
+#    cannot silently change behaviour under us.
+# 4. Scans twice (both --no-llm for reproducibility): SARIF for
+#    code scanning, JSON for the threshold gate.
+# 5. Normalises SARIF uris to be repo-relative and fails closed
+#    on any hostile (traversing/absolute/url) uri.
+# 6. The threshold gate (check-skillspector-threshold.sh) is the
+#    REQUIRED, blocking check.
+# 7. Publishes the normalised SARIF and the JSON as artifacts
+#    (always(), so reviewers and the upload workflow still get
+#    them when the gate fails).
+#
+# OPERATIONAL DOCS: docs/ops/skill-security-scan.md
+# ---------------------------------------------------------
+
+name: Skill Security Scan
+
+# --- When does this workflow run? ---
+# On ALL pull requests targeting dev or main. We intentionally omit
+# the paths: filter so the workflow always runs and reports a status
+# to satisfy required-check branch protection rules. Path filtering
+# is handled inside the job using dorny/paths-filter instead.
+on:
+  pull_request:
+    branches: [dev, main]
+
+# --- Security: least-privilege ---
+# This job may run fork-authored content, so it gets NO write scopes.
+# SARIF is published to code scanning by the trusted companion
+# workflow (skill-security-scan-upload.yml), which never runs fork code.
+permissions:
+  contents: read
+  pull-requests: read # needed by dorny/paths-filter to list PR files
+
+jobs:
+  skill-security-scan:
+    name: SkillSpector scan (azure-cost-calculator)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # --- Shared variables ---
+    # Update SKILLSPECTOR_REF and SKILLSPECTOR_REF_DATE together
+    # when bumping the SkillSpector pin. See ops doc for procedure.
+    env:
+      SKILL_PATH: skills/azure-cost-calculator
+      SKILLSPECTOR_REF: 2eb844780ab163f01468ecf142c40a2ec0fcaec0
+      SKILLSPECTOR_REF_DATE: "2026-05-18"
+      SKILLSPECTOR_FAIL_ON: "HIGH,CRITICAL"
+      SARIF_OUTPUT: skillspector.sarif
+      JSON_OUTPUT: skillspector.json
+
+    steps:
+      # --- Step 1: Check if any relevant paths changed ---
+      # Runs first and without a checkout: dorny/paths-filter uses the
+      # REST API for pull_request events. Replaces the top-level paths:
+      # filter so the workflow always reports a status (required for
+      # branch protection) but skips the expensive scan when nothing in
+      # the skill changed.
+      - name: Check for relevant path changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        with:
+          filters: |
+            relevant:
+              - 'skills/azure-cost-calculator/**'
+
+      # --- Early exit when nothing relevant changed ---
+      - name: Skip; no relevant changes
+        if: steps.filter.outputs.relevant == 'false'
+        run: echo "No changes under ${SKILL_PATH}/. Skipping SkillSpector scan."
+
+      # --- Step 2: Check out the PR HEAD commit ---
+      # We pin to the PR head sha (not the default merge ref) so the
+      # scanned content matches the head_sha that the upload workflow
+      # reports results against (refs/pull/<n>/head + head_sha).
+      - name: Checkout PR head
+        if: steps.filter.outputs.relevant == 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      # --- Step 3: Python toolchain ---
+      # SkillSpector requires Python 3.12+.
+      - name: Set up Python
+        if: steps.filter.outputs.relevant == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      # --- Step 4: Install SkillSpector pinned by commit SHA ---
+      - name: Install SkillSpector
+        if: steps.filter.outputs.relevant == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "git+https://github.com/NVIDIA/skillspector@${SKILLSPECTOR_REF}"
+          skillspector --help >/dev/null
+
+      # --- Step 5: Scan, SARIF output (for code scanning UI) ---
+      - name: Run SkillSpector (SARIF)
+        if: steps.filter.outputs.relevant == 'true'
+        run: |
+          skillspector scan "./${SKILL_PATH}/" \
+            --no-llm \
+            --format sarif \
+            --output "${SARIF_OUTPUT}"
+
+      # --- Step 6: Normalise SARIF uris (fail closed on hostile uris) ---
+      # SkillSpector emits skill-dir-relative uris; rewrite them to be
+      # repo-relative so code scanning annotates the right files. The
+      # script rejects traversing/absolute/url uris (exit 3), which fails
+      # this job and prevents a poisoned SARIF from ever being published.
+      - name: Normalise SARIF paths
+        id: normalize
+        if: steps.filter.outputs.relevant == 'true'
+        run: .github/scripts/security/normalize-skillspector-sarif.sh "${SARIF_OUTPUT}" "${SKILL_PATH}"
+
+      # --- Step 7: Scan, JSON output (for threshold gate) ---
+      # SARIF does not carry SkillSpector's risk_assessment block,
+      # so a second pass produces the JSON the gate parses.
+      - name: Run SkillSpector (JSON)
+        if: steps.filter.outputs.relevant == 'true'
+        run: |
+          skillspector scan "./${SKILL_PATH}/" \
+            --no-llm \
+            --format json \
+            --output "${JSON_OUTPUT}"
+
+      # --- Step 8: Gate on severity threshold (required check) ---
+      - name: Check severity threshold
+        if: steps.filter.outputs.relevant == 'true'
+        run: .github/scripts/security/check-skillspector-threshold.sh "${JSON_OUTPUT}"
+
+      # --- Step 9: Publish normalised SARIF for the upload workflow ---
+      # Only when normalisation succeeded, so the companion workflow can
+      # trust the artifact and upload it without re-validating. always()
+      # so a failed gate still surfaces findings.
+      - name: Upload SARIF artifact
+        if: always() && steps.filter.outputs.relevant == 'true' && steps.normalize.outcome == 'success' && hashFiles(env.SARIF_OUTPUT) != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: skillspector-sarif
+          path: ${{ env.SARIF_OUTPUT }}
+
+      # --- Step 10: Attach JSON report for triage ---
+      - name: Upload JSON report artifact
+        if: always() && steps.filter.outputs.relevant == 'true' && hashFiles(env.JSON_OUTPUT) != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: skillspector-report
+          path: ${{ env.JSON_OUTPUT }}

--- a/docs/ops/skill-security-scan.md
+++ b/docs/ops/skill-security-scan.md
@@ -1,0 +1,231 @@
+# Skill Security Scan: Operations Guide
+
+Scans the `azure-cost-calculator` skill with [SkillSpector](https://github.com/NVIDIA/skillspector) on every pull request and blocks merge when the assessed severity is HIGH or CRITICAL. Findings are uploaded to GitHub code scanning so they appear inline on the PR diff and in the Security tab.
+
+This runs as **two workflows**. The scan workflow runs in the untrusted PR context (no write scopes) and produces a SARIF artifact plus the blocking severity gate. A trusted companion workflow, triggered via `workflow_run`, holds the only `security-events: write` scope and publishes that artifact to code scanning. This split is what lets fork PRs receive inline annotations without ever granting write scope to fork-authored content. See [Two-workflow architecture](#two-workflow-architecture) for the rationale.
+
+| Item              | Detail                                                                                                          |
+| ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| Scan workflow     | `.github/workflows/skill-security-scan.yml` (PR context: scan + gate, no write scopes)                         |
+| Upload workflow   | `.github/workflows/skill-security-scan-upload.yml` (trusted `workflow_run`: publishes SARIF)                   |
+| Gate script       | `.github/scripts/security/check-skillspector-threshold.sh`                                                      |
+| SARIF normaliser  | `.github/scripts/security/normalize-skillspector-sarif.sh`                                                      |
+| Tests             | `tests/unit/bash/ci/check-skillspector-threshold.bats`, `tests/unit/bash/ci/normalize-skillspector-sarif.bats` |
+| Scan target       | `skills/azure-cost-calculator/`                                                                                 |
+| Trigger           | All pull requests to `dev` and `main`; scan only runs when files under `skills/azure-cost-calculator/**` change |
+| Fail threshold    | `HIGH` or `CRITICAL` (configurable via `SKILLSPECTOR_FAIL_ON`)                                                  |
+| SkillSpector pin  | `2eb844780ab163f01468ecf142c40a2ec0fcaec0` (2026-05-18)                                                         |
+| LLM analysis      | Off in CI (`--no-llm`); use locally for triage                                                                  |
+
+---
+
+## What it does
+
+SkillSpector is a static analyzer for AI agent skills. It scans `SKILL.md`, scripts, manifests, and reference data for 64 vulnerability patterns across 16 categories (prompt injection, data exfiltration, supply chain, excessive agency, MCP tool poisoning, dangerous AST patterns, taint flows, YARA signatures, and more). The README in the upstream repo lists every rule.
+
+The scan workflow runs two passes per PR, both with LLM analysis disabled for reproducibility:
+
+| Pass       | Format | Purpose                                                                       |
+| ---------- | ------ | ----------------------------------------------------------------------------- |
+| SARIF pass | SARIF  | Normalised, published as an artifact, then uploaded to code scanning by the upload workflow |
+| JSON pass  | JSON   | Parsed by `check-skillspector-threshold.sh` to decide pass/fail (the required gate)         |
+
+A separate JSON pass is required because SARIF does not carry SkillSpector's `risk_assessment` block, which is the source of truth for the gate.
+
+### Two-workflow architecture
+
+On a `pull_request` from a fork, `GITHUB_TOKEN` is read-only and `security-events: write` cannot be granted, so a single-workflow design cannot upload SARIF from fork PRs (the upload step fails and reddens otherwise-safe PRs). GitHub's documented pattern is to split the work:
+
+| Workflow | Trigger | Permissions | Runs fork code? | Responsibility |
+| -------- | ------- | ----------- | --------------- | -------------- |
+| `skill-security-scan.yml` | `pull_request` | `contents: read`, `pull-requests: read` | Yes (scans it) | Scan, normalise SARIF, run the blocking gate, publish artifacts |
+| `skill-security-scan-upload.yml` | `workflow_run` (completed) | adds `actions: read`, `security-events: write` | **No** | Download the SARIF artifact and upload it to code scanning |
+
+The gate stays in the scan workflow, so it remains the required, blocking check on the PR. The upload workflow's result is not a PR status and does not gate; it only surfaces findings in the UI.
+
+**Why this is safe.** The upload workflow holds write scope but is hardened against the artifact it consumes:
+
+- It **never checks out or executes** PR/fork code; it only downloads the artifact and calls `upload-sarif`.
+- The PR head sha comes from the authoritative `github.event.workflow_run.head_sha` (set by GitHub), never from the artifact, so it cannot be spoofed.
+- The PR number is resolved from the commit-to-PRs API and strictly filtered (open, matching head sha, head repo, base repo, base branch). Ambiguous matches are skipped, never guessed, so a shared sha cannot redirect alerts onto another PR.
+- The scan workflow publishes the SARIF artifact **only after** `normalize-skillspector-sarif.sh` validates every uri, so a poisoned SARIF is never produced for the upload workflow to consume.
+
+### Why the SARIF needs normalising
+
+SkillSpector records component paths relative to the scanned skill directory (`build_context.py`: `rel = item.relative_to(skill_dir)`). A finding in `skills/azure-cost-calculator/SKILL.md` is therefore emitted with `uri: "SKILL.md"`. GitHub code scanning resolves SARIF uris against the repository root, so without a rewrite the alert lands on a non-existent root-level `SKILL.md` (or is dropped). `normalize-skillspector-sarif.sh` prepends the skill path to each uri and **fails closed** (exit 3) on any uri that is absolute, a URL, contains a backslash, is percent-encoded, or contains a `..` traversal segment, since the uri is the only fork-influenced value that reaches code scanning.
+
+### Why the scan checks out the PR head
+
+The scan workflow checks out `github.event.pull_request.head.sha` rather than the default merge ref, so the scanned tree matches the `head_sha` the upload workflow associates results with (`ref: refs/pull/<n>/head` + `sha: head_sha`). This keeps ref and sha a consistent pairing and means the gate evaluates the actual proposed content, not a synthetic merge commit.
+
+
+### Why scan all of `skills/azure-cost-calculator/**`
+
+The threat model treats anything an agent reads or executes as in scope:
+
+- `SKILL.md` and `USAGE.md`: instructions interpreted by the agent (prompt-injection surface)
+- `scripts/`: code the agent executes (AST, taint, YARA surface)
+- `references/`: data the agent reads (hidden-instruction and unicode-deception surface)
+
+Filtering to scripts alone would leave the largest attack surface unscanned.
+
+### Why static-only in CI
+
+LLM-augmented analysis improves precision but adds:
+
+- An API key to manage as a repo secret
+- Per-PR cost
+- Non-determinism that flakes a required check
+
+The trade-off picked here is a deterministic gate in CI plus an explicit local workflow (below) for triaging findings with LLM context.
+
+---
+
+## Prerequisites
+
+### CI
+
+Nothing manual. The runner installs Python 3.12 and SkillSpector at the pinned SHA on every run. `jq` is already on `ubuntu-latest`.
+
+### Local
+
+| Tool         | Install                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| Python 3.12+ | [python.org](https://www.python.org/downloads/) or `brew install python@3.12` (macOS)               |
+| pip          | bundled with Python                                                                                 |
+| jq           | `brew install jq` (macOS) · `sudo apt install jq` (Ubuntu)                                          |
+| SkillSpector | `pip install "git+https://github.com/NVIDIA/skillspector@2eb844780ab163f01468ecf142c40a2ec0fcaec0"` |
+| bats-core    | `brew install bats-core` (macOS) · `npm i -g bats` (Ubuntu/CI) — only for running gate tests        |
+
+> Use a virtual environment: `python3 -m venv .venv-skillspector && source .venv-skillspector/bin/activate`.
+
+---
+
+## Running locally
+
+### Reproduce the CI scan
+
+```bash
+skillspector scan ./skills/azure-cost-calculator/ \
+  --no-llm \
+  --format json \
+  --output skillspector.json
+
+.github/scripts/security/check-skillspector-threshold.sh skillspector.json
+```
+
+Exit code 0 means the gate would pass; exit code 1 means HIGH or CRITICAL was found.
+
+### Reproduce the SARIF normalisation
+
+The CI upload path rewrites SARIF uris to be repo-relative and rejects hostile paths. To reproduce it locally:
+
+```bash
+skillspector scan ./skills/azure-cost-calculator/ \
+  --no-llm \
+  --format sarif \
+  --output skillspector.sarif
+
+.github/scripts/security/normalize-skillspector-sarif.sh skillspector.sarif skills/azure-cost-calculator
+```
+
+Exit 0 rewrites the file in place; exit 3 means an unsafe uri was found and nothing was written (CI would block the upload).
+
+### Triage with LLM context
+
+LLM analysis improves precision and explains findings in plain English. Pick a provider; see the SkillSpector README for the full list.
+
+```bash
+# Example: OpenAI
+export SKILLSPECTOR_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+
+skillspector scan ./skills/azure-cost-calculator/ \
+  --format markdown \
+  --output skillspector-triage.md
+```
+
+### Run the gate-script tests
+
+```bash
+bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/check-skillspector-threshold.bats
+bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/normalize-skillspector-sarif.bats
+```
+
+---
+
+## Updating the SkillSpector pin
+
+The pin is a commit SHA, not a tag. Bump only when there is a reason (new rule you want, false positive fix, security advisory). The pin lives only in the scan workflow.
+
+1. Choose the new SHA from [NVIDIA/skillspector commits](https://github.com/NVIDIA/skillspector/commits/main).
+2. Update three places in `.github/workflows/skill-security-scan.yml`:
+   - `SKILLSPECTOR_REF` in the job `env:` block
+   - `SKILLSPECTOR_REF_DATE` in the job `env:` block
+   - The pinned SHA in the `Install SkillSpector` step (sourced from `SKILLSPECTOR_REF`)
+3. Update the summary table at the top of this doc.
+4. Open a PR. The first PR after a bump may surface new findings; triage before merging.
+
+---
+
+## Tuning the threshold
+
+The gate fails on `HIGH` and `CRITICAL` by default. To change it, edit `SKILLSPECTOR_FAIL_ON` in the workflow `env:` block:
+
+```yaml
+SKILLSPECTOR_FAIL_ON: "CRITICAL"            # CRITICAL only; HIGH becomes advisory
+SKILLSPECTOR_FAIL_ON: "MEDIUM,HIGH,CRITICAL" # strict; blocks on MEDIUM
+```
+
+The script normalises case and tolerates whitespace, so `"high , critical"` is equivalent to `"HIGH,CRITICAL"`.
+
+Severity bands and recommendations come from SkillSpector's risk scoring (see upstream README):
+
+| Score  | Severity | Recommendation |
+| ------ | -------- | -------------- |
+| 0-20   | LOW      | SAFE           |
+| 21-50  | MEDIUM   | CAUTION        |
+| 51-80  | HIGH     | DO NOT INSTALL |
+| 81-100 | CRITICAL | DO NOT INSTALL |
+
+---
+
+## Interpreting findings in the PR UI
+
+| Surface                  | Where to look                                                                |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| Inline annotations on PR | "Files changed" tab; appear once `Skill Security Scan Upload` finishes (shortly after the scan check), for both same-repo and fork PRs |
+| Aggregated view          | Repo → Security → Code scanning → filter by tool `SkillSpector`              |
+| Raw JSON for scripting   | PR → Checks → `Skill Security Scan` → Artifacts → `skillspector-report`      |
+| Pass/fail summary        | PR → Checks → `Skill Security Scan` → step summary panel (this is the blocking check) |
+
+---
+
+## Troubleshooting
+
+| Symptom                                                               | Likely cause                                                                | Fix                                                                                                       |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Workflow runs on every PR even when the skill is untouched            | Top-level `paths:` filter was added                                         | Keep `paths:` off so branch protection always sees a status; rely on `dorny/paths-filter` for early exit  |
+| Workflow always passes even with known-bad fixture                    | Threshold gate step missing or `--no-llm` JSON pass not running             | Confirm the `Run SkillSpector (JSON)` and `Check severity threshold` steps ran; check the JSON artifact for `risk_assessment.severity` |
+| `SARIF upload failed: Resource not accessible by integration`         | The scan workflow is uploading SARIF directly instead of the upload workflow | The scan workflow must not call `upload-sarif` or hold `security-events: write`; that belongs only to `skill-security-scan-upload.yml` |
+| Findings missing from code scanning on a fork PR                      | Upload workflow skipped or could not resolve the PR                          | Check the `Skill Security Scan Upload` run: it skips when no `skillspector-sarif` artifact exists or when the PR could not be unambiguously resolved from the head sha |
+| `Skill Security Scan Upload` did nothing (`skip=true`)                | No SARIF artifact (scan path-skipped/blocked) or ambiguous PR match          | Expected for irrelevant PRs; otherwise confirm the scan workflow published `skillspector-sarif` and that exactly one open PR matches the head sha |
+| Scan job fails at `Normalise SARIF paths` (exit 3)                    | SkillSpector emitted a uri that escapes the skill dir (absolute/URL/`..`)    | Treated as hostile and blocked by design; inspect the flagged uri in the step log before overriding |
+| `pip install git+https://...` fails to resolve                        | Network restrictions on the runner, or the pinned SHA was force-pushed away | Re-run; if persistent, re-pin to a fresh SHA from the upstream commit log                                 |
+| `jq: command not found` locally                                       | jq not installed                                                            | `brew install jq` (macOS) · `sudo apt install jq` (Ubuntu)                                                |
+| Gate fails on a finding the team agrees is a false positive           | Static analysis lacks context                                               | Re-run locally with LLM analysis enabled; if still flagged, address the pattern or open an upstream issue |
+| Threshold gate exits 2 in CI                                          | Report file missing or malformed (scan step likely failed earlier)          | Check earlier steps in the job; download the JSON artifact and re-run the script locally                  |
+| SARIF appears in code scanning but PR check is green despite findings | Severity is below the fail threshold                                        | Expected; tune `SKILLSPECTOR_FAIL_ON` if MEDIUM should also block                                         |
+
+---
+
+## References
+
+- [SkillSpector](https://github.com/NVIDIA/skillspector): upstream scanner, rule catalogue, JSON schema
+- [OSV.dev](https://osv.dev): vulnerability database used by SkillSpector rule SC4
+- [SARIF v2.1.0 spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html): output format
+- [GitHub code scanning with SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning): how findings render in the UI
+- [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif): action used to publish SARIF
+- [`dorny/paths-filter`](https://github.com/dorny/paths-filter): in-job path filter used to keep the required check fast on irrelevant PRs
+- [Uploading SARIF from forks with `workflow_run`](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-the-upload-sarif-action-with-third-party-analysis-tools#uploading-analysis-results-from-forks): the two-workflow pattern this implements
+- [`actions/download-artifact`](https://github.com/actions/download-artifact): cross-run artifact download used by the upload workflow

--- a/docs/ops/skill-security-scan.md
+++ b/docs/ops/skill-security-scan.md
@@ -159,10 +159,9 @@ bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/normalize-skillspector-sari
 The pin is a commit SHA, not a tag. Bump only when there is a reason (new rule you want, false positive fix, security advisory). The pin lives only in the scan workflow.
 
 1. Choose the new SHA from [NVIDIA/skillspector commits](https://github.com/NVIDIA/skillspector/commits/main).
-2. Update three places in `.github/workflows/skill-security-scan.yml`:
-   - `SKILLSPECTOR_REF` in the job `env:` block
-   - `SKILLSPECTOR_REF_DATE` in the job `env:` block
-   - The pinned SHA in the `Install SkillSpector` step (sourced from `SKILLSPECTOR_REF`)
+2. Update two values in the job `env:` block of `.github/workflows/skill-security-scan.yml`:
+   - `SKILLSPECTOR_REF` (the `Install SkillSpector` step reads `${SKILLSPECTOR_REF}`, so no other edit is needed)
+   - `SKILLSPECTOR_REF_DATE`
 3. Update the summary table at the top of this doc.
 4. Open a PR. The first PR after a bump may surface new findings; triage before merging.
 
@@ -170,14 +169,15 @@ The pin is a commit SHA, not a tag. Bump only when there is a reason (new rule y
 
 ## Tuning the threshold
 
-The gate fails on `HIGH` and `CRITICAL` by default. To change it, edit `SKILLSPECTOR_FAIL_ON` in the workflow `env:` block:
+The gate fails on `HIGH` and `CRITICAL` by default. `SKILLSPECTOR_FAIL_ON` is a threshold, not an exact-match list: the gate fails when the report severity is at or above the lowest-ranked severity you list (rank order `LOW < MEDIUM < HIGH < CRITICAL`). To change it, edit `SKILLSPECTOR_FAIL_ON` in the workflow `env:` block:
 
 ```yaml
-SKILLSPECTOR_FAIL_ON: "CRITICAL"            # CRITICAL only; HIGH becomes advisory
-SKILLSPECTOR_FAIL_ON: "MEDIUM,HIGH,CRITICAL" # strict; blocks on MEDIUM
+SKILLSPECTOR_FAIL_ON: "CRITICAL"             # CRITICAL only; HIGH and below advisory
+SKILLSPECTOR_FAIL_ON: "MEDIUM"               # blocks on MEDIUM, HIGH, and CRITICAL
+SKILLSPECTOR_FAIL_ON: "MEDIUM,HIGH,CRITICAL" # equivalent to "MEDIUM" (lowest rank wins)
 ```
 
-The script normalises case and tolerates whitespace, so `"high , critical"` is equivalent to `"HIGH,CRITICAL"`.
+The script normalises case and tolerates whitespace, so `"high , critical"` is equivalent to `"HIGH,CRITICAL"`. A threshold with no recognized severity, or a report whose severity is unrecognized, exits 2.
 
 Severity bands and recommendations come from SkillSpector's risk scoring (see upstream README):
 

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -6,6 +6,7 @@ argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
 allowed-tools:
   - Bash
+  - PowerShell
 metadata:
   author: ahmadabdalla
   version: "1.8.0"

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -4,6 +4,8 @@ description: Helps estimate and calculate Azure resource costs. Use this skill w
 license: MIT
 argument-hint: "<azure-service-name>"
 compatibility: Requires curl + jq (macOS/Linux) or PowerShell 7+ (pwsh) or Windows PowerShell 5.1 (powershell.exe on Windows), and internet access to prices.azure.com. No Azure subscription needed.
+allowed-tools:
+  - Bash
 metadata:
   author: ahmadabdalla
   version: "1.8.0"

--- a/tests/unit/bash/ci/check-skillspector-threshold.bats
+++ b/tests/unit/bash/ci/check-skillspector-threshold.bats
@@ -125,6 +125,49 @@ JSON
 }
 
 # ---------------------------------------------------------
+# Threshold ordering (not exact-match membership)
+# ---------------------------------------------------------
+
+@test "threshold HIGH also fails CRITICAL (ordering, not exact match)" {
+    write_report "CRITICAL" 90 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="HIGH" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"meets fail threshold"* ]]
+}
+
+@test "threshold HIGH fails HIGH" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="HIGH" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+}
+
+@test "threshold HIGH lets MEDIUM pass" {
+    write_report "MEDIUM" 30 "CAUTION" 1
+    SKILLSPECTOR_FAIL_ON="HIGH" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+}
+
+@test "list threshold uses lowest rank (MEDIUM,CRITICAL fails HIGH)" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="MEDIUM,CRITICAL" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+}
+
+@test "unrecognized report severity exits 2" {
+    write_report "BOGUS" 50 "CAUTION" 0
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unrecognized severity"* ]]
+}
+
+@test "unrecognized SKILLSPECTOR_FAIL_ON token exits 2" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="NONSENSE" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unrecognized severity"* ]]
+}
+
+# ---------------------------------------------------------
 # Input error cases (exit 2)
 # ---------------------------------------------------------
 

--- a/tests/unit/bash/ci/check-skillspector-threshold.bats
+++ b/tests/unit/bash/ci/check-skillspector-threshold.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/security/check-skillspector-threshold.sh
+
+setup() {
+    source "$BATS_TEST_DIRNAME/../test_helper.bash"
+    source "$BATS_TEST_DIRNAME/ci_test_helper.bash"
+
+    SCRIPT="$CI_SCRIPTS_DIR/security/check-skillspector-threshold.sh"
+    REPORT="$(mktemp)"
+    export REPORT
+}
+
+teardown() {
+    if [[ -n "${REPORT:-}" && -f "$REPORT" ]]; then
+        rm -f "$REPORT"
+    fi
+}
+
+# Build a minimal valid SkillSpector JSON report.
+# Usage: write_report <severity> [score] [recommendation] [issue_count]
+write_report() {
+    local severity="$1"
+    local score="${2:-50}"
+    local recommendation="${3:-CAUTION}"
+    local issue_count="${4:-0}"
+
+    local issues="[]"
+    if [ "$issue_count" -gt 0 ]; then
+        issues="["
+        for ((i=1; i<=issue_count; i++)); do
+            issues+='{"rule_id":"X1","severity":"'"$severity"'","message":"x"}'
+            [ "$i" -lt "$issue_count" ] && issues+=","
+        done
+        issues+="]"
+    fi
+
+    cat > "$REPORT" <<JSON
+{
+  "skill": {"name": "test", "source": ".", "scanned_at": "2026-01-01T00:00:00Z"},
+  "risk_assessment": {
+    "score": ${score},
+    "severity": "${severity}",
+    "recommendation": "${recommendation}"
+  },
+  "components": [],
+  "issues": ${issues},
+  "metadata": {}
+}
+JSON
+}
+
+# ---------------------------------------------------------
+# Pass cases (severity below default fail threshold)
+# ---------------------------------------------------------
+
+@test "LOW severity passes" {
+    write_report "LOW" 10 "SAFE" 0
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Severity:       LOW"* ]]
+    [[ "$output" == *"gate passed"* ]]
+}
+
+@test "MEDIUM severity passes" {
+    write_report "MEDIUM" 35 "CAUTION" 2
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Severity:       MEDIUM"* ]]
+}
+
+@test "lowercase severity is normalised and passes for low" {
+    write_report "low" 5 "SAFE" 0
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Severity:       LOW"* ]]
+}
+
+# ---------------------------------------------------------
+# Fail cases (severity at or above default fail threshold)
+# ---------------------------------------------------------
+
+@test "HIGH severity fails the gate" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"meets fail threshold"* ]]
+    [[ "$output" == *"Blocking merge"* ]]
+}
+
+@test "CRITICAL severity fails the gate" {
+    write_report "CRITICAL" 90 "DO_NOT_INSTALL" 3
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Severity:       CRITICAL"* ]]
+    [[ "$output" == *"meets fail threshold"* ]]
+}
+
+@test "lowercase critical is normalised and fails" {
+    write_report "critical" 95 "DO_NOT_INSTALL" 1
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------
+# Custom threshold via SKILLSPECTOR_FAIL_ON
+# ---------------------------------------------------------
+
+@test "custom threshold CRITICAL only lets HIGH pass" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="CRITICAL" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Fail threshold: CRITICAL"* ]]
+}
+
+@test "custom threshold MEDIUM,HIGH,CRITICAL fails MEDIUM" {
+    write_report "MEDIUM" 30 "CAUTION" 1
+    SKILLSPECTOR_FAIL_ON="MEDIUM,HIGH,CRITICAL" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+}
+
+@test "custom threshold tolerates whitespace and case" {
+    write_report "HIGH" 60 "DO_NOT_INSTALL" 1
+    SKILLSPECTOR_FAIL_ON="high , critical" run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------
+# Input error cases (exit 2)
+# ---------------------------------------------------------
+
+@test "missing argument exits 2" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "missing report file exits 2" {
+    run bash "$SCRIPT" "/tmp/does-not-exist-$$.json"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "invalid JSON exits 2" {
+    printf 'not json{' > "$REPORT"
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "missing severity field exits 2" {
+    cat > "$REPORT" <<'JSON'
+{
+  "skill": {"name": "test"},
+  "risk_assessment": {"score": 50},
+  "issues": []
+}
+JSON
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Missing field"* ]]
+}
+
+# ---------------------------------------------------------
+# GITHUB_STEP_SUMMARY integration
+# ---------------------------------------------------------
+
+@test "writes markdown summary to GITHUB_STEP_SUMMARY when set" {
+    write_report "LOW" 5 "SAFE" 0
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" == *"SkillSpector security gate"* ]]
+    [[ "$summary" == *"| Severity | LOW |"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}

--- a/tests/unit/bash/ci/normalize-skillspector-sarif.bats
+++ b/tests/unit/bash/ci/normalize-skillspector-sarif.bats
@@ -69,6 +69,13 @@ read_uris() {
     [ "$(read_uris)" = '["skills/azure-cost-calculator/SKILL.md"]' ]
 }
 
+@test "is idempotent on an already-prefixed nested uri" {
+    write_sarif "skills/azure-cost-calculator/scripts/lib/pricing.sh"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/scripts/lib/pricing.sh"]' ]
+}
+
 @test "tolerates a trailing slash on the prefix" {
     write_sarif "SKILL.md"
     run bash "$SCRIPT" "$SARIF" "$PREFIX/"
@@ -105,6 +112,19 @@ JSON
 
 @test "rejects mid-path traversal" {
     write_sarif "scripts/../../secret"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "rejects traversal in an already-prefixed uri" {
+    write_sarif "skills/azure-cost-calculator/../../.github/workflows/ci.yml"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"unsafe artifact uri"* ]]
+}
+
+@test "rejects mid-path traversal in an already-prefixed uri" {
+    write_sarif "skills/azure-cost-calculator/scripts/../../../secret"
     run bash "$SCRIPT" "$SARIF" "$PREFIX"
     [ "$status" -eq 3 ]
 }

--- a/tests/unit/bash/ci/normalize-skillspector-sarif.bats
+++ b/tests/unit/bash/ci/normalize-skillspector-sarif.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/security/normalize-skillspector-sarif.sh
+
+setup() {
+    source "$BATS_TEST_DIRNAME/../test_helper.bash"
+    source "$BATS_TEST_DIRNAME/ci_test_helper.bash"
+
+    SCRIPT="$CI_SCRIPTS_DIR/security/normalize-skillspector-sarif.sh"
+    PREFIX="skills/azure-cost-calculator"
+    SARIF="$(mktemp)"
+    export SARIF PREFIX
+}
+
+teardown() {
+    if [[ -n "${SARIF:-}" && -f "$SARIF" ]]; then
+        rm -f "$SARIF"
+    fi
+}
+
+# Write a SARIF report whose results carry the given uris.
+# Usage: write_sarif <uri> [<uri> ...]
+write_sarif() {
+    local results="" first=1
+    for uri in "$@"; do
+        [ "$first" -eq 1 ] || results+=","
+        first=0
+        results+='{"ruleId":"X1","locations":[{"physicalLocation":{"artifactLocation":{"uri":"'"$uri"'"},"region":{"startLine":1}}}]}'
+    done
+    cat > "$SARIF" <<JSON
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"skillspector"}},"results":[${results}]}]}
+JSON
+}
+
+# Read back the list of uris as a compact JSON array.
+read_uris() {
+    jq -c '[.runs[].results[]?.locations[]?.physicalLocation.artifactLocation.uri]' "$SARIF"
+}
+
+# ---------------------------------------------------------
+# Happy path: skill-relative uris become repo-relative
+# ---------------------------------------------------------
+
+@test "prefixes a top-level uri" {
+    write_sarif "SKILL.md"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/SKILL.md"]' ]
+}
+
+@test "prefixes a nested uri" {
+    write_sarif "scripts/lib/pricing.sh"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/scripts/lib/pricing.sh"]' ]
+}
+
+@test "prefixes multiple uris in one report" {
+    write_sarif "SKILL.md" "references/services/redis-cache.md"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/SKILL.md","skills/azure-cost-calculator/references/services/redis-cache.md"]' ]
+}
+
+@test "is idempotent on already-prefixed uris" {
+    write_sarif "SKILL.md"
+    bash "$SCRIPT" "$SARIF" "$PREFIX"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/SKILL.md"]' ]
+}
+
+@test "tolerates a trailing slash on the prefix" {
+    write_sarif "SKILL.md"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX/"
+    [ "$status" -eq 0 ]
+    [ "$(read_uris)" = '["skills/azure-cost-calculator/SKILL.md"]' ]
+}
+
+@test "handles a result with no locations" {
+    cat > "$SARIF" <<'JSON'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"skillspector"}},"results":[{"ruleId":"X1","locations":[]}]}]}
+JSON
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+}
+
+@test "handles a report with no results" {
+    cat > "$SARIF" <<'JSON'
+{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"skillspector"}},"results":[]}]}
+JSON
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------
+# Fail-closed sanitisation (exit 3, file untouched)
+# ---------------------------------------------------------
+
+@test "rejects parent-directory traversal" {
+    write_sarif "../../.github/workflows/ci.yml"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"unsafe artifact uri"* ]]
+}
+
+@test "rejects mid-path traversal" {
+    write_sarif "scripts/../../secret"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "rejects an absolute path" {
+    write_sarif "/etc/passwd"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "rejects a url scheme" {
+    write_sarif "https://evil.example/x"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "rejects percent-encoded traversal" {
+    write_sarif "%2e%2e/secret"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "rejects a backslash separator" {
+    write_sarif 'scripts\\windows.ps1'
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+}
+
+@test "leaves the file unchanged when an unsafe uri is rejected" {
+    write_sarif "../escape"
+    before="$(cat "$SARIF")"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 3 ]
+    [ "$(cat "$SARIF")" = "$before" ]
+}
+
+# ---------------------------------------------------------
+# Input errors (exit 2)
+# ---------------------------------------------------------
+
+@test "missing arguments exit 2" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "missing prefix argument exits 2" {
+    write_sarif "SKILL.md"
+    run bash "$SCRIPT" "$SARIF"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "missing file exits 2" {
+    run bash "$SCRIPT" "/tmp/does-not-exist-$$.sarif" "$PREFIX"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "invalid JSON exits 2" {
+    printf 'not json{' > "$SARIF"
+    run bash "$SCRIPT" "$SARIF" "$PREFIX"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}


### PR DESCRIPTION
## What

Adds a fork-safe CI pipeline that scans the `azure-cost-calculator` skill with NVIDIA SkillSpector on every PR, and blocks merges on HIGH/CRITICAL aggregate risk.

## How

Two-workflow `workflow_run` split so untrusted fork PRs never get write scopes:

- **`skill-security-scan.yml`** — runs the scan on the PR head and enforces the blocking gate. No elevated permissions.
- **`skill-security-scan-upload.yml`** — trusted `workflow_run` consumer; holds the only `security-events: write` and publishes normalized SARIF to the PR.
- **`check-skillspector-threshold.sh`** — gate; keys on aggregate `risk_assessment.severity`, fails on `HIGH,CRITICAL`.
- **`normalize-skillspector-sarif.sh`** — rewrites SARIF URIs skill-dir-relative → repo-relative; fails closed on hostile URIs.
- Bats coverage for both scripts under `tests/unit/bash/ci/`.
- Ops guide: `docs/ops/skill-security-scan.md`.

## Findings remediated

Prior false positives filed as #945–#948 were resolved upstream (BOM strip, cross-service marker → metadata, entra-domain-services agency wording).

## Remaining finding (accepted, non-blocking)

`SKILL.md` declares `allowed-tools: [Bash, PowerShell]` (agent-skills standard). SkillSpector's MCP Least Privilege rule (ASI02/LP3) reads a non-standard `permissions` field and ignores `allowed-tools`, so it reports a single MEDIUM (#947). Aggregate stays **LOW/SAFE** and the gate (`HIGH,CRITICAL`) passes. Standard alignment was chosen over the scanner's bespoke field.

## Verification

Real SkillSpector (pinned ref `2eb84478`, `--no-llm`) run locally: aggregate **LOW/SAFE**, gate exits 0.

> Note: repo convention targets `dev` for feature PRs; opened against `main` per explicit request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated security scanning now runs on all pull requests targeting main development branches
  * Security findings are automatically published to GitHub code scanning for centralized visibility
  * Severity-based gating mechanism prevents merge when findings exceed configured risk thresholds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
