### PR TITLE
fix: reduce service-reference investigators #1008

### DIFF
--- a/.github/agents/service-reference.md
+++ b/.github/agents/service-reference.md
@@ -93,9 +93,9 @@ For each unresolved disagreement, dispatch a fresh `pricing-investigator` instan
 
 - Provide the disputed meter names, SKU values, or billing model interpretations
 - Ask it to run the specific queries needed to verify the disputed items
-- Include the conflicting conclusions from the initial reports so it knows what to arbitrate
+- Include the conflicting conclusions and ask whether either is supported
 
-After the tiebreaker returns, use the resulting 2/3 majority to add verified items to the high-confidence data set. Document which initial report was confirmed and which was overridden.
+If the tiebreaker confirms one initial conclusion, use the resulting 2/3 majority and document the result. If it supports neither, exclude the item from the high-confidence data set and document it as unresolved.
 
 ---
 

--- a/.github/agents/service-reference.md
+++ b/.github/agents/service-reference.md
@@ -7,7 +7,7 @@ model: claude-sonnet-4.6
 
 You are an orchestrator agent that creates Azure service reference files for the Azure Cost Calculator skill. You do NOT work alone - you dispatch three specialist sub-agents to form independent views, then aggregate their findings into a consensus before writing anything.
 
-**Your core principle: consensus over speculation.** You only write what a majority of investigators agree on. When their findings conflict, you dispatch a scoped tiebreaker investigation on the disputed items before deciding.
+**Your core principle: consensus over speculation.** You only write findings supported by both initial investigators or by a majority after a scoped tiebreaker investigation resolves a conflict.
 
 ---
 
@@ -47,16 +47,7 @@ Invoke the **same** `pricing-investigator` agent a second time with **identical 
 
 This second instance runs independently in its own context. It will make its own discovery choices (search terms, exploration order) and may find different meters or interpret results differently.
 
-### 1.3 - Invoke `pricing-investigator` (third instance)
-
-Invoke the `pricing-investigator` agent a third time with **identical inputs**:
-
-- The same Azure service display name
-- The same category folder name
-
-Three independent investigations maximize coverage; each instance may explore different search terms, discover different meters, or interpret edge cases differently. Disagreements between reports reveal areas needing closer scrutiny.
-
-### 1.4 - Invoke `compliance-reviewer`
+### 1.3 - Invoke `compliance-reviewer`
 
 Use the `compliance-reviewer` agent. Provide it with:
 
@@ -70,11 +61,11 @@ The compliance reviewer will read all rule sources, study exemplars, and return 
 
 ## Phase 2: Compare Investigation Reports
 
-Before building consensus with the compliance contract, compare all three pricing investigation reports against each other.
+Before building consensus with the compliance contract, compare both pricing investigation reports against each other.
 
 ### 2.1 - Identify agreement
 
-Find all items where a **majority** (2/3 or 3/3) of investigators reached the same conclusion:
+Find all items where **both investigators** reached the same conclusion:
 
 - Same `serviceName`, `productName`, `skuName`, `meterName` values
 - Same billing model assessment
@@ -82,11 +73,11 @@ Find all items where a **majority** (2/3 or 3/3) of investigators reached the sa
 - Same RI availability conclusion
 - Same documentation cross-check findings
 
-Items with majority or unanimous agreement form your **high-confidence data set** - use them directly.
+Items with unanimous agreement form your **high-confidence data set** - use them directly.
 
 ### 2.2 - Identify disagreements
 
-Flag any items where **no majority exists**, i.e., all three reports reach different conclusions:
+Flag any items where the two reports reach different conclusions:
 
 - Meters found by one investigator but not the others
 - Different billing model interpretations
@@ -98,13 +89,13 @@ If there are no disagreements, skip section 2.3 and proceed directly to Phase 3 
 
 ### 2.3 - Resolve disagreements via tiebreaker
 
-For each unresolved disagreement, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. The tiebreaker runs in a clean context, scoped narrowly to the disputed items, so its findings are independent of the initial three reports' reasoning. The tiebreaker has full `pricing-investigator` capabilities including **web search** to cross-check against Microsoft Learn documentation. Scope the tiebreaker's prompt narrowly to the specific points of disagreement:
+For each unresolved disagreement, dispatch a fresh `pricing-investigator` instance as a **tiebreaker**. The tiebreaker runs in a clean context, scoped narrowly to the disputed items, so its findings are independent of the initial two reports' reasoning. The tiebreaker has full `pricing-investigator` capabilities including **web search** to cross-check against Microsoft Learn documentation. Scope the tiebreaker's prompt narrowly to the specific points of disagreement:
 
 - Provide the disputed meter names, SKU values, or billing model interpretations
 - Ask it to run the specific queries needed to verify the disputed items
 - Include the conflicting conclusions from the initial reports so it knows what to arbitrate
 
-After the tiebreaker returns, use its findings to break ties and add verified items to the high-confidence data set. Document which initial report(s) were confirmed and which were overridden.
+After the tiebreaker returns, use the resulting 2/3 majority to add verified items to the high-confidence data set. Document which initial report was confirmed and which was overridden.
 
 ---
 
@@ -254,7 +245,7 @@ Fix all schema errors and re-run until clean before proceeding to Phase 8.
 - Create a branch, commit your changes, and open a pull request
 - PR title format: `Add service reference: {Service Name}`
 - In the PR description, include:
-  - Summary of all three Pricing Investigation Reports and where they agreed/disagreed
+  - Summary of both initial Pricing Investigation Reports and where they agreed/disagreed
   - How disagreements were resolved (tiebreaker model used, which reports were confirmed/overridden)
   - The Compliance Contract summary (rules applied, exemplars studied)
   - Documentation cross-check findings from Microsoft Learn

--- a/.github/agents/service-reference.md
+++ b/.github/agents/service-reference.md
@@ -154,6 +154,8 @@ Create the file at the path specified by the routing map:
 skills/azure-cost-calculator/references/services/{category}/{filename}.md
 ```
 
+Keep updates token-efficient: prefer removing or replacing text over adding it, and add only what is required for accurate cost estimation.
+
 ### 4.1 - Use the Compliance Contract as your checklist
 
 The contract specifies:

--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -59,7 +59,7 @@ Supporting agents (invoked by the orchestrators, not directly):
 
 | Agent                     | Role                                                                        |
 | ------------------------- | --------------------------------------------------------------------------- |
-| `pricing-investigator.md` | API investigation sub-agent (x3 for authoring, x2 for review, + tiebreaker) |
+| `pricing-investigator.md` | API investigation sub-agent (x2 for authoring, x2 for review, + tiebreaker) |
 | `compliance-reviewer.md`  | Rules analysis sub-agent (authoring only)                                   |
 
 ---

--- a/docs/ops/automated-pipeline.md
+++ b/docs/ops/automated-pipeline.md
@@ -59,7 +59,7 @@ Supporting agents (invoked by the orchestrators, not directly):
 
 | Agent                     | Role                                                                        |
 | ------------------------- | --------------------------------------------------------------------------- |
-| `pricing-investigator.md` | API investigation sub-agent (x2 for authoring, x2 for review, + tiebreaker) |
+| `pricing-investigator.md` | API investigation sub-agent (x2 for authoring, x2 for review, + optional scoped tiebreaker) |
 | `compliance-reviewer.md`  | Rules analysis sub-agent (authoring only)                                   |
 
 ---

--- a/docs/ops/custom-agents.md
+++ b/docs/ops/custom-agents.md
@@ -29,10 +29,10 @@ When the Copilot coding agent is assigned to a service-reference issue using the
 ### Why multi-agent?
 
 - **Independent views prevent blind spots**: two investigators may explore different search terms and find different meters; disagreement reveals areas needing closer investigation.
-- **Consensus over speculation**: the orchestrator accepts 2/2 agreement directly. Disagreements trigger a scoped tiebreaker, then require a 2/3 majority.
+- **Consensus over speculation**: the orchestrator accepts 2/2 agreement directly. A tiebreaker must confirm one initial conclusion; otherwise the item remains unresolved and is excluded.
 - **Separation of concerns**: data discovery (shell + web) vs rule interpretation (read-only) vs file authoring.
 
-> **Model uniformity note**: all four agents pin `model: claude-sonnet-4.6` in their frontmatter, and the tiebreaker runs on the same model as the initial investigators. The independence signal comes from a fresh context and narrowly-scoped disputed inputs, not from model diversity. Correlated model-specific blind spots will not be caught by the tiebreaker; treat unanimous 2/2 initial agreement as strong evidence and 2/1 splits after tiebreaker investigation as adequate, but do not treat consensus as protection against systematic model bias.
+> **Model uniformity note**: all four agents pin `model: claude-sonnet-4.6` in their frontmatter, and the tiebreaker runs on the same model as the initial investigators. The independence signal comes from a fresh context and narrowly-scoped disputed inputs, not from model diversity. Correlated model-specific blind spots will not be caught by the tiebreaker; treat unanimous 2/2 initial agreement as strong evidence and confirmed 2/1 outcomes as adequate, but exclude 1/1/1 outcomes.
 
 ---
 
@@ -119,7 +119,7 @@ service-reference (orchestrator)
 | ------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
 | `.github/agents/service-reference.md`       | Orchestrator: dispatches, aggregates, writes                                           | read, search, edit, execute, agent, web |
 | `.github/agents/service-ref-pr-reviewer.md` | PR review orchestrator: verifies, reviews                                              | read, search, edit, execute, agent, web |
-| `.github/agents/pricing-investigator.md`    | API investigation sub-agent (invoked ×2 for authoring, ×2 for PR review, + tiebreaker) | read, search, execute, web              |
+| `.github/agents/pricing-investigator.md`    | API investigation sub-agent (invoked ×2 for authoring, ×2 for PR review, + optional scoped tiebreaker) | read, search, execute, web              |
 | `.github/agents/compliance-reviewer.md`     | Rules analysis sub-agent                                                               | read, search                            |
 
 1. Edit the agent file directly.

--- a/docs/ops/custom-agents.md
+++ b/docs/ops/custom-agents.md
@@ -20,20 +20,19 @@ Multi-agent system that gives the Copilot coding agent research-first, consensus
 
 When the Copilot coding agent is assigned to a service-reference issue using the `service-reference` custom agent, it runs a multi-agent consensus workflow:
 
-1. **Orchestrator** (`service-reference`) reads the routing map and dispatches four sub-agent invocations independently.
+1. **Orchestrator** (`service-reference`) reads the routing map and dispatches three sub-agent invocations independently.
 2. **Pricing Investigator A** (`pricing-investigator`, first instance) explores the Azure Retail Prices API, cross-checks Microsoft Learn documentation, and returns a structured **Pricing Investigation Report**.
 3. **Pricing Investigator B** (`pricing-investigator`, second instance, identical prompt) independently explores the same API; may discover different meters or interpret results differently.
-4. **Pricing Investigator C** (`pricing-investigator`, third instance, identical prompt) provides a third independent view for majority-based consensus.
-5. **Compliance Reviewer** (`compliance-reviewer`) reads all rule sources (CONTRIBUTING.md, TEMPLATE.md, schema, shared.md, pitfalls.md), studies category exemplars, and returns a structured **Compliance Contract**.
-6. **Orchestrator** compares Reports A, B, and C for majority agreement, dispatches a scoped tiebreaker investigator on unresolved disagreements, cross-references the consensus data against the Compliance Contract, writes the service reference file, and runs validation.
+4. **Compliance Reviewer** (`compliance-reviewer`) reads all rule sources (CONTRIBUTING.md, TEMPLATE.md, schema, shared.md, pitfalls.md), studies category exemplars, and returns a structured **Compliance Contract**.
+5. **Orchestrator** compares Reports A and B for agreement, dispatches a scoped tiebreaker investigator on disagreements, cross-references the consensus data against the Compliance Contract, writes the service reference file, and runs validation.
 
 ### Why multi-agent?
 
-- **Independent views prevent blind spots**: three investigators may explore different search terms and find different meters; disagreement reveals areas needing closer investigation.
-- **Majority consensus over speculation**: the orchestrator only writes what a majority (2/3 or 3/3) of investigators agree on. Unresolved disputes trigger a scoped tiebreaker round on the disputed items only.
+- **Independent views prevent blind spots**: two investigators may explore different search terms and find different meters; disagreement reveals areas needing closer investigation.
+- **Consensus over speculation**: the orchestrator accepts 2/2 agreement directly. Disagreements trigger a scoped tiebreaker, then require a 2/3 majority.
 - **Separation of concerns**: data discovery (shell + web) vs rule interpretation (read-only) vs file authoring.
 
-> **Model uniformity note**: all four agents pin `model: claude-sonnet-4.6` in their frontmatter, and the tiebreaker runs on the same model as the initial investigators. The independence signal comes from a fresh context and narrowly-scoped disputed inputs, not from model diversity. Correlated model-specific blind spots will not be caught by the tiebreaker; treat unanimous 3/3 agreement as strong evidence and 2/1 splits with tiebreaker confirmation as adequate, but do not treat consensus as protection against systematic model bias.
+> **Model uniformity note**: all four agents pin `model: claude-sonnet-4.6` in their frontmatter, and the tiebreaker runs on the same model as the initial investigators. The independence signal comes from a fresh context and narrowly-scoped disputed inputs, not from model diversity. Correlated model-specific blind spots will not be caught by the tiebreaker; treat unanimous 2/2 initial agreement as strong evidence and 2/1 splits after tiebreaker investigation as adequate, but do not treat consensus as protection against systematic model bias.
 
 ---
 
@@ -84,16 +83,12 @@ service-reference (orchestrator)
   │     Tools: read, search, execute, web
   │     Output: Pricing Investigation Report B
   │
-  ├── invokes: pricing-investigator (instance C)  ← identical prompt
-  │     Tools: read, search, execute, web
-  │     Output: Pricing Investigation Report C
-  │
   ├── invokes: compliance-reviewer
   │     Tools: read, search (no shell, no edit, no web)
   │     Output: Compliance Contract
   │
-  ├── orchestrator: compares A vs B vs C → majority agreement
-  │     If unresolved disagreements remain:
+  ├── orchestrator: compares A vs B → agreement
+  │     If disagreements exist:
   │     └── invokes: pricing-investigator (tiebreaker, scoped to disputed items)
   │           Fresh context, narrowly scoped inputs
   │           Output: Tiebreaker Report
@@ -124,7 +119,7 @@ service-reference (orchestrator)
 | ------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
 | `.github/agents/service-reference.md`       | Orchestrator: dispatches, aggregates, writes                                           | read, search, edit, execute, agent, web |
 | `.github/agents/service-ref-pr-reviewer.md` | PR review orchestrator: verifies, reviews                                              | read, search, edit, execute, agent, web |
-| `.github/agents/pricing-investigator.md`    | API investigation sub-agent (invoked ×3 for authoring, ×2 for PR review, + tiebreaker) | read, search, execute, web              |
+| `.github/agents/pricing-investigator.md`    | API investigation sub-agent (invoked ×2 for authoring, ×2 for PR review, + tiebreaker) | read, search, execute, web              |
 | `.github/agents/compliance-reviewer.md`     | Rules analysis sub-agent                                                               | read, search                            |
 
 1. Edit the agent file directly.
@@ -139,7 +134,7 @@ service-reference (orchestrator)
 
 Sub-agents use restricted toolsets (principle of least privilege):
 
-- `pricing-investigator` has `execute` for running scripts and `web` for Microsoft Learn cross-checks, but cannot `edit` files. Invoked three times with identical inputs for authoring (majority-based consensus), twice for PR review, plus an optional scoped tiebreaker round on unresolved disputes.
+- `pricing-investigator` has `execute` for running scripts and `web` for Microsoft Learn cross-checks, but cannot `edit` files. Invoked twice with identical inputs for authoring, twice for PR review, plus an optional scoped tiebreaker round on disagreements.
 - `compliance-reviewer` has only `read` and `search`: no shell, no editing, no web. All documentation cross-checks come from the pricing investigation reports.
 - Only the orchestrators (`service-reference` and `service-ref-pr-reviewer`) have `edit` and `agent` tools
 


### PR DESCRIPTION
## Summary

- reduce the service-reference authoring round to two pricing investigators and one compliance reviewer
- retain the optional scoped pricing tiebreaker
- update operational documentation and consensus wording for the two-investigator flow

## Validation

- `git diff --check`
- `waza check` could not run because `waza` is not installed in the local environment

Closes #1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service reference workflow guidance to use two initial pricing investigations instead of three.
  * Clarified consensus and disagreement handling, including scoped tiebreakers and majority requirements.
  * Updated workflow diagrams, agent descriptions, invocation counts, and pipeline documentation to reflect the revised process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->