### PR TITLE
fix: make skillspector gate authoritative and surface findings (#984)…

### DIFF
--- a/.github/scripts/security/check-skillspector-threshold.sh
+++ b/.github/scripts/security/check-skillspector-threshold.sh
@@ -157,6 +157,40 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| Issues | ${ISSUE_COUNT} |"
     echo "| Fail threshold | ${THRESHOLD_LABEL} or higher (configured: ${FAIL_ON_UPPER}) |"
   } >> "$GITHUB_STEP_SUMMARY"
+
+  # Enumerate the individual findings so the run page is self-contained:
+  # an author can read what tripped the gate without opening the Security
+  # tab or downloading the JSON report. Finding text derives from the
+  # scanned (untrusted) skill, so each field is sanitised before it is
+  # written: table-breaking pipes and backslashes are escaped, newlines/
+  # tabs are collapsed, and the detail is truncated to keep one finding per
+  # row. The table is capped (see MAX_SUMMARY_ROWS) so a report with very
+  # many findings cannot blow past GitHub's step-summary size limit; the
+  # full set always remains in the uploaded JSON artifact.
+  if [ "${ISSUE_COUNT}" -gt 0 ]; then
+    MAX_SUMMARY_ROWS=50
+    {
+      echo
+      echo "#### Findings (${ISSUE_COUNT})"
+      echo
+      echo "| Severity | Rule | Location | Detail |"
+      echo "|---|---|---|---|"
+      jq -r --argjson max "$MAX_SUMMARY_ROWS" '
+        def san: (. // "-") | tostring | gsub("\\\\"; "\\\\") | gsub("\\|"; "\\|") | gsub("[\r\n\t]+"; " ");
+        def trunc($n): if (length > $n) then (.[0:$n] + "...") else . end;
+        .issues[0:$max][]
+        | "| " + (.severity | san)
+        + " | " + (.id | san)
+        + " | " + ((.location.file | san) + ":" + ((.location.start_line // 0) | san))
+        + " | " + (((.explanation // .message) | san) | trunc(160))
+        + " |"
+      ' "$REPORT_PATH"
+      if [ "${ISSUE_COUNT}" -gt "${MAX_SUMMARY_ROWS}" ]; then
+        echo
+        echo "_Showing first ${MAX_SUMMARY_ROWS} of ${ISSUE_COUNT} findings; see the uploaded report artifact for the full list._"
+      fi
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
 fi
 
 if [ "$FAIL" -eq 1 ]; then

--- a/.github/scripts/security/normalize-skillspector-sarif.sh
+++ b/.github/scripts/security/normalize-skillspector-sarif.sh
@@ -17,12 +17,16 @@
 # uri so alerts annotate the correct file on the PR diff.
 #
 # FAIL-CLOSED SANITISATION
-# The uri is the only fork-influenced value uploaded to code
+# The artifact uri is the only fork-influenced value uploaded to code
 # scanning. A crafted uri (absolute path, URL scheme, backslash, or
 # ".." traversal) could mislocate an alert onto an unrelated victim
-# file. Any uri that is not a plain, in-tree relative path is
-# treated as hostile and the script exits non-zero (exit 3) so the
-# caller blocks rather than uploads a poisoned report.
+# file. The pinned SkillSpector build emits findings only at
+# results[].locations[].physicalLocation.artifactLocation.uri, which is
+# the single path validated and rewritten here. Any uri that is not a
+# plain, in-tree relative path is treated as hostile and the script
+# exits non-zero (exit 3) so the caller blocks rather than uploads a
+# poisoned report. (If a future SkillSpector version emits file uris in
+# other SARIF fields, extend both checks below to cover them.)
 #
 # Usage:
 #   normalize-skillspector-sarif.sh <path-to.sarif> <path-prefix>

--- a/.github/scripts/security/run-skillspector-scan.sh
+++ b/.github/scripts/security/run-skillspector-scan.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------
+# run-skillspector-scan.sh
+# ---------------------------------------------------------
+# Runs `skillspector scan` and tolerates a non-zero exit code
+# WHEN the scanner still produced usable output.
+#
+# WHY THIS EXISTS
+# SkillSpector writes its output file and then exits non-zero
+# (1) when it finds HIGH/CRITICAL issues. Under the workflow's
+# default `set -e` shell, that non-zero exit would abort the job
+# at the scan step, before the threshold gate and the SARIF
+# upload ever run. The result was that the documented gate
+# (check-skillspector-threshold.sh) never decided anything for
+# exactly the dangerous skills, and no code-scanning finding was
+# produced. See issue #984.
+#
+# CONTRACT
+# The exit CODE is not trusted as a pass/fail signal (future
+# SkillSpector versions may use other non-zero codes). Instead,
+# OUTPUT VALIDITY controls continuation:
+#   - output file exists, is non-empty, parses as JSON (SkillSpector
+#     SARIF is JSON too), AND carries the minimal shape its consumer
+#     needs (SARIF: a non-empty runs[]; JSON: a string
+#     risk_assessment.severity, the one field the gate reads) ->
+#     succeed (exit 0), so the gate downstream becomes the single
+#     decision authority.
+#   - missing, empty, unparseable, or structurally empty output -> a
+#     genuine tooling failure; exit 1 so the caller fails closed.
+#
+# Usage:
+#   run-skillspector-scan.sh <skill-path> <format> <output-file>
+#
+# Arguments:
+#   <skill-path>   Repo-relative skill directory, no trailing slash
+#                  (e.g. skills/azure-cost-calculator).
+#   <format>       SkillSpector --format value (json or sarif).
+#   <output-file>  Path SkillSpector writes the report to.
+#
+# Exit codes:
+#   0  scan produced valid output (regardless of SkillSpector's code)
+#   1  scan produced no usable output (missing/empty/unparseable)
+#   2  input error: missing arguments, unsupported format, or jq not
+#      installed
+# ---------------------------------------------------------
+
+set -euo pipefail
+
+SKILL_PATH="${1:-}"
+FORMAT="${2:-}"
+OUTPUT="${3:-}"
+
+if [ -z "$SKILL_PATH" ] || [ -z "$FORMAT" ] || [ -z "$OUTPUT" ]; then
+  echo "::error::Usage: run-skillspector-scan.sh <skill-path> <format> <output-file>"
+  exit 2
+fi
+
+# Validate FORMAT once, up front, so the downstream shape check is provably
+# exhaustive: an unsupported value must not slip past structural validation
+# and return a false success.
+case "$FORMAT" in
+  json|sarif) ;;
+  *)
+    echo "::error::Unsupported format '${FORMAT}'; expected 'json' or 'sarif'."
+    exit 2
+    ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::jq is required but not installed."
+  exit 2
+fi
+
+# Remove any pre-existing output so a stale or planted file cannot be trusted
+# if the scanner fails to write. The workflow uses fixed repo-root filenames in
+# an untrusted pull_request checkout, so the path is attacker-influenceable.
+rm -f -- "$OUTPUT"
+
+# Tolerate SkillSpector's non-zero "findings present" exit; the output
+# file, not the exit code, is the source of truth (see CONTRACT above).
+set +e
+skillspector scan "./${SKILL_PATH}/" \
+  --no-llm \
+  --format "$FORMAT" \
+  --output "$OUTPUT"
+rc=$?
+set -e
+
+if [ ! -s "$OUTPUT" ]; then
+  echo "::error::SkillSpector wrote no ${FORMAT} output to ${OUTPUT} (exit ${rc}); failing closed."
+  exit 1
+fi
+
+if ! jq empty "$OUTPUT" >/dev/null 2>&1; then
+  echo "::error::SkillSpector ${FORMAT} output ${OUTPUT} is not valid JSON (exit ${rc}); failing closed."
+  exit 1
+fi
+
+# Valid JSON is necessary but not sufficient: a stub or a partially written
+# file could be "{}" and still parse. Require the minimal shape the
+# downstream consumer needs so an empty-but-valid document fails closed here
+# rather than silently producing no gate decision / no code-scanning alert.
+# FORMAT was validated above, so this case is exhaustive by construction.
+case "$FORMAT" in
+  sarif)
+    if ! jq -e '(.runs | type) == "array" and (.runs | length) > 0' "$OUTPUT" >/dev/null 2>&1; then
+      echo "::error::SkillSpector SARIF output ${OUTPUT} has no runs[] (exit ${rc}); failing closed."
+      exit 1
+    fi
+    ;;
+  json)
+    if ! jq -e '(.risk_assessment.severity | type) == "string"' "$OUTPUT" >/dev/null 2>&1; then
+      echo "::error::SkillSpector JSON output ${OUTPUT} has no risk_assessment.severity (exit ${rc}); failing closed."
+      exit 1
+    fi
+    ;;
+esac
+
+echo "SkillSpector ${FORMAT} scan completed (exit ${rc}); ${OUTPUT} is present and parses."
+exit 0

--- a/.github/workflows/skill-security-scan.yml
+++ b/.github/workflows/skill-security-scan.yml
@@ -24,15 +24,19 @@
 #    associate the results with.
 # 3. Installs SkillSpector pinned to a commit SHA so the gate
 #    cannot silently change behaviour under us.
-# 4. Scans twice (both --no-llm for reproducibility): SARIF for
-#    code scanning, JSON for the threshold gate.
-# 5. Normalises SARIF uris to be repo-relative and fails closed
-#    on any hostile (traversing/absolute/url) uri.
-# 6. The threshold gate (check-skillspector-threshold.sh) is the
-#    REQUIRED, blocking check.
-# 7. Publishes the normalised SARIF and the JSON as artifacts
-#    (always(), so reviewers and the upload workflow still get
-#    them when the gate fails).
+# 4. Runs the gate FIRST (the decision): a JSON scan feeds
+#    check-skillspector-threshold.sh, the REQUIRED blocking check,
+#    which also writes the consumable job summary (verdict + the
+#    per-finding enumeration).
+# 5. Then runs the surfacing path (always(), so a blocked gate still
+#    surfaces findings): a SARIF scan, normalised to repo-relative
+#    uris (fails closed on hostile uris), published as an artifact for
+#    the trusted upload workflow to send to code scanning. Ordering it
+#    after the gate means a normalisation failure can never suppress
+#    the merge decision.
+# 6. Both scans go through run-skillspector-scan.sh, which tolerates
+#    SkillSpector's non-zero "findings present" exit but fails closed
+#    when no usable output is produced (issue #984).
 #
 # OPERATIONAL DOCS: docs/ops/skill-security-scan.md
 # ---------------------------------------------------------
@@ -120,45 +124,49 @@ jobs:
           python -m pip install "git+https://github.com/NVIDIA/skillspector@${SKILLSPECTOR_REF}"
           skillspector --help >/dev/null
 
-      # --- Step 5: Scan, SARIF output (for code scanning UI) ---
-      - name: Run SkillSpector (SARIF)
-        if: steps.filter.outputs.relevant == 'true'
-        run: |
-          skillspector scan "./${SKILL_PATH}/" \
-            --no-llm \
-            --format sarif \
-            --output "${SARIF_OUTPUT}"
-
-      # --- Step 6: Normalise SARIF uris (fail closed on hostile uris) ---
-      # SkillSpector emits skill-dir-relative uris; rewrite them to be
-      # repo-relative so code scanning annotates the right files. The
-      # script rejects traversing/absolute/url uris (exit 3), which fails
-      # this job and prevents a poisoned SARIF from ever being published.
-      - name: Normalise SARIF paths
-        id: normalize
-        if: steps.filter.outputs.relevant == 'true'
-        run: .github/scripts/security/normalize-skillspector-sarif.sh "${SARIF_OUTPUT}" "${SKILL_PATH}"
-
-      # --- Step 7: Scan, JSON output (for threshold gate) ---
-      # SARIF does not carry SkillSpector's risk_assessment block,
-      # so a second pass produces the JSON the gate parses.
+      # --- Step 5: Scan for the gate (JSON) ---
+      # The threshold gate is the merge-blocking decision, so it runs
+      # first and depends on nothing else. The wrapper tolerates
+      # SkillSpector's non-zero "findings present" exit (issue #984) and
+      # fails closed only when no usable JSON is produced.
       - name: Run SkillSpector (JSON)
+        id: json_scan
         if: steps.filter.outputs.relevant == 'true'
-        run: |
-          skillspector scan "./${SKILL_PATH}/" \
-            --no-llm \
-            --format json \
-            --output "${JSON_OUTPUT}"
+        run: .github/scripts/security/run-skillspector-scan.sh "${SKILL_PATH}" json "${JSON_OUTPUT}"
 
-      # --- Step 8: Gate on severity threshold (required check) ---
+      # --- Step 6: Gate on severity threshold (required check) ---
+      # SkillSpector has no --fail-on flag, so this script is the single
+      # authority that blocks merge. It also writes the consumable job
+      # summary (verdict table + per-finding enumeration).
       - name: Check severity threshold
         if: steps.filter.outputs.relevant == 'true'
         run: .github/scripts/security/check-skillspector-threshold.sh "${JSON_OUTPUT}"
 
+      # --- Step 7: Scan for code scanning (SARIF) ---
+      # Surfacing path. Runs even when the gate above blocked (always()),
+      # so a flagged skill still produces an inline code-scanning finding.
+      # SARIF carries no risk_assessment block, hence the separate pass.
+      - name: Run SkillSpector (SARIF)
+        id: sarif_scan
+        if: always() && steps.filter.outputs.relevant == 'true'
+        run: .github/scripts/security/run-skillspector-scan.sh "${SKILL_PATH}" sarif "${SARIF_OUTPUT}"
+
+      # --- Step 8: Normalise SARIF uris (fail closed on hostile uris) ---
+      # SkillSpector emits skill-dir-relative uris; rewrite them to be
+      # repo-relative so code scanning annotates the right files. The
+      # script rejects traversing/absolute/url uris (exit 3), which fails
+      # this job and prevents a poisoned SARIF from ever being published.
+      # Placed after the gate so a normalisation failure can never
+      # suppress the merge decision.
+      - name: Normalise SARIF paths
+        id: normalize
+        if: always() && steps.filter.outputs.relevant == 'true' && steps.sarif_scan.outcome == 'success'
+        run: .github/scripts/security/normalize-skillspector-sarif.sh "${SARIF_OUTPUT}" "${SKILL_PATH}"
+
       # --- Step 9: Publish normalised SARIF for the upload workflow ---
       # Only when normalisation succeeded, so the companion workflow can
       # trust the artifact and upload it without re-validating. always()
-      # so a failed gate still surfaces findings.
+      # so a blocked gate still surfaces findings in code scanning.
       - name: Upload SARIF artifact
         if: always() && steps.filter.outputs.relevant == 'true' && steps.normalize.outcome == 'success' && hashFiles(env.SARIF_OUTPUT) != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/docs/ops/skill-security-scan.md
+++ b/docs/ops/skill-security-scan.md
@@ -9,8 +9,9 @@ This runs as **two workflows**. The scan workflow runs in the untrusted PR conte
 | Scan workflow     | `.github/workflows/skill-security-scan.yml` (PR context: scan + gate, no write scopes)                         |
 | Upload workflow   | `.github/workflows/skill-security-scan-upload.yml` (trusted `workflow_run`: publishes SARIF)                   |
 | Gate script       | `.github/scripts/security/check-skillspector-threshold.sh`                                                      |
+| Scan wrapper      | `.github/scripts/security/run-skillspector-scan.sh`                                                             |
 | SARIF normaliser  | `.github/scripts/security/normalize-skillspector-sarif.sh`                                                      |
-| Tests             | `tests/unit/bash/ci/check-skillspector-threshold.bats`, `tests/unit/bash/ci/normalize-skillspector-sarif.bats` |
+| Tests             | `tests/unit/bash/ci/check-skillspector-threshold.bats`, `tests/unit/bash/ci/run-skillspector-scan.bats`, `tests/unit/bash/ci/normalize-skillspector-sarif.bats` |
 | Scan target       | `skills/azure-cost-calculator/`                                                                                 |
 | Trigger           | All pull requests to `dev` and `main`; scan only runs when files under `skills/azure-cost-calculator/**` change |
 | Fail threshold    | `HIGH` or `CRITICAL` (configurable via `SKILLSPECTOR_FAIL_ON`)                                                  |
@@ -23,14 +24,18 @@ This runs as **two workflows**. The scan workflow runs in the untrusted PR conte
 
 SkillSpector is a static analyzer for AI agent skills. It scans `SKILL.md`, scripts, manifests, and reference data for 64 vulnerability patterns across 16 categories (prompt injection, data exfiltration, supply chain, excessive agency, MCP tool poisoning, dangerous AST patterns, taint flows, YARA signatures, and more). The README in the upstream repo lists every rule.
 
-The scan workflow runs two passes per PR, both with LLM analysis disabled for reproducibility:
+The scan workflow runs two passes per PR, both with LLM analysis disabled for reproducibility. The gate runs **first** (the merge decision); the SARIF surfacing path runs **after** it under `always()`, so a blocked gate still produces a code-scanning finding:
 
-| Pass       | Format | Purpose                                                                       |
-| ---------- | ------ | ----------------------------------------------------------------------------- |
-| SARIF pass | SARIF  | Normalised, published as an artifact, then uploaded to code scanning by the upload workflow |
-| JSON pass  | JSON   | Parsed by `check-skillspector-threshold.sh` to decide pass/fail (the required gate)         |
+| Order | Pass       | Format | Purpose                                                                       |
+| ----- | ---------- | ------ | ----------------------------------------------------------------------------- |
+| 1     | JSON pass  | JSON   | Parsed by `check-skillspector-threshold.sh` to decide pass/fail (the required gate) and to write the job summary |
+| 2     | SARIF pass | SARIF  | Normalised, published as an artifact, then uploaded to code scanning by the upload workflow |
 
 A separate JSON pass is required because SARIF does not carry SkillSpector's `risk_assessment` block, which is the source of truth for the gate.
+
+### Why the scans run through a wrapper
+
+`skillspector scan` writes its output file and then **exits non-zero when it finds HIGH or CRITICAL issues**. Under the workflow's `set -e` shell, that non-zero exit would abort the job at the scan step, before the gate ever ran, so SkillSpector's raw exit code (not the configurable gate) would block merge, and no SARIF would be published for the worst skills (issue #984). Both passes therefore go through `run-skillspector-scan.sh`, which tolerates a non-zero exit **only when the scanner produced valid output** (file exists, is non-empty, parses as JSON, and carries the minimal shape its consumer needs: a non-empty `runs[]` for SARIF or a string `risk_assessment.severity` (the one field the gate reads) for JSON) and otherwise fails closed. This keeps `check-skillspector-threshold.sh` the single decision authority. Running the gate before the SARIF normaliser also means a normalisation failure can never suppress the merge decision.
 
 ### Two-workflow architecture
 
@@ -48,7 +53,7 @@ The gate stays in the scan workflow, so it remains the required, blocking check 
 - It **never checks out or executes** PR/fork code; it only downloads the artifact and calls `upload-sarif`.
 - The PR head sha comes from the authoritative `github.event.workflow_run.head_sha` (set by GitHub), never from the artifact, so it cannot be spoofed.
 - The PR number is resolved from the commit-to-PRs API and strictly filtered (open, matching head sha, head repo, base repo, base branch). Ambiguous matches are skipped, never guessed, so a shared sha cannot redirect alerts onto another PR.
-- The scan workflow publishes the SARIF artifact **only after** `normalize-skillspector-sarif.sh` validates every uri, so a poisoned SARIF is never produced for the upload workflow to consume.
+- The scan workflow publishes the SARIF artifact **only after** `normalize-skillspector-sarif.sh` validates the artifact uri, so a poisoned SARIF is never produced for the upload workflow to consume.
 
 ### Why the SARIF needs normalising
 
@@ -149,6 +154,7 @@ skillspector scan ./skills/azure-cost-calculator/ \
 
 ```bash
 bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/check-skillspector-threshold.bats
+bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/run-skillspector-scan.bats
 bash tests/unit/run-bats-tests.sh tests/unit/bash/ci/normalize-skillspector-sarif.bats
 ```
 
@@ -197,7 +203,7 @@ Severity bands and recommendations come from SkillSpector's risk scoring (see up
 | Inline annotations on PR | "Files changed" tab; appear once `Skill Security Scan Upload` finishes (shortly after the scan check), for both same-repo and fork PRs |
 | Aggregated view          | Repo → Security → Code scanning → filter by tool `SkillSpector`              |
 | Raw JSON for scripting   | PR → Checks → `Skill Security Scan` → Artifacts → `skillspector-report`      |
-| Pass/fail summary        | PR → Checks → `Skill Security Scan` → step summary panel (this is the blocking check) |
+| Pass/fail summary        | PR → Checks → `Skill Security Scan` → step summary panel: a verdict table (score, severity, recommendation, threshold) plus a per-finding table (severity, rule, `file:line`, detail). This is the blocking check and is self-contained, so an author can see what tripped the gate without opening the Security tab |
 
 ---
 

--- a/tests/unit/bash/ci/check-skillspector-threshold.bats
+++ b/tests/unit/bash/ci/check-skillspector-threshold.bats
@@ -28,7 +28,7 @@ write_report() {
     if [ "$issue_count" -gt 0 ]; then
         issues="["
         for ((i=1; i<=issue_count; i++)); do
-            issues+='{"rule_id":"X1","severity":"'"$severity"'","message":"x"}'
+            issues+='{"id":"RULE'"$i"'","category":"secrets","severity":"'"$severity"'","confidence":0.9,"location":{"file":"scripts/x.py","start_line":'"$i"'},"explanation":"finding '"$i"'"}'
             [ "$i" -lt "$issue_count" ] && issues+=","
         done
         issues+="]"
@@ -216,5 +216,146 @@ JSON
     summary="$(cat "$GITHUB_STEP_SUMMARY")"
     [[ "$summary" == *"SkillSpector security gate"* ]]
     [[ "$summary" == *"| Severity | LOW |"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "enumerates individual findings in the step summary" {
+    write_report "HIGH" 70 "DO_NOT_INSTALL" 2
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" == *"#### Findings (2)"* ]]
+    [[ "$summary" == *"| Severity | Rule | Location | Detail |"* ]]
+    [[ "$summary" == *"| HIGH | RULE1 | scripts/x.py:1 | finding 1 |"* ]]
+    [[ "$summary" == *"| HIGH | RULE2 | scripts/x.py:2 | finding 2 |"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "omits the findings table when there are no issues" {
+    write_report "LOW" 5 "SAFE" 0
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 0 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" != *"#### Findings"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "sanitises pipe and newline characters in finding text" {
+    cat > "$REPORT" <<'JSON'
+{
+  "skill": {"name": "test"},
+  "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
+  "issues": [
+    {"id": "PIPE", "severity": "HIGH", "location": {"file": "a|b.py", "start_line": 3},
+     "explanation": "line one\nline two | piped"}
+  ]
+}
+JSON
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    # Raw newline must not leak into the table, and pipes are escaped.
+    [[ "$summary" == *"line one line two \| piped"* ]]
+    [[ "$summary" == *"a\|b.py:3"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "escapes backslash-pipe so it cannot inject a table column" {
+    # An attacker-crafted finding containing the two characters backslash
+    # then pipe must not survive as a live column delimiter. The escaped
+    # form is a literal backslash (\\) followed by an escaped pipe (\|),
+    # i.e. three backslashes then a pipe in the rendered markdown source.
+    printf '%s' '{
+  "skill": {"name": "test"},
+  "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
+  "issues": [
+    {"id": "BS", "severity": "HIGH", "location": {"file": "x.py", "start_line": 1},
+     "explanation": "evil\\|injected"}
+  ]
+}' > "$REPORT"
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" == *'evil\\\|injected'* ]]
+    # The raw (unescaped) backslash-pipe must not appear as a bare delimiter.
+    [[ "$summary" != *'evil\|injected'* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "falls back to .message when .explanation is absent" {
+    cat > "$REPORT" <<'JSON'
+{
+  "skill": {"name": "test"},
+  "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
+  "issues": [
+    {"id": "MSG", "severity": "HIGH", "location": {"file": "x.py", "start_line": 1},
+     "message": "from message field"}
+  ]
+}
+JSON
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" == *"from message field"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "sanitises a non-numeric start_line so it cannot break the table" {
+    # start_line is normally an integer, but a malformed/hostile report
+    # could carry a string containing a pipe or newline. The "// 0" guard
+    # only fires on null, so the value must still pass through san.
+    cat > "$REPORT" <<'JSON'
+{
+  "skill": {"name": "test"},
+  "risk_assessment": {"score": 90, "severity": "CRITICAL", "recommendation": "DO_NOT_INSTALL"},
+  "issues": [
+    {"id": "LINE", "severity": "CRITICAL", "location": {"file": "x.py", "start_line": "1|evil"},
+     "explanation": "detail"}
+  ]
+}
+JSON
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    # The raw pipe from start_line must be escaped, not a live delimiter.
+    [[ "$summary" == *"x.py:1\|evil"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "caps the findings table and notes the omitted findings" {
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    write_report "CRITICAL" 95 DO_NOT_INSTALL 60
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    # The header reflects the true total, but the table is capped at 50 rows.
+    [[ "$summary" == *"#### Findings (60)"* ]]
+    [[ "$summary" == *"RULE50"* ]]
+    [[ "$summary" != *"RULE51"* ]]
+    [[ "$summary" == *"Showing first 50 of 60 findings"* ]]
+    rm -f "$GITHUB_STEP_SUMMARY"
+}
+
+@test "does not show the cap note when findings fit under the limit" {
+    GITHUB_STEP_SUMMARY="$(mktemp)"
+    export GITHUB_STEP_SUMMARY
+    write_report "CRITICAL" 95 DO_NOT_INSTALL 3
+    run bash "$SCRIPT" "$REPORT"
+    [ "$status" -eq 1 ]
+    summary="$(cat "$GITHUB_STEP_SUMMARY")"
+    [[ "$summary" != *"Showing first"* ]]
     rm -f "$GITHUB_STEP_SUMMARY"
 }

--- a/tests/unit/bash/ci/run-skillspector-scan.bats
+++ b/tests/unit/bash/ci/run-skillspector-scan.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/security/run-skillspector-scan.sh
+#
+# Regression cover for issue #984: SkillSpector writes its output file
+# and then exits non-zero when it finds HIGH/CRITICAL issues. The wrapper
+# must treat such a run as a success (output is valid) so the downstream
+# threshold gate stays the single decision authority, while still failing
+# closed when no usable output is produced.
+
+setup() {
+    source "$BATS_TEST_DIRNAME/../test_helper.bash"
+    source "$BATS_TEST_DIRNAME/ci_test_helper.bash"
+
+    SCRIPT="$CI_SCRIPTS_DIR/security/run-skillspector-scan.sh"
+    setup_mock_path
+
+    # OUT must be a path that does not exist yet so the "no output file"
+    # case is exercised, but allocating it with `mktemp -u` is race-prone.
+    # Use a private dir and a fixed child name instead: the child does not
+    # exist until the stub writes it.
+    OUT_DIR="$(mktemp -d)"
+    OUT="$OUT_DIR/report.out"
+    export OUT OUT_DIR
+}
+
+teardown() {
+    teardown_mock_path
+    if [[ -n "${OUT_DIR:-}" && -d "$OUT_DIR" ]]; then
+        rm -rf "$OUT_DIR"
+    fi
+}
+
+# Create a fake `skillspector` on PATH. It honours --output <path>,
+# writing $payload there (skip writing when $payload is the literal
+# NO_OUTPUT), then exits with $exit_code.
+# Usage: stub_skillspector <exit_code> <payload>
+stub_skillspector() {
+    local exit_code="$1" payload="$2"
+    printf '%s' "$payload" > "$MOCK_DIR/skillspector_payload"
+    printf '%s' "$exit_code" > "$MOCK_DIR/skillspector_exit"
+    cat > "$MOCK_DIR/skillspector" <<'SCRIPT'
+#!/usr/bin/env bash
+out=""
+prev=""
+for arg in "$@"; do
+    [[ "$prev" == "--output" ]] && out="$arg"
+    prev="$arg"
+done
+payload="$(cat "$(dirname "$0")/skillspector_payload")"
+if [[ -n "$out" && "$payload" != "NO_OUTPUT" ]]; then
+    printf '%s' "$payload" > "$out"
+fi
+exit "$(cat "$(dirname "$0")/skillspector_exit")"
+SCRIPT
+    chmod +x "$MOCK_DIR/skillspector"
+}
+
+# ---------------------------------------------------------
+# Success: valid output, regardless of SkillSpector exit code
+# ---------------------------------------------------------
+
+@test "exit 0 with valid JSON output passes" {
+    stub_skillspector 0 '{"risk_assessment":{"severity":"LOW"},"issues":[]}'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"is present and parses"* ]]
+}
+
+@test "exit 1 with valid output still passes (the #984 regression)" {
+    stub_skillspector 1 '{"risk_assessment":{"severity":"CRITICAL"},"issues":[{"id":"X"}]}'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit 1"* ]]
+}
+
+@test "exit 1 with valid SARIF output passes" {
+    stub_skillspector 1 '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"skillspector"}},"results":[]}]}'
+    run bash "$SCRIPT" skills/azure-cost-calculator sarif "$OUT"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------
+# Fail closed: valid JSON but structurally empty (a stub or a
+# truncated write could parse yet carry no usable report)
+# ---------------------------------------------------------
+
+@test "SARIF output with empty runs[] fails closed" {
+    stub_skillspector 0 '{"version":"2.1.0","runs":[]}'
+    run bash "$SCRIPT" skills/azure-cost-calculator sarif "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no runs"* ]]
+}
+
+@test "JSON output with no risk_assessment fails closed" {
+    stub_skillspector 0 '{"issues":[]}'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no risk_assessment"* ]]
+}
+
+# ---------------------------------------------------------
+# Fail closed: no usable output
+# ---------------------------------------------------------
+
+@test "exit 1 with no output file fails closed" {
+    stub_skillspector 1 'NO_OUTPUT'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"wrote no json output"* ]]
+}
+
+@test "empty output file fails closed" {
+    stub_skillspector 0 ''
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"wrote no json output"* ]]
+}
+
+@test "non-JSON output fails closed" {
+    stub_skillspector 1 'not json{'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "JSON output with risk_assessment but no severity fails closed" {
+    stub_skillspector 0 '{"risk_assessment":{}}'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no risk_assessment.severity"* ]]
+}
+
+# ---------------------------------------------------------
+# Fail closed: a stale/planted output file must not be trusted
+# when the scanner produces nothing on this run
+# ---------------------------------------------------------
+
+@test "pre-existing output is cleared so a stale report is not trusted" {
+    printf '%s' '{"risk_assessment":{"severity":"LOW"}}' > "$OUT"
+    stub_skillspector 1 'NO_OUTPUT'
+    run bash "$SCRIPT" skills/azure-cost-calculator json "$OUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"wrote no json output"* ]]
+}
+
+# ---------------------------------------------------------
+# Input errors (exit 2)
+# ---------------------------------------------------------
+
+@test "missing arguments exit 2" {
+    run bash "$SCRIPT" skills/azure-cost-calculator json
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "unsupported format exit 2" {
+    run bash "$SCRIPT" skills/azure-cost-calculator xml "$OUT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unsupported format"* ]]
+}


### PR DESCRIPTION
… (#985)

* fix: make skillspector gate authoritative and surface findings (#984)

skillspector scan writes its output then exits non-zero on HIGH/CRITICAL findings; under set -e that aborted the scan job before the threshold gate and the SARIF upload, so the documented gate never ran for the dangerous case and no code-scanning finding was produced.

- Add run-skillspector-scan.sh: tolerate a non-zero scan exit only when valid output was written (exists, non-empty, parses), else fail closed.
- Reorder skill-security-scan.yml so the JSON scan + gate run first (the merge decision) and the SARIF scan + normalise + upload run after under always(), so a blocked gate still surfaces a code-scanning finding and a normalisation failure cannot suppress the decision.
- Enumerate findings in the gate job summary as a sanitised markdown table (escape backslashes and pipes, collapse newlines, truncate) since the text derives from the untrusted scanned skill.
- Fix the gate bats fixture to the real SkillSpector issue schema and add wrapper, enumeration, and sanitisation tests.
- Update docs/ops/skill-security-scan.md.



* fix: address skillspector gate review comments (#984)

Resolve PR review feedback on the SkillSpector gate and surfacing: sanitise the start_line column in the job-summary findings table, cap the table at 50 rows with an overflow note, harden the scan wrapper (set -euo pipefail plus a fail-closed shape check that rejects structurally empty output), and correct the SARIF normaliser comment to name the single uri path it validates.



* fix: harden skillspector scan wrapper validation (#984)

Address PR review feedback on the scan wrapper:

- Reject unsupported FORMAT up front (exit 2) so an unknown value cannot skip structural validation and return a false success.
- Require a string risk_assessment.severity (the field the gate reads) instead of just the risk_assessment key, so {"risk_assessment":{}} fails closed in the wrapper rather than only at the gate.
- Remove any pre-existing output before scanning so a stale or planted report cannot be trusted if the scanner fails to write, since the workflow uses fixed filenames in an untrusted pull_request checkout.

Adds bats coverage for all three cases.



---------

## Description

<!-- Brief description of the service reference being added or changed -->

## Pre-submission Checklist

- [ ] YAML front matter has `serviceName`, `category`, and `aliases`
- [ ] `serviceName` matches the exact case-sensitive API value
- [ ] `category` matches the folder this file is in
- [ ] First query pattern appears within lines 1-45
- [ ] All API filter values verified against live API using `skills/azure-cost-calculator/scripts/Explore-AzurePricing.ps1`
- [ ] Cost formula uses `retailPrice` from API (no hardcoded prices)
- [ ] Validation script passes locally: `.\tests\Validate-ServiceReference.ps1 -Path skills\azure-cost-calculator\references\services\{category}\{file} -CheckAliasUniqueness`
- [ ] File placed in correct `skills/azure-cost-calculator/references/services/{category}/` folder
