### PR TITLE
fix: update ai-content-understanding service reference

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
@@ -14,7 +14,7 @@ privateEndpoint: true
 
 > **Trap (mixed units)**: Meters use 3 unit types: `1K` (pages/tokens/images/transactions), `1 Hour` (audio/video processing), `1K/Month` (face storage). Script's `× 730` only applies to `1 Hour` meters. Verify unit per meter.
 
-> **Trap (regional gaps)**: Only 3 regions (westus, swedencentral, australiaeast) have all 22 meters. Default region eastus has only 7 GA content extraction meters. Field Extraction, Classification, and Face meters return empty in other regions.
+> **Trap (regional gaps)**: Only 3 regions (westus, swedencentral, australiaeast) have all 22 meters. Default region eastus has only 7 GA content extraction meters. Field Extraction, Classification, and Face meters return empty in other regions. swedencentral prices differ from westus/australiaeast for ~10 meters (field extraction, audio/video processing add-ons); always query the user's target region explicitly.
 
 ## Query Pattern
 
@@ -74,6 +74,7 @@ Quantity: 1000 # 1000 × 1K = 1M tokens
 | `Document Field Extraction Pages` | `Document Field Extraction` | `1K` | Doc field extraction; 3 regions |
 | `Image Field Extraction Images` | `Image Field Extraction` | `1K` | Image field extraction; 3 regions |
 | `Face Storage Faces` | `Face Storage` | `1K/Month` | Monthly face storage; 3 regions |
+| `Face Transaction Transactions` | `Face Transaction` | `1K` | Face transactions; 3 regions |
 
 ## Cost Formula
 
@@ -88,11 +89,11 @@ Composite:              Monthly = ContentExtraction + Contextualization + FieldE
 ## Notes
 
 - **No free tier**: Unlike sibling AI services, Content Understanding has no free tier or monthly grant
-- **Azure OpenAI dependency**: Field extraction incurs separate Azure OpenAI model charges (see `openai-service.md` for model pricing)
+- **Azure OpenAI dependency**: Field extraction incurs separate Azure OpenAI model charges (see `ai-ml/openai-service.md` for model pricing)
 - **Extraction tiers** (never-assume): Documents offer Minimal/Basic/Standard tiers; contextualization and field extraction also have **Pro** variants. Ask user which tier
 - **Regional availability**: GA content extraction in 16–17 regions; Field Extraction/Classification/Face only in westus, swedencentral, australiaeast
 - **Two-phase billing**: Content extraction + field extraction are separate meters for all modalities (doc/audio/video); field extraction rates are significantly higher
 - **Capacity planning**: `Quantity: 1` = 1K pages/tokens/images when `unitOfMeasure` is `1K`; `1 Hour` meters bill per hour of media processed
 - **Supports private endpoints** via AI Services multi-service resource (see `networking/private-link.md` for PE pricing)
-- **10 additional meters** in 3-region tier: Classification In/Out, Pro Contextualization, Pro Field Extract In/Out, Audio/Video Field Extraction, Add-On Formula/Face Grouping, Face Transaction. Query `ProductName: Azure Content Understanding` in westus
-- **Scope**: For broader Foundry Tools coverage, see `ai-services.md`
+- **9 additional meters** in 3-region tier: Classification In/Out, Pro Contextualization, Pro Field Extract In/Out, Audio/Video Field Extraction, Add-On Formula/Face Grouping. Query `ProductName: Azure Content Understanding` in westus
+- **Scope**: For broader Foundry Tools coverage, see `ai-ml/ai-services.md`


### PR DESCRIPTION
## Summary

Updates the Azure AI Content Understanding service reference file based on a fresh 3-investigator consensus review against the Azure Retail Prices API.

## Pricing Investigation Summary

All three independent pricing investigators queried the API and reached unanimous agreement:

- `serviceName: Foundry Tools` — unchanged, still correct
- `productName: Azure Content Understanding` — unchanged, still correct
- 22 meters confirmed; zero added, zero removed
- Region tiers unchanged: GA 16 regions, Min 17 regions, Pro/Field/Face 3 regions
- PAYG only; no RI, no free tier

**No disagreements between investigators — no tiebreaker required.**

## New Findings (unanimous, 3/3)

| Finding | Action taken |
|---|---|
| `Face Transaction Transactions` meter existed only in prose Notes, not in the formal Meter Names table | Promoted to Meter Names table |
| swedencentral prices differ from westus/australiaeast for ~10 meters (field extraction, audio/video add-ons) | Added to Trap (regional gaps) |
| Cross-reference paths used bare filenames (`ai-services.md`, `openai-service.md`) instead of category-prefixed paths | Updated to `ai-ml/ai-services.md`, `ai-ml/openai-service.md` per exemplar convention |

## Compliance Contract Summary

Compliance reviewer assessed the existing file as a clean PASS across all 38 validation checks. Exemplar: `document-intelligence.md` (same `apiServiceName: Foundry Tools` pattern). The advisory on cross-reference path style was applied as a code change.

## Validation

```
RESULT: PASS - All checks passed (38/38)
```

File: 99 lines (limit: 120)