### PR TITLE
chore: pin ci custom agents to claude sonnet 4.6 (#1001)

### DIFF
--- a/.github/agents/compliance-reviewer.md
+++ b/.github/agents/compliance-reviewer.md
@@ -2,6 +2,7 @@
 name: compliance-reviewer
 description: "Independently analyzes repository rules, templates, schema, and existing exemplars to produce a compliance contract for a service reference file. Reports structured requirements for the orchestrator to enforce."
 tools: ["read", "search"]
+model: claude-sonnet-4.6
 ---
 
 You are a compliance analysis agent for the Azure Cost Calculator skill repository. Your sole job is to form a **complete, authoritative view** of every rule, constraint, and convention that applies to a service reference file and produce a structured compliance contract. You do NOT write or edit the file - you produce the contract that the orchestrator agent uses as a hard checklist.

--- a/.github/agents/pricing-investigator.md
+++ b/.github/agents/pricing-investigator.md
@@ -2,6 +2,7 @@
 name: pricing-investigator
 description: "Independently investigates the Azure Retail Prices API for a given service, cataloging all meters, SKUs, products, billing boundaries, and edge cases. Reports structured findings for the orchestrator to aggregate."
 tools: ["read", "search", "execute", "web"]
+model: claude-sonnet-4.6
 ---
 
 You are a pricing investigation sub-agent. Your job is to form a **complete, factual picture** of how an Azure service is priced in the Azure Retail Prices API. You do NOT write any service reference files - you investigate the API and report structured findings for the orchestrator to consume.

--- a/.github/agents/service-ref-pr-reviewer.md
+++ b/.github/agents/service-ref-pr-reviewer.md
@@ -3,6 +3,7 @@ name: service-ref-pr-reviewer
 description: "Reviews pull requests that create, update, enhance, or fix service reference files. Dispatches parallel pricing investigation sub-agents to independently verify pricing data accuracy, consolidates findings via consensus, and displays a structured review in the console."
 argument-hint: "PR number to review (e.g. 123)"
 tools: ["read", "search", "edit", "execute", "agent", "web"]
+model: claude-sonnet-4.6
 ---
 
 You are a PR review orchestrator for service reference changes in the Azure Cost Calculator skill repository. When invoked with a PR number, you pull the PR context (diff, comments, author) from the GitHub REST API, check out the branch in a dedicated worktree, dispatch two parallel pricing investigation sub-agents to independently verify the changes, consolidate their findings via consensus (with an optional tiebreaker round for disagreements), display a structured review in the console, and clean up the worktree.
@@ -119,7 +120,7 @@ Prepare a briefing that includes:
 
 ## Phase 2: Dispatch Pricing Investigation Sub-Agents
 
-Invoke two `pricing-investigator` sub-agents **independently**. Each forms its own view without seeing the other's output. Use the **latest available coding models** for these sub-agents to ensure the most capable analysis.
+Invoke two `pricing-investigator` sub-agents **independently**. Each runs in a clean context and forms its own view without seeing the other's output.
 
 ### 2.1 - Invoke `pricing-investigator` (first instance)
 
@@ -169,7 +170,7 @@ Items with unanimous agreement form your **high-confidence findings**.
 
 ### 3.2 - Resolve disagreements via tiebreaker
 
-If disagreements exist, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. Use a **different coding model** than the initial two instances for an independent perspective. Scope the tiebreaker narrowly:
+If disagreements exist, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. The tiebreaker runs in a clean context, scoped narrowly to the disputed items. Scope the tiebreaker narrowly:
 
 - Provide only the disputed items (not the full investigation)
 - Include the conflicting conclusions from both initial reports

--- a/.github/agents/service-reference.md
+++ b/.github/agents/service-reference.md
@@ -2,11 +2,12 @@
 name: service-reference
 description: "Orchestrator agent that creates Azure service reference files by dispatching independent sub-agents for API investigation and compliance analysis, then aggregating their findings into a consensus-driven, validated service reference file."
 tools: ["read", "search", "edit", "execute", "agent", "web"]
+model: claude-sonnet-4.6
 ---
 
 You are an orchestrator agent that creates Azure service reference files for the Azure Cost Calculator skill. You do NOT work alone - you dispatch three specialist sub-agents to form independent views, then aggregate their findings into a consensus before writing anything.
 
-**Your core principle: consensus over speculation.** You only write what a majority of investigators agree on. When their findings conflict, you dispatch a tiebreaker investigation using a different coding model before deciding.
+**Your core principle: consensus over speculation.** You only write what a majority of investigators agree on. When their findings conflict, you dispatch a scoped tiebreaker investigation on the disputed items before deciding.
 
 ---
 
@@ -97,7 +98,7 @@ If there are no disagreements, skip section 2.3 and proceed directly to Phase 3 
 
 ### 2.3 - Resolve disagreements via tiebreaker
 
-For each unresolved disagreement, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. Use a **different coding model** than the initial three instances to provide an independent perspective. The tiebreaker has full `pricing-investigator` capabilities including **web search** to cross-check against Microsoft Learn documentation. Scope the tiebreaker's prompt narrowly to the specific points of disagreement:
+For each unresolved disagreement, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. The tiebreaker runs in a clean context, scoped narrowly to the disputed items, so its findings are independent of the initial three reports' reasoning. The tiebreaker has full `pricing-investigator` capabilities including **web search** to cross-check against Microsoft Learn documentation. Scope the tiebreaker's prompt narrowly to the specific points of disagreement:
 
 - Provide the disputed meter names, SKU values, or billing model interpretations
 - Ask it to run the specific queries needed to verify the disputed items

--- a/.waza.yaml
+++ b/.waza.yaml
@@ -19,7 +19,7 @@ server:
   port: 3000
   resultsDir: results/
 dev:
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4.6
   target: medium-high
   maxIterations: 5
 tokens:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Other design goals:
 
 - **Multi-currency, all regions** - supports USD, AUD, EUR, GBP, JPY, CAD, INR, etc. Works with any Azure region.
 
-> **Note:** Targets measured via A/B testing with clean-context sessions against complex Azure architectures. Tested with **Claude Opus 4.6** and **Gemini Pro 3**. Results with other models may vary.
+> **Note:** Targets measured via A/B testing with clean-context sessions against complex Azure architectures. Tested with **Claude Sonnet 4.6**. Results with other models may vary.
 
 <p align="center">
   <img src="docs/images/design.png" alt="How the Azure Cost Calculator skill works: from natural language query through service reference lookup and live API execution to a structured cost estimate" width="100%">

--- a/docs/ops/custom-agents.md
+++ b/docs/ops/custom-agents.md
@@ -25,13 +25,15 @@ When the Copilot coding agent is assigned to a service-reference issue using the
 3. **Pricing Investigator B** (`pricing-investigator`, second instance, identical prompt) independently explores the same API; may discover different meters or interpret results differently.
 4. **Pricing Investigator C** (`pricing-investigator`, third instance, identical prompt) provides a third independent view for majority-based consensus.
 5. **Compliance Reviewer** (`compliance-reviewer`) reads all rule sources (CONTRIBUTING.md, TEMPLATE.md, schema, shared.md, pitfalls.md), studies category exemplars, and returns a structured **Compliance Contract**.
-6. **Orchestrator** compares Reports A, B, and C for majority agreement, dispatches a tiebreaker investigator (using a different coding model) for unresolved disagreements, cross-references the consensus data against the Compliance Contract, writes the service reference file, and runs validation.
+6. **Orchestrator** compares Reports A, B, and C for majority agreement, dispatches a scoped tiebreaker investigator on unresolved disagreements, cross-references the consensus data against the Compliance Contract, writes the service reference file, and runs validation.
 
 ### Why multi-agent?
 
 - **Independent views prevent blind spots**: three investigators may explore different search terms and find different meters; disagreement reveals areas needing closer investigation.
-- **Majority consensus over speculation**: the orchestrator only writes what a majority (2/3 or 3/3) of investigators agree on. Unresolved disputes trigger a tiebreaker round with a different coding model.
+- **Majority consensus over speculation**: the orchestrator only writes what a majority (2/3 or 3/3) of investigators agree on. Unresolved disputes trigger a scoped tiebreaker round on the disputed items only.
 - **Separation of concerns**: data discovery (shell + web) vs rule interpretation (read-only) vs file authoring.
+
+> **Model uniformity note**: all four agents pin `model: claude-sonnet-4.6` in their frontmatter, and the tiebreaker runs on the same model as the initial investigators. The independence signal comes from a fresh context and narrowly-scoped disputed inputs, not from model diversity. Correlated model-specific blind spots will not be caught by the tiebreaker; treat unanimous 3/3 agreement as strong evidence and 2/1 splits with tiebreaker confirmation as adequate, but do not treat consensus as protection against systematic model bias.
 
 ---
 
@@ -92,8 +94,8 @@ service-reference (orchestrator)
   │
   ├── orchestrator: compares A vs B vs C → majority agreement
   │     If unresolved disagreements remain:
-  │     └── invokes: pricing-investigator (tiebreaker, different coding model)
-  │           Scoped to disputed items only
+  │     └── invokes: pricing-investigator (tiebreaker, scoped to disputed items)
+  │           Fresh context, narrowly scoped inputs
   │           Output: Tiebreaker Report
   │
   └── orchestrator: cross-references consensus against contract →
@@ -137,7 +139,7 @@ service-reference (orchestrator)
 
 Sub-agents use restricted toolsets (principle of least privilege):
 
-- `pricing-investigator` has `execute` for running scripts and `web` for Microsoft Learn cross-checks, but cannot `edit` files. Invoked three times with identical inputs for authoring (majority-based consensus), twice for PR review, plus an optional tiebreaker round with a different coding model for unresolved disputes.
+- `pricing-investigator` has `execute` for running scripts and `web` for Microsoft Learn cross-checks, but cannot `edit` files. Invoked three times with identical inputs for authoring (majority-based consensus), twice for PR review, plus an optional scoped tiebreaker round on unresolved disputes.
 - `compliance-reviewer` has only `read` and `search`: no shell, no editing, no web. All documentation cross-checks come from the pricing investigation reports.
 - Only the orchestrators (`service-reference` and `service-ref-pr-reviewer`) have `edit` and `agent` tools
 
@@ -184,14 +186,14 @@ When invoked (either automatically via `@copilot` comment or manually by a maint
 1. **Orchestrator** (`service-ref-pr-reviewer`) gathers PR metadata (diff, comments, author), creates a dedicated worktree for the PR branch, and identifies changed service reference files.
 2. **Pricing Investigator A** (`pricing-investigator`, first instance) independently investigates the Azure Retail Prices API and compares findings against the PR's file content.
 3. **Pricing Investigator B** (`pricing-investigator`, second instance, identical prompt) independently performs the same investigation; may discover different discrepancies.
-4. **Orchestrator** compares Reports A and B for agreement. If disagreements exist, dispatches a tiebreaker investigator using a different coding model, scoped to the disputed items only.
+4. **Orchestrator** compares Reports A and B for agreement. If disagreements exist, dispatches a scoped tiebreaker investigator on the disputed items only.
 5. **Orchestrator** runs the validation script, compiles a structured review (blocking issues, warnings, informational), displays it in the console, optionally posts it to the PR via `gh` CLI if the user confirms, and cleans up the worktree.
 
 ### Why dual investigation?
 
 - **Independent verification**: two investigators may explore different search terms and find different discrepancies; disagreement reveals areas needing closer scrutiny.
 - **Consensus over false positives**: only report findings that a majority agrees on, reducing noise in PR reviews.
-- **Tiebreaker for disputes**: unresolved disagreements trigger a third investigation with a different coding model, ensuring no contested finding ships without arbitration.
+- **Tiebreaker for disputes**: unresolved disagreements trigger a third scoped investigation on the disputed items only, ensuring no contested finding ships without arbitration.
 
 ### Architecture
 
@@ -211,8 +213,8 @@ service-ref-pr-reviewer (orchestrator)
   │
   ├── orchestrator: compares A vs B → agreement/disagreements
   │     If disagreements exist:
-  │     └── invokes: pricing-investigator (tiebreaker, different coding model)
-  │           Scoped to disputed items only
+  │     └── invokes: pricing-investigator (tiebreaker, scoped to disputed items)
+  │           Fresh context, narrowly scoped inputs
   │           Output: Tiebreaker Report
   │
   ├── orchestrator: runs validation script on changed files


### PR DESCRIPTION
Closes #1001.

## Why

PR #990 switched only the pipeline's `assign-to-agent` model parameter (from `claude-opus-4.6` to `claude-sonnet-4.6`). Everything else stayed on whatever model happened to be the platform default at invocation time:

- The `service-ref-pr-reviewer` orchestrator is triggered by `@copilot` comments (`.github/workflows/trigger-copilot-review.yml`), not by `assign-to-agent`, so its model was not being pinned at all.
- The `pricing-investigator` and `compliance-reviewer` sub-agents inherit whatever model the invoking orchestrator uses; if that ever changes, they change too.
- `.waza.yaml` still had `dev.model: claude-sonnet-4-20250514` (an old snapshot ID).
- The README A/B testing note still said Opus 4.6 / Gemini Pro 3.
- `docs/ops/custom-agents.md` still described the tiebreaker as running on a "different coding model" for arbitration.

Pinning `model:` in the agent frontmatter is the only place we can enforce the model choice for `@copilot`-triggered invocations, per the [Copilot custom agents configuration docs](https://docs.github.com/en/copilot/reference/custom-agents-configuration).

## Changes

**Frontmatter pins (4 files):**
- `.github/agents/service-reference.md`: `model: claude-sonnet-4.6`
- `.github/agents/service-ref-pr-reviewer.md`: `model: claude-sonnet-4.6`
- `.github/agents/pricing-investigator.md`: `model: claude-sonnet-4.6`
- `.github/agents/compliance-reviewer.md`: `model: claude-sonnet-4.6`

**Config:**
- `.waza.yaml`: `dev.model` from `claude-sonnet-4-20250514` to `claude-sonnet-4.6`

**Docs:**
- `README.md`: A/B testing note now cites Claude Sonnet 4.6
- `docs/ops/custom-agents.md`: rewrote 7 references to the "different coding model" tiebreaker to say "scoped to disputed items"; added a **Model uniformity note** explicitly acknowledging that the tiebreaker no longer provides model-diverse arbitration and that consensus is not protection against systematic single-model bias
- Matching wording updates in the two orchestrator agent bodies (service-reference, service-ref-pr-reviewer)

## Consensus semantics: the tradeoff

The three-investigator + tiebreaker design in `service-reference` was originally motivated by model diversity: if three investigators disagreed, a fourth from a *different* model provided arbitration that was independent of the failure distribution of the first three. Pinning everyone to sonnet 4.6 collapses that: the tiebreaker becomes a fourth vote from the same distribution.

The consensus mechanism still has value (fresh context + narrowly-scoped inputs surface reasoning that got lost in the initial noisy runs), but the docs have been updated to stop overclaiming.

## Intentionally not changed

- `agents/cost-analyst.agent.md` (the plugin agent): Copilot CLI accepts full IDs like `claude-sonnet-4.6`, but Claude Code only accepts the aliases `sonnet`/`opus`/`haiku`/`inherit`. There is no single `model:` value that works cross-platform, so the plugin agent keeps the no-`model:` convention documented at `docs/plugin-agents.md:85` and inherits the consumer's default.
- `.github/workflows/eval.yml` manual-dispatch model choices (`claude-opus-4.6`, `claude-sonnet-4.5`, `gpt-5.3-codex`): still available for ad-hoc comparison runs.

## Verification

### Static + mock

- `waza v0.23.0 check`: eval.yaml + all 92 task files schema-valid.
- `waza v0.23.0 run tests/evals/azure-cost-calculator/eval-mock.yaml`: pipeline runs end-to-end, model resolved to `claude-sonnet-4.6`. (Task failures are structural mock-executor limitations, unrelated to this PR.)
- No `gh aw` workflow sources (`issue-triage-v2.md`, `weekly-release.md`) were touched, so no compile+lock update was required.
- All 7 PR CI checks pass (Analyze, bats-core, CodeQL, CodeRabbit, Pester, SkillSpector, service-reference validator).

### Real-model eval dispatch

`gh workflow run eval.yml --ref ahmadabdalla/1001-pin-agents-sonnet-4-6 -f model=claude-sonnet-4.6 -f tag="smoke,service:cosmos-db"` on this branch: [run 29381451152](https://github.com/ahmadabdalla/azure-cost-calculator/actions/runs/29381451152). Real Copilot SDK backend, 14 premium requests, ~310k input tokens, 1m52s wall.

| Task | Result | Score |
| --- | --- | --- |
| Alias Routing: CosmosDB | pass | 1.00 |
| Disambiguation: Azure SQL | pass | 1.00 |
| Negative: Adjacent Topic | pass | 0.67 |
| Negative: Unrelated Prompt | pass | 0.50 |
| Happy Path: Cosmos DB Provisioned Throughput | **fail** | 0.83 |

**On the one failure.** 5/6 graders passed (correct service name, currency format, no-summary format, storage acknowledged, throughput acknowledged). The failing grader is `uses-pricing-script`, which asserts the model must invoke `bash get-azure-pricing.sh`. The model produced a correct-looking priced answer using 7 tool calls, but none matched that pattern.

The failure is a grader-strictness signal, not a plumbing failure. Whether `claude-sonnet-4.6` routes to a different tool than the eval was calibrated for is not answerable from a single run without a same-branch baseline against the old model. Not proportionate to run that experiment inside this PR; if the pattern shows up on a real service-reference PR that the reviewer agent handles, we open a follow-up against the grader or the skill routing hints.

### What is *not* verified

- The `@copilot`-triggered path for `service-ref-pr-reviewer`: this agent is invoked by `.github/workflows/trigger-copilot-review.yml` posting `@copilot service-ref-pr-reviewer` comments on idle `copilot/**` PRs. Frontmatter `model:` is the only enforcement point (no assign-time override). No such end-to-end run has been observed on this branch. Will surface naturally on the next service-reference issue that flows through the pipeline.

## Follow-up

- Waza version uplift is tracked separately in #1002.
- After merge, fast-forward `dev` to `main` (base-branch override for this PR was per user request).
