### PR TITLE
feat: increase service reference line limit to 120

### DIFF
--- a/.github/agents/compliance-reviewer.md
+++ b/.github/agents/compliance-reviewer.md
@@ -37,6 +37,7 @@ These characteristics determine which conditional fields, sections, traps, and n
 ## Step 1: Read All Rule Sources
 
 Read each of the following files **completely** - do not skim. Extract every rule, constraint, format requirement, and convention.
+Read `MaxLineCount` from `tests/lib/validation/ValidationConfig.psd1` and derive all line budgets and reported limits from it.
 
 ### 1.1 - `CONTRIBUTING.md`
 
@@ -123,7 +124,7 @@ For each exemplar, measure and record:
 7. **Optional sections present** - which optional sections are included and why they're relevant
 8. **Private endpoint handling** - whether and how PE support is documented in Notes
 9. **Billing considerations** - how billing notes are structured
-10. **Total line count** - the file's total length (must be < 100)
+10. **Total line count** - the file's total length (must not exceed `MaxLineCount`)
 11. **Tone and depth** - technical density, explanation style, how much context is given
 
 Use these measurements to derive the line budget for the compliance contract:
@@ -131,7 +132,7 @@ Use these measurements to derive the line budget for the compliance contract:
 - **YAML budget** = median of exemplar YAML line counts. Add 2 lines if the service needs `billingNeeds` or `billingConsiderations`.
 - **Trap budget** = max trap count from exemplars if the service has similar characteristics, otherwise median.
 - **Per-section budget** = median of each exemplar's section line count.
-- **Total budget** = sum of section medians, capped at 95 lines (5-line buffer under the 100-line hard limit).
+- **Total budget** = sum of section medians, capped at `MaxLineCount - 5`.
 - **First query deadline** = minimum first-query-line from exemplars (must be ≤ 45).
 
 ---
@@ -188,7 +189,7 @@ Based on exemplar analysis:
 - Meter Names table: ~{N} lines
 - Cost Formula: ~{N} lines
 - Notes: ~{N} lines
-- **Total: ~{N} lines** (must be < 100)
+- **Total: ~{N} lines** (must not exceed {MaxLineCount})
 - **First query pattern must start by line 45**
 
 ### Required Sections (in exact order)
@@ -242,7 +243,7 @@ Every item below is a pass/fail gate. The file must satisfy all of them:
 7. [ ] No verified dates
 8. [ ] All YAML fields pass schema validation (types, lengths, allowed values)
 9. [ ] Elision rule followed - no fields set to their default values
-10. [ ] Total file length < 100 lines
+10. [ ] Total file length does not exceed {MaxLineCount}
 11. [ ] Validation script passes: `pwsh tests/Validate-ServiceReference.ps1 -Path {filepath} -CheckAliasUniqueness`
 12. [ ] Happy-path eval task exists at `tests/evals/azure-cost-calculator/tasks/{category}/{service-name}/` tagged `happy-path` and `service:<service-name>`, and `waza check` passes
 

--- a/.github/agents/service-ref-pr-reviewer.md
+++ b/.github/agents/service-ref-pr-reviewer.md
@@ -103,6 +103,7 @@ Read these files to understand conventions and known issues:
 
 - `CONTRIBUTING.md`: contributor guide, "The Prompt" workflow, hard rules
 - `docs/TEMPLATE.md`: canonical file structure and formatting rules
+- `tests/lib/validation/ValidationConfig.psd1`: configured service-reference line limit
 - `skills/azure-cost-calculator/references/pitfalls.md`: known API traps
 - `skills/azure-cost-calculator/references/shared.md`: category index, constants
 - `skills/azure-cost-calculator/references/service-routing.md`: implemented services
@@ -201,7 +202,7 @@ Record pass/fail status and any failure messages.
 Manually verify against key rules from `CONTRIBUTING.md`:
 
 - First query pattern starts within lines 1–45
-- Total file length < 100 lines
+- Total file length does not exceed `MaxLineCount` from `tests/lib/validation/ValidationConfig.psd1`
 - No hardcoded dollar amounts outside Known Rates tables
 - No "verified" dates
 - At least one query uses `InstanceCount` or `Quantity` for scaling
@@ -298,7 +299,7 @@ Organize findings into this format:
 ### Validation Results
 
 - Script: {pass/fail + details}
-- Line count: {N}/100
+- Line count: {N}/{MaxLineCount}
 - First query line: {N}/45
 - Routing/catalog: {consistent/issues found}
 - Eval coverage: {covered/missing — path where task should be added if missing}

--- a/.github/agents/service-reference.md
+++ b/.github/agents/service-reference.md
@@ -13,7 +13,7 @@ You are an orchestrator agent that creates Azure service reference files for the
 
 ## Phase 0: Orientation
 
-Before dispatching sub-agents, read these files yourself to build baseline understanding:
+Before dispatching sub-agents, read `MaxLineCount` from `tests/lib/validation/ValidationConfig.psd1` and these files:
 
 1. `CONTRIBUTING.md` - contributor guide with "The Prompt" workflow
 2. `docs/service-catalog.md` - pending services only. Read this to find the service's name, aliases, and category. Also check for alias collisions when updating existing services.
@@ -138,7 +138,7 @@ If the agreed data and compliance contract disagree, follow this authority hiera
 
 Specific conflict patterns:
 
-- **Budget conflicts** (e.g., investigation found 50 meters but compliance says file must be under 100 lines): Select the meters needed for a standard cost estimate (compute, storage, backup). Omit niche variants and note them below the Meter Names table.
+- **Budget conflicts** (e.g., investigation found more meters than fit within `MaxLineCount`): Select the meters needed for a standard cost estimate (compute, storage, backup). Omit niche variants and note them below the Meter Names table.
 - **Documentation conflicts** (e.g., docs say RI is available but API returns no RI meters): Trust the API for pricing data. Note the discrepancy as a trap.
 
 ### 3.3 - Determine characteristics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,6 @@ Releases are handled by `create-release.yml` when a PR with a `release: ` prefix
 
 - Service reference files live in `skills/azure-cost-calculator/references/services/`.
 - Follow the template at `docs/TEMPLATE.md`.
-- Each service file must stay under 100 lines.
 - Run the validation script before submitting:
   ```
   pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Create the file at: `skills/azure-cost-calculator/references/services/{category}
 
 The file MUST follow these critical constraints:
 - **First query pattern must appear within lines 1–45** of the file. This is the most critical layout constraint. Keep the YAML, title, and trap concise to ensure this.
-- **Total file length**: under 100 lines of markdown content.
+- **Total file length**: must not exceed `MaxLineCount` in `tests/lib/validation/ValidationConfig.psd1`.
 - **Use declarative `Key: Value` format** for query patterns (no code fences, no script names). Agents translate parameters to the detected runtime's syntax.
 - **ServiceName in every query block**: Always include `ServiceName:` in each individual query pattern block. Do not rely on "All patterns below use..." preambles - batch mode parses individual blocks.
 - **Declare every query serviceName in metadata**: `ServiceName:` values must match `serviceName`, `apiServiceName`, `billingNeeds`, or `queryServiceNames`. Use `queryServiceNames: [...]` only for additional query-only API service names.

--- a/docs/TEMPLATE.md
+++ b/docs/TEMPLATE.md
@@ -80,10 +80,9 @@ primaryCost:
      1–45. Do not rely on exact line ranges for YAML front matter, titles, or
      trap warnings; their length may vary.
 
-  0b. 100-LINE LIMIT: The total file length must not exceed 100 lines of markdown
-      content. This budget covers YAML, title, traps, query patterns,
-      tables, formulas, and notes. Optimize for density; every line costs tokens
-      at runtime.
+  0b. CONFIGURED LINE LIMIT: Total file length must not exceed MaxLineCount in
+      tests/lib/validation/ValidationConfig.psd1. This covers all content;
+      optimize for density because every line costs tokens at runtime.
 
   0c. SECTION ORDER (enforced by validation): Sections must appear in this order:
         YAML front matter → Title (H1) → Trap(s) → Query Pattern →

--- a/tests/lib/validation/ValidationConfig.psd1
+++ b/tests/lib/validation/ValidationConfig.psd1
@@ -12,7 +12,7 @@
         'Reserved Instance Pricing', 'Manual Calculation Example',
         'Known Rates', 'Common SKUs', 'Product Names', 'SKU Selection Guide'
     )
-    MaxLineCount = 100
+    MaxLineCount = 120
     QueryPatternDeadline = 45
     ServicesFolderPattern = 'references/services/([^/]+)/'
 }

--- a/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
+++ b/tests/unit/powershell/validation/Test-ContentRule.Tests.ps1
@@ -1,9 +1,11 @@
-Describe 'Test-ContentRule serviceName consistency' {
+Describe 'Test-ContentRule' {
 
     BeforeAll {
         $validationRoot = Join-Path $PSScriptRoot '../../../lib/validation'
         . (Join-Path $validationRoot 'Get-FrontMatter.ps1')
         . (Join-Path $validationRoot 'Test-ContentRule.ps1')
+        $validationConfig = Import-PowerShellDataFile -Path (Join-Path $validationRoot 'ValidationConfig.psd1')
+        $emptyFrontMatter = @{ Found = $false; Fields = @{} }
 
         function New-ServiceReferenceLines {
             param(
@@ -49,6 +51,7 @@ Describe 'Test-ContentRule serviceName consistency' {
                 }
             }
         }
+
     }
 
     It 'passes when ServiceName matches serviceName' {
@@ -94,5 +97,19 @@ Describe 'Test-ContentRule serviceName consistency' {
 
         $check.Pass | Should -BeFalse
         $check.Message | Should -Match 'Unknown Service'
+    }
+
+    It 'allows a file at the configured line-count limit' {
+        $checks = Test-ContentRule -Lines (@('') * $validationConfig.MaxLineCount) -FrontMatter $emptyFrontMatter
+        $check = $checks | Where-Object Name -eq 'line_count_limit'
+
+        $check.Pass | Should -BeTrue
+    }
+
+    It 'rejects a file above the configured line-count limit' {
+        $checks = Test-ContentRule -Lines (@('') * ($validationConfig.MaxLineCount + 1)) -FrontMatter $emptyFrontMatter
+        $check = $checks | Where-Object Name -eq 'line_count_limit'
+
+        $check.Pass | Should -BeFalse
     }
 }


### PR DESCRIPTION
## Summary

- raise the configured service-reference line ceiling from 100 to 120
- derive documentation and agent limits from `MaxLineCount`
- add inclusive boundary coverage for the configured maximum

## Testing

- `pwsh tests/unit/Run-PesterTests.ps1 -OutputFormat Minimal`
- `pwsh .github/scripts/validate/Invoke-Validation.ps1 -Mode Full -ServicesRoot skills/azure-cost-calculator/references/services -ValidationScript tests/Validate-ServiceReference.ps1`

Closes #1006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authoring and contribution guidance to use a configurable maximum file length instead of a fixed 100-line limit.
  * Updated templates and review guidance to reflect the configured limit and improve content-density recommendations.

* **Validation**
  * Increased the permitted service reference length to 120 lines.
  * Added checks confirming files at the limit pass validation while longer files are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->