### PR TITLE
fix: refresh pricing data for Azure AI Content Understanding

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
@@ -16,6 +16,8 @@ privateEndpoint: true
 
 > **Trap (regional gaps)**: Only 3 regions (westus, swedencentral, australiaeast) have all 22 meters. Default region eastus has only 7 GA content extraction meters. Field Extraction, Classification, and Face meters return empty in other regions.
 
+> **Trap (regional prices)**: Within the 3-region narrow tier, `swedencentral` prices differ from `westus`/`australiaeast` by ~9–10%; the direction inverts by meter type. Per-page and per-hour narrow-tier meters are cheaper in swedencentral; token-based narrow-tier meters are more expensive. `westus` and `australiaeast` are always price-identical. Specify region explicitly for narrow-tier meter queries.
+
 ## Query Pattern
 
 ### Standard document content extraction: 10K pages/month
@@ -49,15 +51,6 @@ SkuName: Std Field Extract Inp
 MeterName: Std Field Extract Inp Tokens
 Quantity: 1000 # 1000 × 1K = 1M tokens
 
-## Key Fields
-
-| Parameter     | How to determine                     | Example values                                                      |
-| ------------- | ------------------------------------ | ------------------------------------------------------------------- |
-| `serviceName` | Always `Foundry Tools`               | `Foundry Tools`                                                     |
-| `productName` | Always `Azure Content Understanding` | `Azure Content Understanding`                                       |
-| `skuName`     | Modality + extraction tier           | `Doc Content Extraction Standard`, `Audio Content Extraction`       |
-| `meterName`   | SKU name + unit suffix               | `Doc Content Extraction Standard Pages`, `Audio Content Extraction` |
-
 ## Meter Names
 
 | Meter | skuName | unitOfMeasure | Notes |
@@ -67,13 +60,23 @@ Quantity: 1000 # 1000 × 1K = 1M tokens
 | `Doc Content Extraction Standard Pages` | `Doc Content Extraction Standard` | `1K` | Standard doc extraction; 16 regions |
 | `Audio Content Extraction` | `Audio Content Extraction` | `1 Hour` | Audio processing; 16 regions |
 | `Video Content Extraction` | `Video Content Extraction` | `1 Hour` | Video processing; 16 regions |
-| `Std Contextualization Tokens` | `Std Contextualization` | `1K` | Token-based contextualization; 16 regions |
-| `Add-On Layout Pages` | `Add-On Layout` | `1K` | Layout extraction add-on; 16 regions |
-| `Std Field Extract Inp Tokens` | `Std Field Extract Inp` | `1K` | Standard field input; 3 regions |
-| `Std Field Extract Outp Tokens` | `Std Field Extract Outp` | `1K` | Standard field output; 3 regions |
-| `Document Field Extraction Pages` | `Document Field Extraction` | `1K` | Doc field extraction; 3 regions |
-| `Image Field Extraction Images` | `Image Field Extraction` | `1K` | Image field extraction; 3 regions |
+| `Std Contextualization Tokens` | `Std Contextualization` | `1K` | Sub-cent; 16 regions |
+| `Add-On Layout Pages` | `Add-On Layout` | `1K` | Layout add-on; 16 regions |
+| `Std Field Extract Inp Tokens` | `Std Field Extract Inp` | `1K` | Sub-cent; 3 regions |
+| `Std Field Extract Outp Tokens` | `Std Field Extract Outp` | `1K` | 3 regions |
+| `Document Field Extraction Pages` | `Document Field Extraction` | `1K` | 3 regions |
+| `Image Field Extraction Images` | `Image Field Extraction` | `1K` | 3 regions |
 | `Face Storage Faces` | `Face Storage` | `1K/Month` | Monthly face storage; 3 regions |
+| `Add-On Face Grouping Video` | `Add-On Face Grouping` | `1 Hour` | Face grouping add-on; 3 regions |
+| `Add-On Formula Pages` | `Add-On Formula` | `1K` | Formula extraction add-on; 3 regions |
+| `Audio Field Extraction` | `Audio Field Extraction` | `1 Hour` | Audio field extraction; 3 regions |
+| `Classification Input Tokens` | `Classification Input` | `1K` | Sub-cent; 3 regions |
+| `Classification Output Tokens` | `Classification Output` | `1K` | 3 regions |
+| `Face Transaction Transactions` | `Face Transaction` | `1K` | 3 regions |
+| `Pro Contextualization Tokens` | `Pro Contextualization` | `1K` | Sub-cent; 3 regions |
+| `Pro Field Extract Inp Tokens` | `Pro Field Extract Inp` | `1K` | Sub-cent; 3 regions |
+| `Pro Field Extract Outp Tokens` | `Pro Field Extract Outp` | `1K` | Sub-cent; 3 regions |
+| `Video Field Extraction` | `Video Field Extraction` | `1 Hour` | Video field extraction; 3 regions |
 
 ## Cost Formula
 
@@ -94,5 +97,3 @@ Composite:              Monthly = ContentExtraction + Contextualization + FieldE
 - **Two-phase billing**: Content extraction + field extraction are separate meters for all modalities (doc/audio/video); field extraction rates are significantly higher
 - **Capacity planning**: `Quantity: 1` = 1K pages/tokens/images when `unitOfMeasure` is `1K`; `1 Hour` meters bill per hour of media processed
 - **Supports private endpoints** via AI Services multi-service resource (see `networking/private-link.md` for PE pricing)
-- **10 additional meters** in 3-region tier: Classification In/Out, Pro Contextualization, Pro Field Extract In/Out, Audio/Video Field Extraction, Add-On Formula/Face Grouping, Face Transaction. Query `ProductName: Azure Content Understanding` in westus
-- **Scope**: For broader Foundry Tools coverage, see `ai-services.md`


### PR DESCRIPTION
## Summary

This PR refreshes the pricing data for **Azure AI Content Understanding** (`ai-ml/ai-content-understanding.md`) based on three independent API investigations run against the live Azure Retail Prices API.

---

## Phase 1–2: Pricing Investigation Reports & Consensus

Three independent `pricing-investigator` agents queried `ServiceName: Foundry Tools` + `ProductName: Azure Content Understanding` across all regions.

### Agreement (3/3 unanimous)

| Finding | Detail |
|---|---|
| Total meters | 22 (unchanged — 0 added, 0 removed) |
| Billing model | PAYG only; no RI (confirmed 0 reservation results) |
| productName casing | `Azure Content Understanding` (no "AI") confirmed |
| Regional tiers | 3-region full (22m), 16-region standard (7m), centralindia partial (1m) |
| **NEW: swedencentral price variance** | Narrow-tier prices differ ~9–10% from westus/australiaeast; direction inverts by unit type |
| Sub-cent meters | 6–7 meters show `$0.00` in script; use `retailPrice` directly |
| 10 previously notes-only meters | All confirmed present in API; suitable for table promotion |

### Disagreements

**None requiring a tiebreaker.** The only discrepancy was definitional: investigators 1 & 2 referred to a "16-region GA tier" while investigator 3 counted "13 standard + 3 full = 16". These are the same underlying data (wide-tier meters available in all 16 regions, which includes the 3 full-tier regions). No tiebreaker dispatched.

---

## Phase 3: Compliance Contract & Data-vs-Rules Conflicts

**Compliance contract applied:**
- `queryServiceNames` omitted (all query ServiceName values covered by `apiServiceName` and `billingNeeds`)
- All elision-rule fields omitted (`hasMeters`, `pricingRegion`, `hasKnownRates`, `hasFreeGrant`, `billingConsiderations`)
- `privateEndpoint: true` retained
- `billingNeeds: [Azure OpenAI Service]` retained

**Budget conflict resolution:** File was at 98 lines with only 2 lines of slack. Adding 10 meter rows (+10) and a new trap (+2) required reclaiming 12 lines. Resolved by:
- Removing optional `## Key Fields` section (−9 lines; redundant with traps and query examples)
- Removing "10 additional meters" Notes bullet (−1 line; promoted to table)
- Removing "Scope" cross-reference Notes bullet (−1 line; lowest-value content)
- Net: **99 lines** (within 100-line limit ✓)

**No other data-vs-rules conflicts detected.**

---

## Changes Made

| Change | Type | Rationale |
|---|---|---|
| **Add `Trap (regional prices)`** | New trap | swedencentral narrow-tier prices differ from westus/australiaeast by ~9–10%; direction inverts by unit type. Not previously documented. All 3 investigators found this. |
| **Expand Meter Names table 12 → 22 rows** | Data update | 10 meters previously in a Notes bullet are now confirmed API meters with known skuName and unitOfMeasure. Table is now complete. |
| **Remove `## Key Fields` section** | Deletion | Optional section; redundant with traps. Removed to meet line budget. |
| **Remove "10 additional meters" Notes bullet** | Deletion | Content promoted to Meter Names table. |
| **Remove "Scope" Notes bullet** | Deletion | Lowest-value item; removed for line budget. |

---

## Documentation Cross-Check

- Investigators 1 & 3 could not access the pricing page (`/pricing/details/ai-content-understanding/` returns 404 or dynamic JS). Investigator 2 accessed the pricing page at an alternative URL and confirmed PAYG model, no RI, and multi-modal tiers consistent with API findings.
- API data is authoritative per CONTRIBUTING.md authority hierarchy (API evidence > docs for what exists).
- swedencentral price variance not documented on any pricing page reviewed; API data is the source of truth.

---

## Validation

```
RESULT: PASS - All checks passed (38/38)
```

Checks include: yaml_front_matter, frontmatter fields, category, file_placement, forty_five_line_rule (first ServiceName at line 25 < 45), line_count_limit (99 ≤ 100), servicename_consistency, inline_aliases, query_block_completeness, no_hardcoded_prices, alias_uniqueness, routing_file_sync, and all structural checks.

---

## Eval Task

Existing task at `tests/evals/azure-cost-calculator/tasks/ai-ml/ai-content-understanding/doc-extraction-standard-10k-pages.yaml` is unmodified and satisfies the coverage contract:
- Tagged: `happy-path` ✓
- Tagged: `service:ai-content-understanding` ✓
- `bash tests/check-eval-coverage.sh ...` returns no output (= covered ✓)

No eval task changes required — the pricing refresh does not add or remove query patterns.
