### PR TITLE
fix: update all ai-ml service references with current API data

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-content-understanding.md
@@ -60,21 +60,21 @@ Quantity: 1000 # 1000 × 1K = 1M tokens
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| ----- | ------- | ------------- | ----- |
-| `Doc Content Extraction Min Pages` | `Doc Content Extraction Min` | `1K` | Minimal doc tier; 17 regions |
-| `Doc Content Extraction Basic Pages` | `Doc Content Extraction Basic` | `1K` | Basic doc extraction; 16 regions |
-| `Doc Content Extraction Standard Pages` | `Doc Content Extraction Standard` | `1K` | Standard doc extraction; 16 regions |
-| `Audio Content Extraction` | `Audio Content Extraction` | `1 Hour` | Audio processing; 16 regions |
-| `Video Content Extraction` | `Video Content Extraction` | `1 Hour` | Video processing; 16 regions |
-| `Std Contextualization Tokens` | `Std Contextualization` | `1K` | Token-based contextualization; 16 regions |
-| `Add-On Layout Pages` | `Add-On Layout` | `1K` | Layout extraction add-on; 16 regions |
-| `Std Field Extract Inp Tokens` | `Std Field Extract Inp` | `1K` | Standard field input; 3 regions |
-| `Std Field Extract Outp Tokens` | `Std Field Extract Outp` | `1K` | Standard field output; 3 regions |
-| `Document Field Extraction Pages` | `Document Field Extraction` | `1K` | Doc field extraction; 3 regions |
-| `Image Field Extraction Images` | `Image Field Extraction` | `1K` | Image field extraction; 3 regions |
-| `Face Storage Faces` | `Face Storage` | `1K/Month` | Monthly face storage; 3 regions |
-| `Face Transaction Transactions` | `Face Transaction` | `1K` | Face transactions; 3 regions |
+| Meter                                   | skuName                           | unitOfMeasure | Notes                                     |
+| --------------------------------------- | --------------------------------- | ------------- | ----------------------------------------- |
+| `Doc Content Extraction Min Pages`      | `Doc Content Extraction Min`      | `1K`          | Minimal doc tier; 17 regions              |
+| `Doc Content Extraction Basic Pages`    | `Doc Content Extraction Basic`    | `1K`          | Basic doc extraction; 16 regions          |
+| `Doc Content Extraction Standard Pages` | `Doc Content Extraction Standard` | `1K`          | Standard doc extraction; 16 regions       |
+| `Audio Content Extraction`              | `Audio Content Extraction`        | `1 Hour`      | Audio processing; 16 regions              |
+| `Video Content Extraction`              | `Video Content Extraction`        | `1 Hour`      | Video processing; 16 regions              |
+| `Std Contextualization Tokens`          | `Std Contextualization`           | `1K`          | Token-based contextualization; 16 regions |
+| `Add-On Layout Pages`                   | `Add-On Layout`                   | `1K`          | Layout extraction add-on; 16 regions      |
+| `Std Field Extract Inp Tokens`          | `Std Field Extract Inp`           | `1K`          | Standard field input; 3 regions           |
+| `Std Field Extract Outp Tokens`         | `Std Field Extract Outp`          | `1K`          | Standard field output; 3 regions          |
+| `Document Field Extraction Pages`       | `Document Field Extraction`       | `1K`          | Doc field extraction; 3 regions           |
+| `Image Field Extraction Images`         | `Image Field Extraction`          | `1K`          | Image field extraction; 3 regions         |
+| `Face Storage Faces`                    | `Face Storage`                    | `1K/Month`    | Monthly face storage; 3 regions           |
+| `Face Transaction Transactions`         | `Face Transaction`                | `1K`          | Face transactions; 3 regions              |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
@@ -54,30 +54,30 @@ Quantity: 10
 
 ## Key Fields
 
-| Parameter     | How to determine               | Example values                                             |
-| ------------- | ------------------------------ | ---------------------------------------------------------- |
-| `serviceName` | Always `Foundry Tools`         | `Foundry Tools`                                            |
-| `productName` | Cognitive domain (sub-service) | `Azure Language`, `Azure Vision - Face`, `Translator Text` |
-| `skuName`     | Tier, varies by sub-service    | `Standard`, `S0`, `S1`, `Free`, `Commitment Tier ...`      |
-| `meterName`   | Billing dimension, varies by product | `Standard Text Records`, `S0 Read Pages`, `S1 Characters` |
+| Parameter     | How to determine                     | Example values                                             |
+| ------------- | ------------------------------------ | ---------------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools`               | `Foundry Tools`                                            |
+| `productName` | Cognitive domain (sub-service)       | `Azure Language`, `Azure Vision - Face`, `Translator Text` |
+| `skuName`     | Tier, varies by sub-service          | `Standard`, `S0`, `S1`, `Free`, `Commitment Tier ...`      |
+| `meterName`   | Billing dimension, varies by product | `Standard Text Records`, `S0 Read Pages`, `S1 Characters`  |
 
 ## Meter Names
 
-| Meter                   | productName                   | unitOfMeasure | Notes                   |
-| ----------------------- | ----------------------------- | ------------- | ----------------------- |
-| `Standard Text Records` | `Azure Language`              | `1K`          | Tiered; see `language.md` |
-| `S0 Read Pages`         | `Azure Document Intelligence` | `1K`          | Tiered; OCR/layout; see `document-intelligence.md` |
-| `Standard Transactions` | `Azure Vision - Face`         | `1K`          | Tiered; see `vision.md` |
-| `S1 Characters`         | `Translator Text`             | `1M`          | Text translation; see `translator.md` |
-| `S1 Speech To Text`     | `Azure Speech`                | `1 Hour`      | Core STT; see `speech.md` |
-| `Voice Live API Lite - LLM Text Cached Tokens` | `Azure Speech` | `1K` | Sub-cent; Lite/Std/Pro tiers; see `speech.md` |
-| `Standard Text Records` | `Content Safety`              | `1K`          | Text moderation; see `content-safety.md` |
-| `Standard Univariate Transactions` | `Anomaly Detector`   | `1K`          | Anomaly detection PAYG |
-| `S0 Transactions`       | `Azure Custom Vision`         | `1K`          | Custom image inference; also `S0 Training`, `S0 Image Storage` |
-| `Doc Content Extraction Standard Pages` | `Azure Content Understanding` | `1K` | See `ai-content-understanding.md` |
-| `Evaluations input tokens Tokens` | `Observability`       | `1K`          | Foundry eval; also Output variant |
-| `Model Routers GL 1M Tokens` | `Model Tools`        | `1M`          | Model router prompt charge; eastus2/swedencentral/westus2 only; also DZ variant |
-| `Radiology Insights Language Detection Text Records` | `Azure Health Insights` | `1K` | Global-only; verify availability |
+| Meter                                                | productName                   | unitOfMeasure | Notes                                                                           |
+| ---------------------------------------------------- | ----------------------------- | ------------- | ------------------------------------------------------------------------------- |
+| `Standard Text Records`                              | `Azure Language`              | `1K`          | Tiered; see `language.md`                                                       |
+| `S0 Read Pages`                                      | `Azure Document Intelligence` | `1K`          | Tiered; OCR/layout; see `document-intelligence.md`                              |
+| `Standard Transactions`                              | `Azure Vision - Face`         | `1K`          | Tiered; see `vision.md`                                                         |
+| `S1 Characters`                                      | `Translator Text`             | `1M`          | Text translation; see `translator.md`                                           |
+| `S1 Speech To Text`                                  | `Azure Speech`                | `1 Hour`      | Core STT; see `speech.md`                                                       |
+| `Voice Live API Lite - LLM Text Cached Tokens`       | `Azure Speech`                | `1K`          | Sub-cent; Lite/Std/Pro tiers; see `speech.md`                                   |
+| `Standard Text Records`                              | `Content Safety`              | `1K`          | Text moderation; see `content-safety.md`                                        |
+| `Standard Univariate Transactions`                   | `Anomaly Detector`            | `1K`          | Anomaly detection PAYG                                                          |
+| `S0 Transactions`                                    | `Azure Custom Vision`         | `1K`          | Custom image inference; also `S0 Training`, `S0 Image Storage`                  |
+| `Doc Content Extraction Standard Pages`              | `Azure Content Understanding` | `1K`          | See `ai-content-understanding.md`                                               |
+| `Evaluations input tokens Tokens`                    | `Observability`               | `1K`          | Foundry eval; also Output variant                                               |
+| `Model Routers GL 1M Tokens`                         | `Model Tools`                 | `1M`          | Model router prompt charge; eastus2/swedencentral/westus2 only; also DZ variant |
+| `Radiology Insights Language Detection Text Records` | `Azure Health Insights`       | `1K`          | Global-only; verify availability                                                |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
@@ -11,11 +11,11 @@ privateEndpoint: true
 
 > **Trap (serviceName rebrand)**: API `serviceName` is `Foundry Tools`, NOT `Azure AI Services` or `Cognitive Services`. Old names return zero results.
 
-> **Trap (inflated totals)**: Broad `eastus` queries return 500+ meters across 28 product families. Always filter by `ProductName`.
+> **Trap (inflated totals)**: Broad `eastus` queries return 560+ meters across 28 product families. Always filter by `ProductName`.
 
 > **Trap (mixed regions)**: Default regional queries miss Global-only products such as `Azure Health Insights`. Check `Global` when a product seems missing.
 
-> **Trap (sub-cent pricing)**: Some meters (e.g., Face Storage) have sub-cent `retailPrice` and display as minimal cost. Use large `Quantity`.
+> **Trap (sub-cent pricing)**: Some meters (e.g., `Voice Live API Lite - LLM Text Cached Tokens`, `Std Contextualization Tokens`) have sub-cent `retailPrice` and round down for small `Quantity` values. Use large `Quantity`.
 
 > **Agent instruction**: Tiered meters (e.g., `Standard Text Records`) return multiple rows with different `tierMinimumUnits`. Use the tier matching the user's volume; do not sum all tiers.
 
@@ -70,12 +70,13 @@ Quantity: 10
 | `Standard Transactions` | `Azure Vision - Face`         | `1K`          | Tiered; see `vision.md` |
 | `S1 Characters`         | `Translator Text`             | `1M`          | Text translation; see `translator.md` |
 | `S1 Speech To Text`     | `Azure Speech`                | `1 Hour`      | Core STT; see `speech.md` |
+| `Voice Live API Lite - LLM Text Cached Tokens` | `Azure Speech` | `1K` | Sub-cent; Lite/Std/Pro tiers; see `speech.md` |
 | `Standard Text Records` | `Content Safety`              | `1K`          | Text moderation; see `content-safety.md` |
 | `Standard Univariate Transactions` | `Anomaly Detector`   | `1K`          | Anomaly detection PAYG |
 | `S0 Transactions`       | `Azure Custom Vision`         | `1K`          | Custom image inference; also `S0 Training`, `S0 Image Storage` |
 | `Doc Content Extraction Standard Pages` | `Azure Content Understanding` | `1K` | See `ai-content-understanding.md` |
 | `Evaluations input tokens Tokens` | `Observability`       | `1K`          | Foundry eval; also Output variant |
-| `Model Routers GL 1M Tokens` | `Model Tools`        | `1M`          | Model router prompt charge; also DZ variant |
+| `Model Routers GL 1M Tokens` | `Model Tools`        | `1M`          | Model router prompt charge; eastus2/swedencentral/westus2 only; also DZ variant |
 | `Radiology Insights Language Detection Text Records` | `Azure Health Insights` | `1K` | Global-only; verify availability |
 
 ## Cost Formula
@@ -86,11 +87,10 @@ Daily meters (1/Day):  Script auto-multiplies by 30
 Hourly meters (1 Hour): Script auto-multiplies by 730
 ```
 
-`Quantity` = billable units (e.g., 100 = 100K records when `unitOfMeasure` is `1K`).
-
 ## Notes
 
 - **Scope**: Covers umbrella and unrouted `Foundry Tools` products; dedicated sub-service files remain authoritative. Azure OpenAI is separate (`openai-service.md`)
+- **Capacity planning**: `Quantity: 1` means one billing unit of the meter `unitOfMeasure` (for example `1K` records or `1M` characters)
 - **Free tiers**: Most sub-services offer Free SKU with limited quota (Language: 5K records, Vision: 20/min)
 - **Daily billing**: Translator S2–S4 and C2–C4 use `1/Day`; script auto-multiplies by 30
 - **Health Insights caution**: The API exposes one Global meter, but Learn docs remain archived/preview-oriented. Verify availability before estimating

--- a/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/ai-services.md
@@ -11,7 +11,9 @@ privateEndpoint: true
 
 > **Trap (serviceName rebrand)**: API `serviceName` is `Foundry Tools`, NOT `Azure AI Services` or `Cognitive Services`. Old names return zero results.
 
-> **Trap (inflated totals)**: Unfiltered queries return 500+ meters across 28+ product families. Always filter by `ProductName`.
+> **Trap (inflated totals)**: Broad `eastus` queries return 500+ meters across 28 product families. Always filter by `ProductName`.
+
+> **Trap (mixed regions)**: Default regional queries miss Global-only products such as `Azure Health Insights`. Check `Global` when a product seems missing.
 
 > **Trap (sub-cent pricing)**: Some meters (e.g., Face Storage) have sub-cent `retailPrice` and display as minimal cost. Use large `Quantity`.
 
@@ -73,6 +75,8 @@ Quantity: 10
 | `S0 Transactions`       | `Azure Custom Vision`         | `1K`          | Custom image inference; also `S0 Training`, `S0 Image Storage` |
 | `Doc Content Extraction Standard Pages` | `Azure Content Understanding` | `1K` | See `ai-content-understanding.md` |
 | `Evaluations input tokens Tokens` | `Observability`       | `1K`          | Foundry eval; also Output variant |
+| `Model Routers GL 1M Tokens` | `Model Tools`        | `1M`          | Model router prompt charge; also DZ variant |
+| `Radiology Insights Language Detection Text Records` | `Azure Health Insights` | `1K` | Global-only; verify availability |
 
 ## Cost Formula
 
@@ -86,9 +90,10 @@ Hourly meters (1 Hour): Script auto-multiplies by 730
 
 ## Notes
 
-- **Scope**: Covers AI Services (formerly Cognitive Services). Azure OpenAI is separate (`openai-service.md`); Foundry Agents (`foundry-agents.md`) and Video Indexer (`video-indexer.md`) share `apiServiceName: Foundry Tools` but have dedicated files
+- **Scope**: Covers umbrella and unrouted `Foundry Tools` products; dedicated sub-service files remain authoritative. Azure OpenAI is separate (`openai-service.md`)
 - **Free tiers**: Most sub-services offer Free SKU with limited quota (Language: 5K records, Vision: 20/min)
 - **Daily billing**: Translator S2–S4 and C2–C4 use `1/Day`; script auto-multiplies by 30
-- **Legacy/Disconnected**: `Form Recognizer` → Azure Document Intelligence, `Content Moderator` → Content Safety. `- Disconnected` products bill annually. Exclude from monthly estimates
+- **Health Insights caution**: The API exposes one Global meter, but Learn docs remain archived/preview-oriented. Verify availability before estimating
+- **Legacy/Disconnected**: `Form Recognizer` → Azure Document Intelligence, `Content Moderator` → Content Safety. Azure Custom Vision is planned for retirement on 9/25/2028. `- Disconnected` products bill annually; exclude them from monthly estimates
 - **Sub-service files**: Language, Vision, Speech, Translator, Document Intelligence, Content Safety, Content Understanding, Video Indexer, and Foundry Agents each have dedicated reference files with full meter tables
 - **Supports private endpoints** via the AI Services multi-service resource (see `networking/private-link.md` for PE pricing)

--- a/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
@@ -37,20 +37,20 @@ Region: Global
 
 ## Key Fields
 
-| Parameter     | How to determine                   | Example values                                          |
-| ------------- | ---------------------------------- | ------------------------------------------------------- |
-| `serviceName` | Always `Azure Bot Service`         | `Azure Bot Service`                                     |
-| `productName` | Always `Azure Bot Service`         | `Azure Bot Service`                                     |
-| `skuName`     | Tier selected by user              | `Free`, `S1`                                            |
+| Parameter     | How to determine                   | Example values                                                 |
+| ------------- | ---------------------------------- | -------------------------------------------------------------- |
+| `serviceName` | Always `Azure Bot Service`         | `Azure Bot Service`                                            |
+| `productName` | Always `Azure Bot Service`         | `Azure Bot Service`                                            |
+| `skuName`     | Tier selected by user              | `Free`, `S1`                                                   |
 | `meterName`   | Channel type + tier (never-assume) | `S1 Premium Channel Messages`, `Free Premium Channel Messages` |
 
 ## Meter Names
 
-| Meter                            | skuName | unitOfMeasure | Notes                                    |
-| -------------------------------- | ------- | ------------- | ---------------------------------------- |
-| `S1 Premium Channel Messages`    | `S1`    | `1K`          | Paid: DirectLine, Web Chat               |
-| `Free Premium Channel Messages`  | `Free`  | `1K`          | Zero price; 10K messages/month cap       |
-| `Free Standard Channel Messages` | `Free`  | `1K`          | Zero price; unlimited (Teams, Slack)     |
+| Meter                            | skuName | unitOfMeasure | Notes                                |
+| -------------------------------- | ------- | ------------- | ------------------------------------ |
+| `S1 Premium Channel Messages`    | `S1`    | `1K`          | Paid: DirectLine, Web Chat           |
+| `Free Premium Channel Messages`  | `Free`  | `1K`          | Zero price; 10K messages/month cap   |
+| `Free Standard Channel Messages` | `Free`  | `1K`          | Zero price; unlimited (Teams, Slack) |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
@@ -3,8 +3,8 @@ serviceName: Azure Bot Service
 category: ai-ml
 aliases: [Bot Framework, Chatbot]
 billingNeeds: [Azure App Service, Functions]
-pricingRegion: global
 primaryCost: "S1 premium channel messages per 1K (DirectLine/Web Chat); standard channels free"
+pricingRegion: global
 hasFreeGrant: true
 ---
 
@@ -12,7 +12,7 @@ hasFreeGrant: true
 
 > **Trap (shared API name)**: The `serviceName` "Azure Bot Service" is shared with Health Bot. Always filter by `ProductName: Azure Bot Service` to isolate channel meters. For Health Bot pricing, see `specialist/health-bot.md`.
 
-> **Trap (global-only)**: Channel meters exist only in Global (commercial) and US Gov sovereign regions — any standard region like `eastus` returns zero results. Use `armRegionName: Global` for commercial pricing.
+> **Trap (global-only)**: Channel meters exist only in Global (commercial) and US Gov sovereign regions — any standard region like `eastus` returns zero results. Use `Region: Global` for commercial pricing or `Region: US Gov` for sovereign pricing.
 
 > **Trap (free channels)**: Standard channels (Teams, Slack, Facebook) are always free with no paid meter. Only premium channels (DirectLine, Web Chat) are billable at S1 tier.
 
@@ -24,6 +24,7 @@ ServiceName: Azure Bot Service
 ProductName: Azure Bot Service
 SkuName: S1
 MeterName: S1 Premium Channel Messages
+Region: Global
 Quantity: 50 # thousands of messages per month
 
 ### Free tier (premium channels, 10K messages/month included)
@@ -32,6 +33,7 @@ ServiceName: Azure Bot Service
 ProductName: Azure Bot Service
 SkuName: Free
 MeterName: Free Premium Channel Messages
+Region: Global
 
 ## Key Fields
 
@@ -63,5 +65,6 @@ Free = no charge (10K premium messages/month included; standard channels unlimit
 - **Premium channels**: DirectLine and Web Chat; billable only on S1 tier
 - **Underlying compute**: Bot apps run on Azure App Service or Functions; billed separately under those services
 - **Free tier cap**: 10,000 premium channel messages/month (enforced service-side; API returns zero-price meters)
+- **Sovereign cloud**: US Gov uses separate `S1 Premium Channel Messages` and `Free Standard Channel Messages` meters; `Free Premium Channel Messages` is absent
 - **Health Bot**: For healthcare bot pricing (Agent Tier, Standard daily fee), see `specialist/health-bot.md`
 - **RI check**: `PriceType: Reservation` returns no results; Reserved Instances not available

--- a/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
@@ -80,8 +80,14 @@ MeterName: Commitment Tier Image Azure 250K CT Overage Transactions
 | `Free Images` | `Free` | `1K` | 5K/month limit (hard stop) |
 | `Commitment Tier Txt Azure 1M Unit` | `Commitment Tier Txt Azure 1M` | `1/Month` | Flat fee, includes 1M text records |
 | `Commitment Tier Txt Azure 1M CT Overage Transactions` | `Commitment Tier Txt Azure 1M` | `1K` | Overage beyond 1M included |
+| `Commitment Tier Txt Conn 1M Unit` | `Commitment Tier Txt Conn 1M` | `1/Month` | Connected flat fee, includes 1M text records |
+| `Commitment Tier Txt Conn 1M CT Overage Transactions` | `Commitment Tier Txt Conn 1M` | `1K` | Connected overage beyond 1M included |
 | `Commitment Tier Image Azure 250K Unit` | `Commitment Tier Image Azure 250K` | `1/Month` | Flat fee, includes 250K images |
 | `Commitment Tier Image Azure 250K CT Overage Transactions` | `Commitment Tier Image Azure 250K` | `1K` | Overage beyond 250K included |
+| `Commitment Tier Image Conn 250K Unit` | `Commitment Tier Image Conn 250K` | `1/Month` | Connected flat fee, includes 250K images |
+| `Commitment Tier Image Conn 250K CT Overage Transactions` | `Commitment Tier Image Conn 250K` | `1K` | Connected overage beyond 250K included |
+| `Commitment Tier Txt DC 60M Unit` | `Commitment Tier Txt DC 60M Unit` | `1/Year` | Disconnected annual text commitment, Global only |
+| `Commitment Tier Image DC 15M Unit` | `Commitment Tier Image DC 15M Unit` | `1/Year` | Disconnected annual image commitment, Global only |
 
 ## Cost Formula
 
@@ -96,5 +102,6 @@ Free grant:        Billable text = max(0, records − 5000); Billable images = m
 
 - **Free tier**: 5K text records + 5K images/month; hard stop at limit (no overages on Free tier)
 - **Commitment tiers**: Text Azure 1M + Image Azure 250K per modality; Connected (`Conn`) variants are ~5% cheaper (same query structure, substitute `Conn` for `Azure` in skuName/meterName)
-- **Legacy/Disconnected**: `Content Moderator` → `Content Safety` (different tiered pricing; do NOT query). Disconnected product bills annually (`1/Year`), Global-only; divide by 12 for monthly
+- **Legacy/Disconnected**: `Content Moderator` → `Content Safety` (different tiered pricing; do NOT query). Disconnected uses `Commitment Tier Txt DC 60M Unit` or `Commitment Tier Image DC 15M Unit`; divide `1/Year` price by 12
+- **Regional pricing**: Standard PAYG has higher `Standard Text Records` and `Standard Images` rates in `usgovarizona` and `usgovvirginia` than in commercial regions
 - **Capacity planning**: `Quantity: 1` = 1,000 transactions when `unitOfMeasure` is `1K`; text record = up to 1,000 Unicode characters

--- a/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/content-safety.md
@@ -63,31 +63,31 @@ MeterName: Commitment Tier Image Azure 250K CT Overage Transactions
 
 ## Key Fields
 
-| Parameter     | How to determine         | Example values                                            |
-| ------------- | ------------------------ | --------------------------------------------------------- |
-| `serviceName` | Always `Foundry Tools`   | `Foundry Tools`                                           |
-| `productName` | Deployment model         | `Content Safety`, `Content Safety - Disconnected`         |
-| `skuName`     | Tier or commitment level | `Standard`, `Free`, `Commitment Tier Txt Azure 1M`       |
-| `meterName`   | Billing dimension        | `Standard Text Records`, `Standard Images`                |
+| Parameter     | How to determine         | Example values                                     |
+| ------------- | ------------------------ | -------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools`   | `Foundry Tools`                                    |
+| `productName` | Deployment model         | `Content Safety`, `Content Safety - Disconnected`  |
+| `skuName`     | Tier or commitment level | `Standard`, `Free`, `Commitment Tier Txt Azure 1M` |
+| `meterName`   | Billing dimension        | `Standard Text Records`, `Standard Images`         |
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| ----- | ------- | ------------- | ----- |
-| `Standard Text Records` | `Standard` | `1K` | PAYG text moderation |
-| `Standard Images` | `Standard` | `1K` | PAYG image moderation |
-| `Free Text Records` | `Free` | `1K` | 5K/month limit (hard stop) |
-| `Free Images` | `Free` | `1K` | 5K/month limit (hard stop) |
-| `Commitment Tier Txt Azure 1M Unit` | `Commitment Tier Txt Azure 1M` | `1/Month` | Flat fee, includes 1M text records |
-| `Commitment Tier Txt Azure 1M CT Overage Transactions` | `Commitment Tier Txt Azure 1M` | `1K` | Overage beyond 1M included |
-| `Commitment Tier Txt Conn 1M Unit` | `Commitment Tier Txt Conn 1M` | `1/Month` | Connected flat fee, includes 1M text records |
-| `Commitment Tier Txt Conn 1M CT Overage Transactions` | `Commitment Tier Txt Conn 1M` | `1K` | Connected overage beyond 1M included |
-| `Commitment Tier Image Azure 250K Unit` | `Commitment Tier Image Azure 250K` | `1/Month` | Flat fee, includes 250K images |
-| `Commitment Tier Image Azure 250K CT Overage Transactions` | `Commitment Tier Image Azure 250K` | `1K` | Overage beyond 250K included |
-| `Commitment Tier Image Conn 250K Unit` | `Commitment Tier Image Conn 250K` | `1/Month` | Connected flat fee, includes 250K images |
-| `Commitment Tier Image Conn 250K CT Overage Transactions` | `Commitment Tier Image Conn 250K` | `1K` | Connected overage beyond 250K included |
-| `Commitment Tier Txt DC 60M Unit` | `Commitment Tier Txt DC 60M Unit` | `1/Year` | Disconnected annual text commitment, Global only |
-| `Commitment Tier Image DC 15M Unit` | `Commitment Tier Image DC 15M Unit` | `1/Year` | Disconnected annual image commitment, Global only |
+| Meter                                                      | skuName                             | unitOfMeasure | Notes                                             |
+| ---------------------------------------------------------- | ----------------------------------- | ------------- | ------------------------------------------------- |
+| `Standard Text Records`                                    | `Standard`                          | `1K`          | PAYG text moderation                              |
+| `Standard Images`                                          | `Standard`                          | `1K`          | PAYG image moderation                             |
+| `Free Text Records`                                        | `Free`                              | `1K`          | 5K/month limit (hard stop)                        |
+| `Free Images`                                              | `Free`                              | `1K`          | 5K/month limit (hard stop)                        |
+| `Commitment Tier Txt Azure 1M Unit`                        | `Commitment Tier Txt Azure 1M`      | `1/Month`     | Flat fee, includes 1M text records                |
+| `Commitment Tier Txt Azure 1M CT Overage Transactions`     | `Commitment Tier Txt Azure 1M`      | `1K`          | Overage beyond 1M included                        |
+| `Commitment Tier Txt Conn 1M Unit`                         | `Commitment Tier Txt Conn 1M`       | `1/Month`     | Connected flat fee, includes 1M text records      |
+| `Commitment Tier Txt Conn 1M CT Overage Transactions`      | `Commitment Tier Txt Conn 1M`       | `1K`          | Connected overage beyond 1M included              |
+| `Commitment Tier Image Azure 250K Unit`                    | `Commitment Tier Image Azure 250K`  | `1/Month`     | Flat fee, includes 250K images                    |
+| `Commitment Tier Image Azure 250K CT Overage Transactions` | `Commitment Tier Image Azure 250K`  | `1K`          | Overage beyond 250K included                      |
+| `Commitment Tier Image Conn 250K Unit`                     | `Commitment Tier Image Conn 250K`   | `1/Month`     | Connected flat fee, includes 250K images          |
+| `Commitment Tier Image Conn 250K CT Overage Transactions`  | `Commitment Tier Image Conn 250K`   | `1K`          | Connected overage beyond 250K included            |
+| `Commitment Tier Txt DC 60M Unit`                          | `Commitment Tier Txt DC 60M Unit`   | `1/Year`      | Disconnected annual text commitment, Global only  |
+| `Commitment Tier Image DC 15M Unit`                        | `Commitment Tier Image DC 15M Unit` | `1/Year`      | Disconnected annual image commitment, Global only |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
@@ -9,7 +9,7 @@ primaryCost: "retailPrice × userMessageCount (per-user-message consumption, reg
 
 > **Trap (unitOfMeasure)**: The single `User Messages` meter uses `unitOfMeasure: "1"` (flat rate per message), not hourly. The script treats this as unitless (monthly multiplier `1`, not `730`), so `MonthlyCost` reflects a single message only. Always set `Quantity` to the actual number of user messages.
 
-> **Trap (regional variance)**: Per-message rates vary by region. Only 12 regions are priced; always pass the user's region and never assume a flat rate.
+> **Trap (regional variance)**: Per-message rates vary by region. Only 15 regions are priced; always pass the user's region and never assume a flat rate.
 
 ## Query Pattern
 
@@ -48,5 +48,5 @@ Monthly = retailPrice × userMessageCount
 
 - Single product/SKU/meter in the Retail Prices API (`User Messages`): per-message consumption only, no tiers, no free grant, no reserved instances. This meter covers Discovery runtime (data-plane) usage only
 - **Billing boundary**: Discovery uses a two-component model. The `User Messages` meter is the only one in the pricing API, but the underlying Azure compute and storage resources deployed by workspaces/projects are billed separately under their own services. A total estimate must add those resource costs
-- Priced in 12 regions only: `southcentralus`, `northeurope`, `southeastasia`, `westus2`, `uksouth`, `eastus`, `swedencentral`, `eastus2`, `australiaeast`, `westeurope`, `westus3`, `japaneast`. Regional rate variance applies (per-message rate differs by region)
+- Priced in 15 regions only: `australiaeast`, `centralus`, `eastus`, `eastus2`, `francecentral`, `japaneast`, `koreacentral`, `northeurope`, `southcentralus`, `southeastasia`, `swedencentral`, `uksouth`, `westeurope`, `westus2`, `westus3`. Regional rate variance applies (per-message rate differs by region)
 - `unitOfMeasure` is `1`; the script's `MonthlyCost` reflects one message — multiply `retailPrice` by the actual message count

--- a/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
@@ -24,18 +24,18 @@ Quantity: 10000 # number of user messages
 
 ## Key Fields
 
-| Parameter     | How to determine             | Example values     |
-| ------------- | ---------------------------- | ------------------ |
+| Parameter     | How to determine             | Example values        |
+| ------------- | ---------------------------- | --------------------- |
 | `serviceName` | Always `Microsoft Discovery` | `Microsoft Discovery` |
 | `productName` | Always `Microsoft Discovery` | `Microsoft Discovery` |
-| `skuName`     | Always `User Messages`       | `User Messages`    |
-| `meterName`   | Always `User Messages`       | `User Messages`    |
+| `skuName`     | Always `User Messages`       | `User Messages`       |
+| `meterName`   | Always `User Messages`       | `User Messages`       |
 
 ## Meter Names
 
-| Meter           | unitOfMeasure | Notes                              |
-| --------------- | ------------- | ---------------------------------- |
-| `User Messages` | `1`           | Flat rate per user message (PAYG)  |
+| Meter           | unitOfMeasure | Notes                             |
+| --------------- | ------------- | --------------------------------- |
+| `User Messages` | `1`           | Flat rate per user message (PAYG) |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/discovery.md
@@ -19,6 +19,7 @@ ServiceName: Microsoft Discovery
 ProductName: Microsoft Discovery
 SkuName: User Messages
 MeterName: User Messages
+Region: <user region>
 Quantity: 10000 # number of user messages
 
 ## Key Fields

--- a/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
@@ -55,36 +55,36 @@ MeterName: Commitment Tier Pre-Built Azure 100K CT Overage Transactions
 
 ## Key Fields
 
-| Parameter     | How to determine                        | Example values                                                              |
-| ------------- | --------------------------------------- | --------------------------------------------------------------------------- |
+| Parameter     | How to determine                                           | Example values                                                              |
+| ------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `serviceName` | Always `Foundry Tools` (API filter; YAML `apiServiceName`) | `Foundry Tools`                                                             |
-| `productName` | Deployment model                        | `Azure Document Intelligence`, `Azure Document Intelligence - Disconnected` |
-| `skuName`     | Tier + model type + deployment + volume | `S0`, `Free`, `Commitment Tier Pre-Built Azure 100K`                        |
-| `meterName`   | Billing dimension                       | `S0 Read Pages`, `S0 Pre-built Pages`, `S0 Custom Pages`                   |
+| `productName` | Deployment model                                           | `Azure Document Intelligence`, `Azure Document Intelligence - Disconnected` |
+| `skuName`     | Tier + model type + deployment + volume                    | `S0`, `Free`, `Commitment Tier Pre-Built Azure 100K`                        |
+| `meterName`   | Billing dimension                                          | `S0 Read Pages`, `S0 Pre-built Pages`, `S0 Custom Pages`                    |
 
 ## Meter Names
 
-| Meter                          | skuName | unitOfMeasure | Notes                                     |
-| ------------------------------ | ------- | ------------- | ----------------------------------------- |
-| `S0 Read Pages`                | `S0`    | `1K`          | OCR/text extraction, **tiered** (2 rows)  |
-| `S0 Pre-built Pages`           | `S0`    | `1K`          | Invoice, Receipt, ID, W-2, Layout         |
-| `S0 Custom Pages`              | `S0`    | `1K`          | Custom extraction models                  |
-| `S0 Custom Generative Pages`   | `S0`    | `1K`          | Custom generative extraction              |
-| `S0 Add-on for Pages`          | `S0`    | `1K`          | High Res, Font, Formula, Barcode          |
-| `S0 Query Pages`               | `S0`    | `1K`          | Premium query, most expensive PAYG meter  |
-| `S0 pages for query fields`    | `S0`    | `1K`          | Query field extraction, note lowercase    |
-| `S0 pages for doc classifier`  | `S0`    | `1K`          | Document classification, note lowercase   |
-| `S0 Batch Add-On Pages`        | `S0`    | `1K`          | Batch add-on (High Res, Font, Formula, Barcode) |
-| `S0 Batch Custom Generative Pages` | `S0` | `1K`       | Batch custom generative extraction          |
-| `S0 Batch Pre-built Pages`     | `S0`    | `1K`          | Batch pre-built (Invoice, Receipt, ID, W-2) |
-| `S0 Batch Layout Pages`        | `S0`    | `1K`          | Batch-only layout meter (no real-time equivalent named "Layout") |
-| `S0 Batch Read Pages`          | `S0`    | `1K`          | Batch OCR, **tiered** (2 rows) like real-time |
-| `S0 Batch Document Classifier Pages` | `S0` | `1K`     | Batch doc classification (note: title case, unlike real-time) |
-| `S0 Batch Custom Extraction Pages` | `S0` | `1K`       | Batch custom extraction (note: not `S0 Batch Custom Pages`) |
-| `S0 Batch Pages for Query Fields` | `S0` | `1K`        | Batch query fields (note: title case, unlike real-time) |
-| `S0 Training`                  | `S0`    | `1 Hour`      | Neural model training (first 10 hrs free) |
-| `Free Transactions`            | `Free`  | `1K`          | Free tier, 500 pages/month                |
-| `Commitment Tier Pre-Built Azure 100K CT Overage Transactions` | `Commitment Tier Pre-Built Azure 100K` | `1K` | Overage beyond the included 100K pages |
+| Meter                                                          | skuName                                | unitOfMeasure | Notes                                                            |
+| -------------------------------------------------------------- | -------------------------------------- | ------------- | ---------------------------------------------------------------- |
+| `S0 Read Pages`                                                | `S0`                                   | `1K`          | OCR/text extraction, **tiered** (2 rows)                         |
+| `S0 Pre-built Pages`                                           | `S0`                                   | `1K`          | Invoice, Receipt, ID, W-2, Layout                                |
+| `S0 Custom Pages`                                              | `S0`                                   | `1K`          | Custom extraction models                                         |
+| `S0 Custom Generative Pages`                                   | `S0`                                   | `1K`          | Custom generative extraction                                     |
+| `S0 Add-on for Pages`                                          | `S0`                                   | `1K`          | High Res, Font, Formula, Barcode                                 |
+| `S0 Query Pages`                                               | `S0`                                   | `1K`          | Premium query, most expensive PAYG meter                         |
+| `S0 pages for query fields`                                    | `S0`                                   | `1K`          | Query field extraction, note lowercase                           |
+| `S0 pages for doc classifier`                                  | `S0`                                   | `1K`          | Document classification, note lowercase                          |
+| `S0 Batch Add-On Pages`                                        | `S0`                                   | `1K`          | Batch add-on (High Res, Font, Formula, Barcode)                  |
+| `S0 Batch Custom Generative Pages`                             | `S0`                                   | `1K`          | Batch custom generative extraction                               |
+| `S0 Batch Pre-built Pages`                                     | `S0`                                   | `1K`          | Batch pre-built (Invoice, Receipt, ID, W-2)                      |
+| `S0 Batch Layout Pages`                                        | `S0`                                   | `1K`          | Batch-only layout meter (no real-time equivalent named "Layout") |
+| `S0 Batch Read Pages`                                          | `S0`                                   | `1K`          | Batch OCR, **tiered** (2 rows) like real-time                    |
+| `S0 Batch Document Classifier Pages`                           | `S0`                                   | `1K`          | Batch doc classification (note: title case, unlike real-time)    |
+| `S0 Batch Custom Extraction Pages`                             | `S0`                                   | `1K`          | Batch custom extraction (note: not `S0 Batch Custom Pages`)      |
+| `S0 Batch Pages for Query Fields`                              | `S0`                                   | `1K`          | Batch query fields (note: title case, unlike real-time)          |
+| `S0 Training`                                                  | `S0`                                   | `1 Hour`      | Neural model training (first 10 hrs free)                        |
+| `Free Transactions`                                            | `Free`                                 | `1K`          | Free tier, 500 pages/month                                       |
+| `Commitment Tier Pre-Built Azure 100K CT Overage Transactions` | `Commitment Tier Pre-Built Azure 100K` | `1K`          | Overage beyond the included 100K pages                           |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/document-intelligence.md
@@ -46,6 +46,13 @@ ProductName: Azure Document Intelligence
 SkuName: Commitment Tier Pre-Built Azure 100K
 MeterName: Commitment Tier Pre-Built Azure 100K Unit # flat monthly fee, unitOfMeasure: 1/Month
 
+### Commitment tier: Pre-Built Azure 100K (overage)
+
+ServiceName: Foundry Tools
+ProductName: Azure Document Intelligence
+SkuName: Commitment Tier Pre-Built Azure 100K
+MeterName: Commitment Tier Pre-Built Azure 100K CT Overage Transactions
+
 ## Key Fields
 
 | Parameter     | How to determine                        | Example values                                                              |
@@ -77,6 +84,7 @@ MeterName: Commitment Tier Pre-Built Azure 100K Unit # flat monthly fee, unitOfM
 | `S0 Batch Pages for Query Fields` | `S0` | `1K`        | Batch query fields (note: title case, unlike real-time) |
 | `S0 Training`                  | `S0`    | `1 Hour`      | Neural model training (first 10 hrs free) |
 | `Free Transactions`            | `Free`  | `1K`          | Free tier, 500 pages/month                |
+| `Commitment Tier Pre-Built Azure 100K CT Overage Transactions` | `Commitment Tier Pre-Built Azure 100K` | `1K` | Overage beyond the included 100K pages |
 
 ## Cost Formula
 
@@ -90,9 +98,10 @@ Free grant:  Billable = max(0, pages − 500) then apply PAYG formula
 
 ## Notes
 
-- **Free tier**: F0 SKU includes 500 pages/month; S0 Training: first 10 hours free for neural models, template training always free
+- **Free tier**: `Free` SKU includes 500 pages/month; `S0 Training` includes the first 10 neural training hours, template training always free
 - **Model types** (never-assume): Read (OCR), Pre-built (Invoice/Receipt/ID/W-2/Layout), Custom (extraction/generative), Add-on. Ask user which model
-- **Commitment tiers**: Pre-built/Custom 20K–1M pages/month, Read 500K–16M pages/month; Connected Container tiers are ~10–20% cheaper (varies by model type)
+- **Commitment tiers**: Pre-built/Custom 20K–1M pages/month, Read 500K–16M pages/month; `Connected` tiers are ~10–20% cheaper (varies by model type)
+- **Capacity planning**: `Quantity: 1` = 1,000 pages for all `1K` meters; monthly cost scales linearly except tiered Read meters
 - **Disconnected containers**: Separate product (`Azure Document Intelligence - Disconnected`), annual billing (`1/Year`), no overage. Divide `retailPrice` by 12 for monthly equivalent
 - **Legacy**: `Form Recognizer` productName has higher Custom pricing; always use `Azure Document Intelligence` for current rates
 - **Scope**: For broader Foundry Tools coverage (Language, Vision, Speech, Translator), see `ai-ml/ai-services.md`

--- a/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
@@ -77,24 +77,24 @@ Quantity: 500 # agent units consumed
 
 ## Key Fields
 
-| Parameter     | How to determine               | Example values                             |
-| ------------- | ------------------------------ | ------------------------------------------ |
-| `serviceName` | Always `Foundry Tools` (API value; see apiServiceName in frontmatter) | `Foundry Tools` |
-| `productName` | Billing dimension              | `Foundry Agents`, `Azure Agent Unit`       |
-| `skuName`     | Compute SKU or agent type      | `Hosted`, `Skills Execution`, `Long Term Memory`, `SRE` |
-| `meterName`   | Specific resource being billed | `Hosted vCPU Usage`, `Skills Execution Container`, `SRE Agent Unit` |
+| Parameter     | How to determine                                                      | Example values                                                      |
+| ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools` (API value; see apiServiceName in frontmatter) | `Foundry Tools`                                                     |
+| `productName` | Billing dimension                                                     | `Foundry Agents`, `Azure Agent Unit`                                |
+| `skuName`     | Compute SKU or agent type                                             | `Hosted`, `Skills Execution`, `Long Term Memory`, `SRE`             |
+| `meterName`   | Specific resource being billed                                        | `Hosted vCPU Usage`, `Skills Execution Container`, `SRE Agent Unit` |
 
 ## Meter Names
 
-| Meter                        | skuName             | productName        | unitOfMeasure | Notes                         |
-| ---------------------------- | ------------------- | ------------------ | ------------- | ----------------------------- |
-| `Hosted vCPU Usage`          | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per vCPU-hour of compute      |
-| `Hosted Memory Usage`        | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per GB-hour of memory         |
-| `Skills Execution Container` | `Skills Execution`  | `Foundry Agents`   | `1 Hour`      | Per hour of skills container  |
-| `Long Term Memory Memories`  | `Long Term Memory`  | `Foundry Agents`   | `1K/Month`    | Persistent memory storage     |
-| `Short Term Memory Events Stored` | `Short Term Memory` | `Foundry Agents` | `1K`       | Ephemeral event storage       |
-| `Memory Retrievals`          | `Memory Retrieval`  | `Foundry Agents`   | `1K`          | Per-1K memory read operations |
-| `SRE Agent Unit`             | `SRE`               | `Azure Agent Unit` | `1`           | Per-unit orchestration charge |
+| Meter                             | skuName             | productName        | unitOfMeasure | Notes                         |
+| --------------------------------- | ------------------- | ------------------ | ------------- | ----------------------------- |
+| `Hosted vCPU Usage`               | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per vCPU-hour of compute      |
+| `Hosted Memory Usage`             | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per GB-hour of memory         |
+| `Skills Execution Container`      | `Skills Execution`  | `Foundry Agents`   | `1 Hour`      | Per hour of skills container  |
+| `Long Term Memory Memories`       | `Long Term Memory`  | `Foundry Agents`   | `1K/Month`    | Persistent memory storage     |
+| `Short Term Memory Events Stored` | `Short Term Memory` | `Foundry Agents`   | `1K`          | Ephemeral event storage       |
+| `Memory Retrievals`               | `Memory Retrieval`  | `Foundry Agents`   | `1K`          | Per-1K memory read operations |
+| `SRE Agent Unit`                  | `SRE`               | `Azure Agent Unit` | `1`           | Per-unit orchestration charge |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
@@ -35,6 +35,30 @@ SkuName: Hosted
 MeterName: Hosted Memory Usage
 Quantity: 8 # GBs of memory
 
+### Long-term memory
+ServiceName: Foundry Tools
+ProductName: Foundry Agents
+SkuName: Long Term Memory
+MeterName: Long Term Memory Memories
+Region: eastus2
+Quantity: 100 # thousands of memories
+
+### Short-term memory
+ServiceName: Foundry Tools
+ProductName: Foundry Agents
+SkuName: Short Term Memory
+MeterName: Short Term Memory Events Stored
+Region: eastus2
+Quantity: 100 # thousands of stored events
+
+### Memory retrieval
+ServiceName: Foundry Tools
+ProductName: Foundry Agents
+SkuName: Memory Retrieval
+MeterName: Memory Retrievals
+Region: eastus2
+Quantity: 100 # thousands of retrievals
+
 ### Skills execution container
 
 ServiceName: Foundry Tools

--- a/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/foundry-agents.md
@@ -15,6 +15,8 @@ primaryCost: "Hosted compute (vCPU + memory × 730 hrs/mo) + skills execution + 
 
 > **Trap (mixed units)**: Compute meters use `1 Hour` (multiply by 730), but SRE Agent Unit uses `unitOfMeasure: 1` (per-unit, not hourly). Do NOT multiply SRE cost by 730.
 
+> **Trap (memory regions)**: `Long Term Memory`, `Short Term Memory`, and `Memory Retrieval` meters return zero in `eastus`; use `eastus2` or another supported region.
+
 ## Query Pattern
 
 ### Hosted agent compute: vCPU
@@ -60,15 +62,15 @@ Quantity: 500 # agent units consumed
 
 ## Meter Names
 
-| Meter                        | productName        | unitOfMeasure | Notes                            |
-| ---------------------------- | ------------------ | ------------- | -------------------------------- |
-| `Hosted vCPU Usage`          | `Foundry Agents`   | `1 Hour`      | Per vCPU-hour of compute         |
-| `Hosted Memory Usage`        | `Foundry Agents`   | `1 Hour`      | Per GB-hour of memory            |
-| `Skills Execution Container` | `Foundry Agents`   | `1 Hour`      | Per hour of skills container     |
-| `Long Term Memory Memories`  | `Foundry Agents`   | `1K/Month`    | Persistent memory storage        |
-| `Short Term Memory Events Stored` | `Foundry Agents` | `1K`       | Ephemeral event storage          |
-| `Memory Retrievals`          | `Foundry Agents`   | `1K`          | Per-1K memory read operations    |
-| `SRE Agent Unit`             | `Azure Agent Unit` | `1`           | Per-unit orchestration charge    |
+| Meter                        | skuName             | productName        | unitOfMeasure | Notes                         |
+| ---------------------------- | ------------------- | ------------------ | ------------- | ----------------------------- |
+| `Hosted vCPU Usage`          | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per vCPU-hour of compute      |
+| `Hosted Memory Usage`        | `Hosted`            | `Foundry Agents`   | `1 Hour`      | Per GB-hour of memory         |
+| `Skills Execution Container` | `Skills Execution`  | `Foundry Agents`   | `1 Hour`      | Per hour of skills container  |
+| `Long Term Memory Memories`  | `Long Term Memory`  | `Foundry Agents`   | `1K/Month`    | Persistent memory storage     |
+| `Short Term Memory Events Stored` | `Short Term Memory` | `Foundry Agents` | `1K`       | Ephemeral event storage       |
+| `Memory Retrievals`          | `Memory Retrieval`  | `Foundry Agents`   | `1K`          | Per-1K memory read operations |
+| `SRE Agent Unit`             | `SRE`               | `Azure Agent Unit` | `1`           | Per-unit orchestration charge |
 
 ## Cost Formula
 
@@ -86,6 +88,7 @@ Total:     Monthly = vCPU + Memory + Skills + LTM + STM + Retrieval + SRE
 ## Notes
 
 - **Billing dependency**: Agent compute only; model inference (LLM tokens) billed separately via Azure OpenAI; see `openai-service.md`
-- **Regional availability**: Compute meters available in multiple regions; SRE Agent Unit in limited regions only
+- **Optional commit pricing**: Agent Commit Unit bundles are separate `Foundry Models` reservation items under `Microsoft Agent Pre-Purchase Plan`
+- **Regional availability**: Hosted compute is multi-region, memory meters require `eastus2` or another supported region, and SRE coverage differs by region
 - **Capacity planning**: 1 unit = 1 vCPU-hour or 1 GB-hour (compute), 1 container-hour (skills), 1 agent unit (SRE); scale `Quantity` to match allocation
 - **Scope**: Part of Foundry Tools umbrella (see `ai-services.md` for other sub-services)

--- a/skills/azure-cost-calculator/references/services/ai-ml/genomics.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/genomics.md
@@ -30,11 +30,11 @@ Quantity: 10 # incremental gigabases above the included 10 per genome
 
 ## Key Fields
 
-| Parameter     | How to determine                                    | Example values                                                                               |
-| ------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `serviceName` | Always `Microsoft Genomics`                         | `Microsoft Genomics`                                                                         |
-| `productName` | Always `Microsoft Genomics`                         | `Microsoft Genomics`                                                                         |
-| `skuName`     | Always `Alignment and Variant Calling`              | `Alignment and Variant Calling`                                                              |
+| Parameter     | How to determine                                   | Example values                                                                               |
+| ------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `serviceName` | Always `Microsoft Genomics`                        | `Microsoft Genomics`                                                                         |
+| `productName` | Always `Microsoft Genomics`                        | `Microsoft Genomics`                                                                         |
+| `skuName`     | Always `Alignment and Variant Calling`             | `Alignment and Variant Calling`                                                              |
 | `meterName`   | Processing model, per genome or per incremental GB | `Alignment and Variant Calling Genome`, `Alignment and Variant Calling Incremental Gigabase` |
 
 ## Meter Names

--- a/skills/azure-cost-calculator/references/services/ai-ml/genomics.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/genomics.md
@@ -18,7 +18,7 @@ ServiceName: Microsoft Genomics
 ProductName: Microsoft Genomics
 SkuName: Alignment and Variant Calling
 MeterName: Alignment and Variant Calling Genome
-Quantity: 5
+Quantity: 5 # genomes processed this month
 
 ### Alignment and Variant Calling: per incremental gigabase
 
@@ -26,7 +26,7 @@ ServiceName: Microsoft Genomics
 ProductName: Microsoft Genomics
 SkuName: Alignment and Variant Calling
 MeterName: Alignment and Variant Calling Incremental Gigabase
-Quantity: 10
+Quantity: 10 # incremental gigabases above the included 10 per genome
 
 ## Key Fields
 
@@ -51,11 +51,10 @@ incrementalGB = max(totalGigabases - (10 × genomeCount), 0)
 Monthly = (genome_retailPrice × genomeCount) + (gigabase_retailPrice × incrementalGB)
 ```
 
-`Quantity` maps directly to number of genomes or gigabases (`unitOfMeasure` is `1`).
-
 ## Notes
 
 - Single product with only 2 meters. No tiers, no reserved instances, no savings plans
+- Prices are identical across all returned Genomics regions; a standard regional query returns the same two meters
 - `unitOfMeasure` is `1` for both meters; Quantity parameter equals the actual count of genomes or gigabases
 - Billing model: genome rate covers first 10 gigabases per workflow; incremental rate applies to each additional gigabase
 - Input/output data stored in Azure Blob Storage; billed separately under Storage

--- a/skills/azure-cost-calculator/references/services/ai-ml/language.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/language.md
@@ -4,20 +4,20 @@ category: ai-ml
 aliases: [Language Understanding, LUIS, Text Analytics, NER, Sentiment Analysis, CLU]
 billingNeeds: [Azure Cognitive Search]
 apiServiceName: Foundry Tools
-primaryCost: "Per-1K text records (tiered by feature) + training per hour + optional commitment tiers."
+primaryCost: "Per-1K text records + training hours + monthly commitment tiers and overage."
 hasFreeGrant: true
 privateEndpoint: true
 ---
 
 # Azure Language
 
-> **Trap (serviceName)**: API `serviceName` is `Foundry Tools`, not `Azure Language`. Always filter by `ProductName` to isolate Language meters from other AI Services.
+> **Trap (product split)**: API `serviceName` is `Foundry Tools`. Azure Language also spans `Language Understanding`, `Text Analytics Container`, and `*-Disconnected` products, so always filter by `ProductName`.
 
-> **Trap (tiered pricing)**: Standard Text Records returns multiple rows with different `tierMinimumUnits`. The script sums all tiers; use the tier matching your volume.
+> **Trap (tiered totals)**: `Standard Text Records`, `Standard Health Text Records`, and `Standard QA Text Records` return multiple `tierMinimumUnits` rows. Use only the tier matching your volume.
 
-> **Trap (training MonthlyCost)**: Training meters use `1 Hour`. The script multiplies by 730. Calculate as `trainingHours × retailPrice` instead.
+> **Trap (mixed billing units)**: Training is `1 Hour`, commitments are `1/Month`, and disconnected products are `1/Year`. Do not use one monthly formula for every meter.
 
-> **Agent instruction**: When estimating Question Answering, also pull in `Azure Cognitive Search` pricing — QA requires a dedicated search index billed separately.
+> **Agent instruction**: When estimating Question Answering, also price `Azure Cognitive Search`; the search index is billed separately.
 
 ## Query Pattern
 
@@ -27,14 +27,14 @@ ServiceName: Foundry Tools
 ProductName: Azure Language
 SkuName: Standard
 MeterName: Standard Text Records
-Quantity: 100 # 100 × 1K = 100K records
+Quantity: 100 # 100 x 1K = 100K records
 
-### CLU inference
+### Standard commitment tier: 1M included records/month
 
 ServiceName: Foundry Tools
 ProductName: Azure Language
-SkuName: Standard
-MeterName: Standard CLU Text Records
+SkuName: Commitment Tier Azure 1M
+MeterName: Commitment Tier Azure 1M Unit
 
 ### CLU / custom model training
 
@@ -43,7 +43,7 @@ ProductName: Azure Language
 SkuName: Standard
 MeterName: Standard CLU Advanced Training Unit
 
-### LUIS (legacy)
+### Legacy LUIS inference
 
 ServiceName: Foundry Tools
 ProductName: Language Understanding
@@ -52,46 +52,51 @@ MeterName: S1 Transactions
 
 ## Key Fields
 
-| Parameter     | How to determine             | Example values                                                        |
-| ------------- | ---------------------------- | --------------------------------------------------------------------- |
-| `serviceName` | Always `Foundry Tools`       | `Foundry Tools`                                                       |
-| `productName` | Feature / deployment variant | `Azure Language`, `Language Understanding`, `Text Analytics Container` |
-| `skuName`     | Tier, varies by feature      | `Standard`, `Free`, `S1`, `Commitment Tier Azure 1M`                  |
-| `meterName`   | Feature-specific meter       | `Standard Text Records`, `Standard CLU Text Records`                  |
+| Parameter | How to determine | Example values |
+| --- | --- | --- |
+| `serviceName` | Always `Foundry Tools` in the API | `Foundry Tools` |
+| `productName` | Feature family or deployment model | `Azure Language`, `Language Understanding`, `Text Analytics Container` |
+| `skuName` | Tier, legacy SKU, or commitment band | `Standard`, `Free`, `P1`, `Commitment Tier Azure 1M` |
+| `meterName` | Exact billing dimension | `Standard Text Records`, `Doc-PII Redaction Pages`, `P1 Transactions` |
 
 ## Meter Names
 
-| Meter                                  | productName                | unitOfMeasure | Notes                              |
-| -------------------------------------- | -------------------------- | ------------- | ---------------------------------- |
-| `Standard Text Records`               | `Azure Language`           | `1K`          | NER, Sentiment, PII (tiered)       |
-| `Standard CLU Text Records`           | `Azure Language`           | `1K`          | CLU inference                      |
-| `Standard CLU Advanced Training Unit` | `Azure Language`           | `1 Hour`      | CLU training                       |
-| `Standard Custom Text Records`        | `Azure Language`           | `1K`          | Custom NER / classification        |
-| `Standard Custom Summarization Text Records` | `Azure Language`  | `1K`          | Custom summarization               |
-| `Standard Custom Training Unit`       | `Azure Language`           | `1 Hour`      | Custom model training              |
-| `Standard Summarization Text Records` | `Azure Language`           | `1K`          | Summarization                      |
-| `Standard Health Text Records`        | `Azure Language`           | `1K`          | Health NER (tiered, first 5K free) |
-| `Standard QA Text Records`            | `Azure Language`           | `1K`          | Question Answering (tiered)        |
-| `Standard Custom Hosting Unit`        | `Azure Language`           | `1/Month`     | Per custom model hosting           |
-| `S1 Transactions`                     | `Language Understanding`   | `1K`          | LUIS text endpoint                 |
-| `S1 Speech To Intent - Understanding Transactions` | `Language Understanding` | `1K` | LUIS speech-to-intent              |
-| `Standard Text Records`               | `Text Analytics Container` | `1K`          | On-prem container (tiered)         |
+| Meter | skuName | productName | unitOfMeasure | Notes |
+| --- | --- | --- | --- | --- |
+| `Standard Text Records` | `Standard` | `Azure Language` | `1K` | Core text analytics; tiers at 0/500/2500/10000 |
+| `Standard Health Text Records` | `Standard` | `Azure Language` | `1K` | TA4H; tiers at 0/5/500/2500/10000 |
+| `Standard QA Text Records` | `Standard` | `Azure Language` | `1K` | Question Answering; tiers at 0/2500 |
+| `Standard CLU Text Records` | `Standard` | `Azure Language` | `1K` | CLU inference |
+| `Standard CLU Advanced Training Unit` | `Standard` | `Azure Language` | `1 Hour` | CLU training |
+| `Standard Custom Text Records` | `Standard` | `Azure Language` | `1K` | Custom NER / classification |
+| `Standard Custom Summarization Text Records` | `Standard` | `Azure Language` | `1K` | Custom summarization |
+| `Standard Custom Training Unit` | `Standard` | `Azure Language` | `1 Hour` | Custom model training |
+| `Standard Custom Hosting Unit` | `Standard` | `Azure Language` | `1/Month` | Hosted custom model |
+| `Doc-PII Redaction Pages` | `Doc-PII Redaction Pages` | `Azure Language` | `1K` | Document PII redaction |
+| `Commitment Tier Azure {1M|3M|10M|25M} Unit` | `Commitment Tier Azure {1M|3M|10M|25M}` | `Azure Language` | `1/Month` | Standard included usage; overage uses `...CT Overage Transactions` |
+| `Commitment Tier CLU Azure {1M|3M|10M|25M} Unit` | `Commitment Tier CLU Azure {1M|3M|10M|25M}` | `Azure Language` | `1/Month` | CLU commitment tiers |
+| `Commitment Tier Summarization Azure {3M|10M} Unit` | `Commitment Tier Summarization Azure {3M|10M}` | `Azure Language` | `1/Month` | Summarization commitment tiers |
+| `Commitment Tier TA4H {1M|3M|10M} Unit` | `Commitment Tier TA4H {1M|3M|10M}` | `Azure Language` | `1/Month` | Health commitment tiers |
+| `P1 Transactions` | `P1` | `Language Understanding` | `1K` | Legacy LUIS inference |
+| `S1 Transactions` | `S1` | `Language Understanding` | `1K` | Legacy LUIS inference |
+| `S1 Speech To Intent - Understanding Transactions` | `S1` | `Language Understanding` | `1K` | Legacy speech-to-intent |
+| `Standard Text Records` | `Standard` | `Text Analytics Container` | `1K` | Connected container PAYG |
 
 ## Cost Formula
 
 ```
-Text analytics: Monthly = retailPrice × Quantity (Quantity = records ÷ 1,000)
-Training:       Monthly = retailPrice × trainingHours (NOT 730)
-Custom hosting: Monthly = retailPrice × modelCount
-Commitment:     Monthly = commitmentFee + (overage_retailPrice × excessQuantity)
-Free grant:     Health NER: max(0, records − 5,000) ÷ 1,000; Free (F0) SKU: hard 5K quota, no overage
+Text records (1K):   Monthly = retailPrice × Quantity
+Training (1 Hour):   Monthly = retailPrice × trainingHours
+Monthly CTs:         Monthly = commitmentFee + (overage_retailPrice × excessQuantity)
+Annual CTs:          Monthly = retailPrice ÷ 12
+Free grant:          Billable = max(0, totalRecords − includedFreeRecords)
 ```
 
 ## Notes
 
-- **Free tier**: 5K text records/month shared across Sentiment, NER, KPE, Language Detection, QA, Summarization, CLU; 1 hour free training; 1 custom model hosting free
-- **Commitment tiers**: Available for Standard, CLU, Summarization, and TA4H features at varying volume tiers (1M–25M depending on feature). Connected container tiers are ~20% cheaper than Azure-hosted
-- **Disconnected products**: `Azure Language - Disconnected` and `Language Understanding - Disconnected` bill annually (`1/Year`). Exclude from monthly estimates
-- **Scope**: Covers Language-specific products under Foundry Tools. For other AI Services, see `ai-services.md`
-- **Legacy tiers**: S0–S4 daily-billed tiers (`1/Day` base + per-1K overage) are deprecated but still in API
-- **QA dependency**: Question Answering requires a separate Azure AI Search resource (billed independently)
+- **Free meters**: `Free Text Records`, `Free Training Unit`, `Free Transactions`, `Free Authoring Transactions`, and `Standard Text Records - Free` appear in the API
+- **Commitment tiers**: Standard and CLU Azure/Connected use 1M/3M/10M/25M; Summarization uses 3M/10M; TA4H uses 1M/3M/10M; legacy LUIS uses 1M/5M/25M
+- **Disconnected products**: `Azure Language - Disconnected` and `Language Understanding - Disconnected` bill annually (`1/Year`); exclude unless the user asks for disconnected containers
+- **Container product split**: `Text Analytics Container` is the connected PAYG product, but connected commitment SKUs still live under `Azure Language`
+- **Legacy scope**: `Language Understanding` still contains LUIS meters, including `P1 Transactions`, `S1 Transactions`, and daily S0-S4 tiers
+- **QA dependency**: Question Answering requires a separate Azure AI Search resource; Azure Language also supports private endpoints through the Azure AI Services resource

--- a/skills/azure-cost-calculator/references/services/ai-ml/language.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/language.md
@@ -52,35 +52,35 @@ MeterName: S1 Transactions
 
 ## Key Fields
 
-| Parameter | How to determine | Example values |
-| --- | --- | --- |
-| `serviceName` | Always `Foundry Tools` in the API | `Foundry Tools` |
-| `productName` | Feature family or deployment model | `Azure Language`, `Language Understanding`, `Text Analytics Container` |
-| `skuName` | Tier, legacy SKU, or commitment band | `Standard`, `Free`, `P1`, `Commitment Tier Azure 1M` |
-| `meterName` | Exact billing dimension | `Standard Text Records`, `Doc-PII Redaction Pages`, `P1 Transactions` |
+| Parameter     | How to determine                     | Example values                                                         |
+| ------------- | ------------------------------------ | ---------------------------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools` in the API    | `Foundry Tools`                                                        |
+| `productName` | Feature family or deployment model   | `Azure Language`, `Language Understanding`, `Text Analytics Container` |
+| `skuName`     | Tier, legacy SKU, or commitment band | `Standard`, `Free`, `P1`, `Commitment Tier Azure 1M`                   |
+| `meterName`   | Exact billing dimension              | `Standard Text Records`, `Doc-PII Redaction Pages`, `P1 Transactions`  |
 
 ## Meter Names
 
-| Meter | skuName | productName | unitOfMeasure | Notes |
-| --- | --- | --- | --- | --- |
-| `Standard Text Records` | `Standard` | `Azure Language` | `1K` | Core text analytics; tiers at 0/500/2500/10000 |
-| `Standard Health Text Records` | `Standard` | `Azure Language` | `1K` | TA4H; tiers at 0/5/500/2500/10000 |
-| `Standard QA Text Records` | `Standard` | `Azure Language` | `1K` | Question Answering; tiers at 0/2500 |
-| `Standard CLU Text Records` | `Standard` | `Azure Language` | `1K` | CLU inference |
-| `Standard CLU Advanced Training Unit` | `Standard` | `Azure Language` | `1 Hour` | CLU training |
-| `Standard Custom Text Records` | `Standard` | `Azure Language` | `1K` | Custom NER / classification |
-| `Standard Custom Summarization Text Records` | `Standard` | `Azure Language` | `1K` | Custom summarization |
-| `Standard Custom Training Unit` | `Standard` | `Azure Language` | `1 Hour` | Custom model training |
-| `Standard Custom Hosting Unit` | `Standard` | `Azure Language` | `1/Month` | Hosted custom model |
-| `Doc-PII Redaction Pages` | `Doc-PII Redaction Pages` | `Azure Language` | `1K` | Document PII redaction |
-| `Commitment Tier Azure {1M/3M/10M/25M} Unit` | `Commitment Tier Azure {1M/3M/10M/25M}` | `Azure Language` | `1/Month` | Standard included usage; overage uses `...CT Overage Transactions` |
-| `Commitment Tier CLU Azure {1M/3M/10M/25M} Unit` | `Commitment Tier CLU Azure {1M/3M/10M/25M}` | `Azure Language` | `1/Month` | CLU commitment tiers |
-| `Commitment Tier Summarization Azure {3M/10M} Unit` | `Commitment Tier Summarization Azure {3M/10M}` | `Azure Language` | `1/Month` | Summarization commitment tiers |
-| `Commitment Tier TA4H {1M/3M/10M} Unit` | `Commitment Tier TA4H {1M/3M/10M}` | `Azure Language` | `1/Month` | Health commitment tiers |
-| `P1 Transactions` | `P1` | `Language Understanding` | `1K` | Legacy LUIS inference |
-| `S1 Transactions` | `S1` | `Language Understanding` | `1K` | Legacy LUIS inference |
-| `S1 Speech To Intent - Understanding Transactions` | `S1` | `Language Understanding` | `1K` | Legacy speech-to-intent |
-| `Standard Text Records` | `Standard` | `Text Analytics Container` | `1K` | Connected container PAYG |
+| Meter                                               | skuName                                        | productName                | unitOfMeasure | Notes                                                              |
+| --------------------------------------------------- | ---------------------------------------------- | -------------------------- | ------------- | ------------------------------------------------------------------ |
+| `Standard Text Records`                             | `Standard`                                     | `Azure Language`           | `1K`          | Core text analytics; tiers at 0/500/2500/10000                     |
+| `Standard Health Text Records`                      | `Standard`                                     | `Azure Language`           | `1K`          | TA4H; tiers at 0/5/500/2500/10000                                  |
+| `Standard QA Text Records`                          | `Standard`                                     | `Azure Language`           | `1K`          | Question Answering; tiers at 0/2500                                |
+| `Standard CLU Text Records`                         | `Standard`                                     | `Azure Language`           | `1K`          | CLU inference                                                      |
+| `Standard CLU Advanced Training Unit`               | `Standard`                                     | `Azure Language`           | `1 Hour`      | CLU training                                                       |
+| `Standard Custom Text Records`                      | `Standard`                                     | `Azure Language`           | `1K`          | Custom NER / classification                                        |
+| `Standard Custom Summarization Text Records`        | `Standard`                                     | `Azure Language`           | `1K`          | Custom summarization                                               |
+| `Standard Custom Training Unit`                     | `Standard`                                     | `Azure Language`           | `1 Hour`      | Custom model training                                              |
+| `Standard Custom Hosting Unit`                      | `Standard`                                     | `Azure Language`           | `1/Month`     | Hosted custom model                                                |
+| `Doc-PII Redaction Pages`                           | `Doc-PII Redaction Pages`                      | `Azure Language`           | `1K`          | Document PII redaction                                             |
+| `Commitment Tier Azure {1M/3M/10M/25M} Unit`        | `Commitment Tier Azure {1M/3M/10M/25M}`        | `Azure Language`           | `1/Month`     | Standard included usage; overage uses `...CT Overage Transactions` |
+| `Commitment Tier CLU Azure {1M/3M/10M/25M} Unit`    | `Commitment Tier CLU Azure {1M/3M/10M/25M}`    | `Azure Language`           | `1/Month`     | CLU commitment tiers                                               |
+| `Commitment Tier Summarization Azure {3M/10M} Unit` | `Commitment Tier Summarization Azure {3M/10M}` | `Azure Language`           | `1/Month`     | Summarization commitment tiers                                     |
+| `Commitment Tier TA4H {1M/3M/10M} Unit`             | `Commitment Tier TA4H {1M/3M/10M}`             | `Azure Language`           | `1/Month`     | Health commitment tiers                                            |
+| `P1 Transactions`                                   | `P1`                                           | `Language Understanding`   | `1K`          | Legacy LUIS inference                                              |
+| `S1 Transactions`                                   | `S1`                                           | `Language Understanding`   | `1K`          | Legacy LUIS inference                                              |
+| `S1 Speech To Intent - Understanding Transactions`  | `S1`                                           | `Language Understanding`   | `1K`          | Legacy speech-to-intent                                            |
+| `Standard Text Records`                             | `Standard`                                     | `Text Analytics Container` | `1K`          | Connected container PAYG                                           |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/language.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/language.md
@@ -73,10 +73,10 @@ MeterName: S1 Transactions
 | `Standard Custom Training Unit` | `Standard` | `Azure Language` | `1 Hour` | Custom model training |
 | `Standard Custom Hosting Unit` | `Standard` | `Azure Language` | `1/Month` | Hosted custom model |
 | `Doc-PII Redaction Pages` | `Doc-PII Redaction Pages` | `Azure Language` | `1K` | Document PII redaction |
-| `Commitment Tier Azure {1M|3M|10M|25M} Unit` | `Commitment Tier Azure {1M|3M|10M|25M}` | `Azure Language` | `1/Month` | Standard included usage; overage uses `...CT Overage Transactions` |
-| `Commitment Tier CLU Azure {1M|3M|10M|25M} Unit` | `Commitment Tier CLU Azure {1M|3M|10M|25M}` | `Azure Language` | `1/Month` | CLU commitment tiers |
-| `Commitment Tier Summarization Azure {3M|10M} Unit` | `Commitment Tier Summarization Azure {3M|10M}` | `Azure Language` | `1/Month` | Summarization commitment tiers |
-| `Commitment Tier TA4H {1M|3M|10M} Unit` | `Commitment Tier TA4H {1M|3M|10M}` | `Azure Language` | `1/Month` | Health commitment tiers |
+| `Commitment Tier Azure {1M/3M/10M/25M} Unit` | `Commitment Tier Azure {1M/3M/10M/25M}` | `Azure Language` | `1/Month` | Standard included usage; overage uses `...CT Overage Transactions` |
+| `Commitment Tier CLU Azure {1M/3M/10M/25M} Unit` | `Commitment Tier CLU Azure {1M/3M/10M/25M}` | `Azure Language` | `1/Month` | CLU commitment tiers |
+| `Commitment Tier Summarization Azure {3M/10M} Unit` | `Commitment Tier Summarization Azure {3M/10M}` | `Azure Language` | `1/Month` | Summarization commitment tiers |
+| `Commitment Tier TA4H {1M/3M/10M} Unit` | `Commitment Tier TA4H {1M/3M/10M}` | `Azure Language` | `1/Month` | Health commitment tiers |
 | `P1 Transactions` | `P1` | `Language Understanding` | `1K` | Legacy LUIS inference |
 | `S1 Transactions` | `S1` | `Language Understanding` | `1K` | Legacy LUIS inference |
 | `S1 Speech To Intent - Understanding Transactions` | `S1` | `Language Understanding` | `1K` | Legacy speech-to-intent |
@@ -87,6 +87,7 @@ MeterName: S1 Transactions
 ```
 Text records (1K):   Monthly = retailPrice × Quantity
 Training (1 Hour):   Monthly = retailPrice × trainingHours
+Direct monthly meters: Monthly = retailPrice × quantity
 Monthly CTs:         Monthly = commitmentFee + (overage_retailPrice × excessQuantity)
 Annual CTs:          Monthly = retailPrice ÷ 12
 Free grant:          Billable = max(0, totalRecords − includedFreeRecords)
@@ -99,4 +100,4 @@ Free grant:          Billable = max(0, totalRecords − includedFreeRecords)
 - **Disconnected products**: `Azure Language - Disconnected` and `Language Understanding - Disconnected` bill annually (`1/Year`); exclude unless the user asks for disconnected containers
 - **Container product split**: `Text Analytics Container` is the connected PAYG product, but connected commitment SKUs still live under `Azure Language`
 - **Legacy scope**: `Language Understanding` still contains LUIS meters, including `P1 Transactions`, `S1 Transactions`, and daily S0-S4 tiers
-- **QA dependency**: Question Answering requires a separate Azure AI Search resource; Azure Language also supports private endpoints through the Azure AI Services resource
+- **QA dependency**: Question Answering requires a separate Azure AI Search resource

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning-studio.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning-studio.md
@@ -2,7 +2,7 @@
 serviceName: Machine Learning Studio
 category: ai-ml
 aliases: [ML Studio (classic), Classic ML]
-primaryCost: "Daily rate × 30 × planCount + overage per 1K; Classic hourly × 730 × instanceCount; workspace + experiment"
+primaryCost: "Daily plan × 30 + hourly/per-1K overage; Classic hourly × 730 + per-1K txns; workspace + experiment"
 hasFreeGrant: true
 ---
 
@@ -12,7 +12,7 @@ hasFreeGrant: true
 
 > **Trap (daily billing)**: Plan meters (S1, S2, S3) use `1/Day` units. The script auto-multiplies by 30, so `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30`; that would overcount by 30x.
 
-> **Trap (no eastus meters)**: This service has **no meters in `eastus`**. Use `Region: Global` (primary for all commercial meters) or a specific region: `southcentralus`, `westeurope`, `eastus2`.
+> **Trap (regional gaps)**: This service has **no meters in `eastus`**. `eastus2` has Production Web API meters, but Standard workspace meters are missing there. Use `Region: Global` for the most complete commercial query coverage.
 
 ## Query Pattern
 
@@ -22,7 +22,7 @@ ServiceName: Machine Learning Studio
 ProductName: Machine Learning Studio Production Web API
 SkuName: S1
 MeterName: S1 Plan
-Region: southcentralus
+Region: Global
 InstanceCount: 3
 
 ### S1 overage transactions: 500K transactions
@@ -31,7 +31,7 @@ ServiceName: Machine Learning Studio
 ProductName: Machine Learning Studio Production Web API
 SkuName: S1
 MeterName: S1 Overage Transactions
-Region: westeurope
+Region: Global
 Quantity: 500
 
 ### Classic hourly tier: 2 instances
@@ -86,14 +86,14 @@ Region: Global
 
 ```
 Plan Monthly      = plan_retailPrice × 30 × planCount
-Overage Monthly   = overage_retailPrice × (overageTransactions / 1000)
-Classic Monthly   = classic_retailPrice × 730 × instanceCount
+Overage Monthly   = (overage_compute_retailPrice × overageHours) + (overage_txn_retailPrice × (overageTransactions / 1000))
+Classic Monthly   = (classic_retailPrice × 730 × instanceCount) + (classic_txn_retailPrice × (transactions / 1000))
 Workspace Monthly = (workspace_fee_retailPrice × 1) + (experiment_retailPrice × 730 × experimentHours)
 ```
 
 ## Notes
 
 - **Deprecated**: Machine Learning Studio (classic) is being retired. Migrate to Azure Machine Learning (`machine-learning.md`)
-- Each plan tier includes free compute hours and transactions (meters return zero price); overage is billed per 1K transactions above the included quantity
-- Meters are available in `Global` and in select regions: `southcentralus`, `westcentralus`, `eastus2`, `westeurope`, `japaneast`, `southeastasia`, `usgovarizona`, `usgovtexas`, `usgovvirginia`
-- Standard workspace product has `Standard Experiment Compute` (hourly) and `Standard Workspace fee` (monthly) meters separate from the Production Web API plans
+- Each plan tier includes free compute hours and transactions (meters return zero price); overage is billed per hour and per 1K transactions above the included quantities
+- Use `Global` as the default commercial query region; `southcentralus`, `westcentralus`, `westeurope`, `japaneast`, `southeastasia`, and `eastus2` also have Web API meters
+- Standard workspace product has `Standard Experiment Compute` (hourly) and `Standard Workspace fee` (monthly) meters separate from the Production Web API plans, and those workspace meters are not available in `eastus2`

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning-studio.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning-studio.md
@@ -59,26 +59,26 @@ Region: Global
 
 ## Key Fields
 
-| Parameter     | How to determine                          | Example values                                                                    |
-| ------------- | ----------------------------------------- | --------------------------------------------------------------------------------- |
-| `serviceName` | Always `Machine Learning Studio`          | `Machine Learning Studio`                                                         |
+| Parameter     | How to determine                          | Example values                                                                      |
+| ------------- | ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| `serviceName` | Always `Machine Learning Studio`          | `Machine Learning Studio`                                                           |
 | `productName` | Workspace, Standard API, or Classic       | `Machine Learning Studio`, `...Production Web API`, `...Production Web API Classic` |
-| `skuName`     | Plan tier or Classic                      | `S1`, `S2`, `S3`, `Classic`                                                       |
-| `meterName`   | Plan, overage, or included quantity meter | `S1 Plan`, `S1 Overage Transactions`, `Standard Workspace fee`, `Classic`         |
+| `skuName`     | Plan tier or Classic                      | `S1`, `S2`, `S3`, `Classic`                                                         |
+| `meterName`   | Plan, overage, or included quantity meter | `S1 Plan`, `S1 Overage Transactions`, `Standard Workspace fee`, `Classic`           |
 
 ## Meter Names
 
-| Meter                              | skuName    | unitOfMeasure | Notes                              |
-| ---------------------------------- | ---------- | ------------- | ---------------------------------- |
-| `S1 Plan`                          | `S1`       | `1/Day`       | Daily plan fee                     |
-| `S1 Overage Transactions`          | `S1`       | `1K`          | Per 1K transactions above included |
-| `S1 Overage Compute`               | `S1`       | `1 Hour`      | Per hour above included compute    |
-| `Included Quantity API Compute`    | `S1`       | `1 Hour`      | Included compute hours, free       |
-| `Included Quantity API Transactions` | `S1`     | `1K`          | Included transactions, free        |
-| `Classic`                          | `Classic`  | `1 Hour`      | Hourly compute, Classic tier       |
-| `Classic Transactions`             | `Classic`  | `1K`          | Per 1K transactions, Classic tier  |
-| `Standard Experiment Compute`      | `Standard` | `1 Hour`      | Workspace experiment compute       |
-| `Standard Workspace fee`           | `Standard` | `1/Month`     | Monthly workspace subscription     |
+| Meter                                | skuName    | unitOfMeasure | Notes                              |
+| ------------------------------------ | ---------- | ------------- | ---------------------------------- |
+| `S1 Plan`                            | `S1`       | `1/Day`       | Daily plan fee                     |
+| `S1 Overage Transactions`            | `S1`       | `1K`          | Per 1K transactions above included |
+| `S1 Overage Compute`                 | `S1`       | `1 Hour`      | Per hour above included compute    |
+| `Included Quantity API Compute`      | `S1`       | `1 Hour`      | Included compute hours, free       |
+| `Included Quantity API Transactions` | `S1`       | `1K`          | Included transactions, free        |
+| `Classic`                            | `Classic`  | `1 Hour`      | Hourly compute, Classic tier       |
+| `Classic Transactions`               | `Classic`  | `1K`          | Per 1K transactions, Classic tier  |
+| `Standard Experiment Compute`        | `Standard` | `1 Hour`      | Workspace experiment compute       |
+| `Standard Workspace fee`             | `Standard` | `1/Month`     | Monthly workspace subscription     |
 
 > S2 and S3 tiers have equivalent Plan, Overage Transactions, Overage Compute, and Included Quantity meters; shown above for S1 only.
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
@@ -2,8 +2,8 @@
 serviceName: Azure Machine Learning
 category: ai-ml
 aliases: [Azure ML, AML, ML Workspace]
-billingNeeds: [Storage, Key Vault, Application Insights]
-primaryCost: "Managed endpoint capacity (hourly × 730) + ML surcharges + token fees. Training clusters billed under VMs."
+billingNeeds: [Virtual Machines, Storage, Key Vault, Application Insights]
+primaryCost: "Managed endpoint capacity + ML surcharges + token and daily management fees; training compute billed under VMs."
 privateEndpoint: true
 ---
 
@@ -13,13 +13,16 @@ privateEndpoint: true
 
 > **Trap (compute billing split)**: Managed endpoints are billed here under `Azure Machine Learning` (Managed Model Hosting Service). Training clusters and compute instances run on **Virtual Machines** and are billed separately under the `Virtual Machines` service. The meters in this service cover managed endpoint capacity and ML service surcharges only.
 
+> **Trap (regional gaps)**: Llama-4 token meters require `Region: eastus2` or `swedencentral`; `Machine Learning Model Management` tiers are not returned in `eastus`. If you omit region filters for those queries, the API can return zero results even when the meter is active.
+
 ## Query Pattern
 
-### Managed online endpoint: e.g., NC4asT4 v3 GPU instance (2 endpoints)
+### Managed online endpoint: NC4asT4 v3 GPU instance (2 endpoints, East US 2)
 
 ServiceName: Azure Machine Learning
 ProductName: Managed Model Hosting Service
 SkuName: NC4asT4 v3
+Region: eastus2
 InstanceCount: 2
 
 ### ML service surcharge: Standard GPU
@@ -33,6 +36,7 @@ MeterName: Standard GPU Surcharge
 ServiceName: Azure Machine Learning
 ProductName: Managed Model Hosting Service
 MeterName: Llama-4-Scout-17B-16E-In Tokens
+Region: eastus2
 Quantity: 100
 
 ### Model Management: S1 Tier
@@ -41,6 +45,7 @@ ServiceName: Azure Machine Learning
 ProductName: Machine Learning Model Management
 SkuName: S1
 MeterName: S1 Tier
+Region: eastus2
 
 ### Safety evaluation tokens (input): 100K tokens
 
@@ -55,32 +60,40 @@ Quantity: 100
 | ------------- | --------------------------------------------------- | ----------------------------------------------------------- |
 | `serviceName` | Always `Azure Machine Learning`                     | `Azure Machine Learning`                                    |
 | `productName` | Component type                                      | `Managed Model Hosting Service`, `Machine Learning service`, `Machine Learning Model Management` |
+| `region`      | Use `eastus2` for Llama-4 tokens and Model Management | `eastus2`, `swedencentral`                                  |
 | `skuName`     | VM size for endpoints; tier for surcharges/mgmt     | `NC4asT4 v3`, `NCadsA100v4`, `Standard`, `PB`, `S1`         |
 | `meterName`   | Matches skuName + "Capacity Unit" or surcharge type | `NC4asT4 v3 Capacity Unit`, `Standard GPU Surcharge`, `Llama-4-Scout-17B-16E-In Tokens` |
 
 ## Meter Names
 
-| Meter                        | skuName                   | unitOfMeasure | Notes                           |
-| ---------------------------- | ------------------------- | ------------- | ------------------------------- |
-| `NC4asT4 v3 Capacity Unit`   | `NC4asT4 v3`              | `1 Hour`      | Managed endpoint, T4 GPU        |
-| `NCadsA100v4 Capacity Unit`  | `NCadsA100v4`             | `1 Hour`      | Managed endpoint, A100 GPU      |
-| `NCadsH100 v5 Capacity Unit` | `NCadsH100 v5`            | `1 Hour`      | Managed endpoint, H100 GPU      |
-| `NDisrH100v5 Capacity Unit`  | `NDisrH100v5`             | `1 Hour`      | Managed endpoint, H100 multi    |
-| `Standard GPU Surcharge`     | `Standard`                | `1 Hour`      | ML service GPU surcharge        |
-| `PB vCPU Surcharge`          | `PB`                      | `1 Hour`      | ML service vCPU surcharge       |
-| `Evaluation Input Tokens`    | `Evaluation Input Tokens` | `1K`          | Safety evaluation input tokens  |
-| `Evaluation Ouput Tokens`    | `Evaluation Ouput Tokens` | `1K`          | Safety evaluation output tokens |
-| `Llama-4-Scout-17B-16E-In Tokens`  | `Llama-4-Scout-17B-16E-In`  | `1K` | Serverless model input tokens   |
-| `Llama-4-Scout-17B-16E-Out Tokens` | `Llama-4-Scout-17B-16E-Out` | `1K` | Serverless model output tokens  |
-| `Llama-4-Mvrck-17B-128E-FP8-In Tokens`  | `Llama-4-Mvrck-17B-128E-FP8-In`  | `1K` | Serverless model input tokens   |
-| `Llama-4-Mvrck-17B-128E-FP8-Out Tokens` | `Llama-4-Mvrck-17B-128E-FP8-Out` | `1K` | Serverless model output tokens  |
-| `S1 Tier`                    | `S1`                      | `1/Day`       | Model Management daily fee      |
-| `S2 Tier`                    | `S2`                      | `1/Day`       | Model Management daily fee      |
-| `S3 Tier`                    | `S3`                      | `1/Day`       | Model Management daily fee      |
+| Meter | skuName | productName | unitOfMeasure | Notes |
+| ----- | ------- | ----------- | ------------- | ----- |
+| `NC4asT4 v3 Capacity Unit` | `NC4asT4 v3` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, T4 GPU |
+| `NCadsA10v4 Capacity Unit` | `NCadsA10v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A10 GPU |
+| `NCadsA100v4 Capacity Unit` | `NCadsA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 GPU |
+| `NCadsH100 v5 Capacity Unit` | `NCadsH100 v5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, H100 GPU |
+| `NCadisH100v5 Capacity Unit` | `NCadisH100v5` | `Managed Model Hosting Service` | `1 Hour` | Distinct H100 SKU |
+| `NDasrA100v4 Capacity Unit` | `NDasrA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 GPU |
+| `NDamsrA100v4 Capacity Unit` | `NDamsrA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 multi |
+| `NDisrH100v5 Capacity Unit` | `NDisrH100v5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, H100 multi |
+| `NDisrMI300Xv5 Capacity Unit` | `NDisrMI300Xv5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, MI300X |
+| `NDsrH200v5 Capacity Unit` | `NDsrH200v5` | `Managed Model Hosting Service` | `1 Hour` | Regional H200 SKU |
+| `Standard GPU Surcharge` | `Standard` | `Machine Learning service` | `1 Hour` | ML service GPU surcharge |
+| `PB vCPU Surcharge` | `PB` | `Machine Learning service` | `1 Hour` | ML service vCPU surcharge |
+| `Evaluation Input Tokens` | `Evaluation Input Tokens` | `Machine Learning service` | `1K` | Safety evaluation input tokens |
+| `Evaluation Ouput Tokens` | `Evaluation Ouput Tokens` | `Machine Learning service` | `1K` | Safety evaluation output tokens |
+| `Llama-4-Scout-17B-16E-In Tokens` | `Llama-4-Scout-17B-16E-In` | `Managed Model Hosting Service` | `1K` | Serverless model input tokens |
+| `Llama-4-Scout-17B-16E-Out Tokens` | `Llama-4-Scout-17B-16E-Out` | `Managed Model Hosting Service` | `1K` | Serverless model output tokens |
+| `Llama-4-Mvrck-17B-128E-FP8-In Tokens` | `Llama-4-Mvrck-17B-128E-FP8-In` | `Managed Model Hosting Service` | `1K` | Serverless model input tokens |
+| `Llama-4-Mvrck-17B-128E-FP8-Out Tokens` | `Llama-4-Mvrck-17B-128E-FP8-Out` | `Managed Model Hosting Service` | `1K` | Serverless model output tokens |
+| `Free Tier` | `Free` | `Machine Learning Model Management` | `1/Day` | Model Management free tier |
+| `S1 Tier` | `S1` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
+| `S2 Tier` | `S2` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
+| `S3 Tier` | `S3` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
 
-> Note: The spelling `Evaluation Ouput Tokens` matches the Retail Prices API meter name exactly and is intentional; do not change it to `Output` in queries or in this table.
+> **Note**: The spelling `Evaluation Ouput Tokens` matches the Retail Prices API meter name exactly and is intentional; do not change it to `Output` in queries or in this table.
 
-> Additional Managed Model Hosting SKUs (NV-series, ND-series) and serverless token-billed models are available. Query with `ProductName 'Managed Model Hosting Service'` to list all.
+> **Note**: Additional NV-series capacity units are available under `Managed Model Hosting Service`; the rows above cover the common active GPU families and newer H100/H200/MI300X variants.
 
 ## Cost Formula
 
@@ -95,6 +108,7 @@ Training Compute         = billed under Virtual Machines (see compute/virtual-ma
 ## Notes
 
 - Managed online endpoints (`Managed Model Hosting Service`) are the primary billable meters; serverless token-billed models (e.g., Llama-4) also bill under this product with `1K` token UoM
-- Model Management (`Machine Learning Model Management`) provides S1/S2/S3 daily-billed tiers
-- `Machine Learning Hardware Accelerated Models` is a legacy product with non-zero pricing; Enterprise Inferencing (`Azure Machine Learning Enterprise *`) meters are legacy and zero cost
-- Storage for ML workspaces is billed under Azure Storage (Blob/File) separately
+- Llama-4 token meters are currently returned in `eastus2` and `swedencentral`; use API `retailPrice` directly because sub-cent rates can display as zero
+- Model Management (`Machine Learning Model Management`) provides `Free`, `S1`, `S2`, and `S3` daily-billed tiers and is not returned in `eastus`
+- `Machine Learning Hardware Accelerated Models` remains a separate non-zero product; `Azure Machine Learning Enterprise *` training/inferencing meters are legacy and zero cost
+- Training clusters and compute instances are billed under `Virtual Machines`; workspace storage is billed under Azure Storage (Blob/File) separately

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
@@ -56,40 +56,40 @@ Quantity: 100
 
 ## Key Fields
 
-| Parameter     | How to determine                                    | Example values                                              |
-| ------------- | --------------------------------------------------- | ----------------------------------------------------------- |
-| `serviceName` | Always `Azure Machine Learning`                     | `Azure Machine Learning`                                    |
-| `productName` | Component type                                      | `Managed Model Hosting Service`, `Machine Learning service`, `Machine Learning Model Management` |
-| `region`      | Use `eastus2` or `swedencentral` for Llama-4 tokens; `eastus2` for Model Management | `eastus2`, `swedencentral`                                  |
-| `skuName`     | VM size for endpoints; tier for surcharges/mgmt     | `NC4asT4 v3`, `NCadsA100v4`, `Standard`, `PB`, `S1`         |
-| `meterName`   | Matches skuName + "Capacity Unit" or surcharge type | `NC4asT4 v3 Capacity Unit`, `Standard GPU Surcharge`, `Llama-4-Scout-17B-16E-In Tokens` |
+| Parameter     | How to determine                                                                    | Example values                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `serviceName` | Always `Azure Machine Learning`                                                     | `Azure Machine Learning`                                                                         |
+| `productName` | Component type                                                                      | `Managed Model Hosting Service`, `Machine Learning service`, `Machine Learning Model Management` |
+| `region`      | Use `eastus2` or `swedencentral` for Llama-4 tokens; `eastus2` for Model Management | `eastus2`, `swedencentral`                                                                       |
+| `skuName`     | VM size for endpoints; tier for surcharges/mgmt                                     | `NC4asT4 v3`, `NCadsA100v4`, `Standard`, `PB`, `S1`                                              |
+| `meterName`   | Matches skuName + "Capacity Unit" or surcharge type                                 | `NC4asT4 v3 Capacity Unit`, `Standard GPU Surcharge`, `Llama-4-Scout-17B-16E-In Tokens`          |
 
 ## Meter Names
 
-| Meter | skuName | productName | unitOfMeasure | Notes |
-| ----- | ------- | ----------- | ------------- | ----- |
-| `NC4asT4 v3 Capacity Unit` | `NC4asT4 v3` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, T4 GPU |
-| `NCadsA10v4 Capacity Unit` | `NCadsA10v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A10 GPU |
-| `NCadsA100v4 Capacity Unit` | `NCadsA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 GPU |
-| `NCadsH100 v5 Capacity Unit` | `NCadsH100 v5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, H100 GPU |
-| `NCadisH100v5 Capacity Unit` | `NCadisH100v5` | `Managed Model Hosting Service` | `1 Hour` | Distinct H100 SKU |
-| `NDasrA100v4 Capacity Unit` | `NDasrA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 GPU |
-| `NDamsrA100v4 Capacity Unit` | `NDamsrA100v4` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, A100 multi |
-| `NDisrH100v5 Capacity Unit` | `NDisrH100v5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, H100 multi |
-| `NDisrMI300Xv5 Capacity Unit` | `NDisrMI300Xv5` | `Managed Model Hosting Service` | `1 Hour` | Managed endpoint, MI300X |
-| `NDsrH200v5 Capacity Unit` | `NDsrH200v5` | `Managed Model Hosting Service` | `1 Hour` | Regional H200 SKU |
-| `Standard GPU Surcharge` | `Standard` | `Machine Learning service` | `1 Hour` | ML service GPU surcharge |
-| `PB vCPU Surcharge` | `PB` | `Machine Learning service` | `1 Hour` | ML service vCPU surcharge |
-| `Evaluation Input Tokens` | `Evaluation Input Tokens` | `Machine Learning service` | `1K` | Safety evaluation input tokens |
-| `Evaluation Ouput Tokens` | `Evaluation Ouput Tokens` | `Machine Learning service` | `1K` | Safety evaluation output tokens |
-| `Llama-4-Scout-17B-16E-In Tokens` | `Llama-4-Scout-17B-16E-In` | `Managed Model Hosting Service` | `1K` | Serverless model input tokens |
-| `Llama-4-Scout-17B-16E-Out Tokens` | `Llama-4-Scout-17B-16E-Out` | `Managed Model Hosting Service` | `1K` | Serverless model output tokens |
-| `Llama-4-Mvrck-17B-128E-FP8-In Tokens` | `Llama-4-Mvrck-17B-128E-FP8-In` | `Managed Model Hosting Service` | `1K` | Serverless model input tokens |
-| `Llama-4-Mvrck-17B-128E-FP8-Out Tokens` | `Llama-4-Mvrck-17B-128E-FP8-Out` | `Managed Model Hosting Service` | `1K` | Serverless model output tokens |
-| `Free Tier` | `Free` | `Machine Learning Model Management` | `1/Day` | Model Management free tier |
-| `S1 Tier` | `S1` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
-| `S2 Tier` | `S2` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
-| `S3 Tier` | `S3` | `Machine Learning Model Management` | `1/Day` | Model Management daily fee |
+| Meter                                   | skuName                          | productName                         | unitOfMeasure | Notes                           |
+| --------------------------------------- | -------------------------------- | ----------------------------------- | ------------- | ------------------------------- |
+| `NC4asT4 v3 Capacity Unit`              | `NC4asT4 v3`                     | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, T4 GPU        |
+| `NCadsA10v4 Capacity Unit`              | `NCadsA10v4`                     | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, A10 GPU       |
+| `NCadsA100v4 Capacity Unit`             | `NCadsA100v4`                    | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, A100 GPU      |
+| `NCadsH100 v5 Capacity Unit`            | `NCadsH100 v5`                   | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, H100 GPU      |
+| `NCadisH100v5 Capacity Unit`            | `NCadisH100v5`                   | `Managed Model Hosting Service`     | `1 Hour`      | Distinct H100 SKU               |
+| `NDasrA100v4 Capacity Unit`             | `NDasrA100v4`                    | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, A100 GPU      |
+| `NDamsrA100v4 Capacity Unit`            | `NDamsrA100v4`                   | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, A100 multi    |
+| `NDisrH100v5 Capacity Unit`             | `NDisrH100v5`                    | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, H100 multi    |
+| `NDisrMI300Xv5 Capacity Unit`           | `NDisrMI300Xv5`                  | `Managed Model Hosting Service`     | `1 Hour`      | Managed endpoint, MI300X        |
+| `NDsrH200v5 Capacity Unit`              | `NDsrH200v5`                     | `Managed Model Hosting Service`     | `1 Hour`      | Regional H200 SKU               |
+| `Standard GPU Surcharge`                | `Standard`                       | `Machine Learning service`          | `1 Hour`      | ML service GPU surcharge        |
+| `PB vCPU Surcharge`                     | `PB`                             | `Machine Learning service`          | `1 Hour`      | ML service vCPU surcharge       |
+| `Evaluation Input Tokens`               | `Evaluation Input Tokens`        | `Machine Learning service`          | `1K`          | Safety evaluation input tokens  |
+| `Evaluation Ouput Tokens`               | `Evaluation Ouput Tokens`        | `Machine Learning service`          | `1K`          | Safety evaluation output tokens |
+| `Llama-4-Scout-17B-16E-In Tokens`       | `Llama-4-Scout-17B-16E-In`       | `Managed Model Hosting Service`     | `1K`          | Serverless model input tokens   |
+| `Llama-4-Scout-17B-16E-Out Tokens`      | `Llama-4-Scout-17B-16E-Out`      | `Managed Model Hosting Service`     | `1K`          | Serverless model output tokens  |
+| `Llama-4-Mvrck-17B-128E-FP8-In Tokens`  | `Llama-4-Mvrck-17B-128E-FP8-In`  | `Managed Model Hosting Service`     | `1K`          | Serverless model input tokens   |
+| `Llama-4-Mvrck-17B-128E-FP8-Out Tokens` | `Llama-4-Mvrck-17B-128E-FP8-Out` | `Managed Model Hosting Service`     | `1K`          | Serverless model output tokens  |
+| `Free Tier`                             | `Free`                           | `Machine Learning Model Management` | `1/Day`       | Model Management free tier      |
+| `S1 Tier`                               | `S1`                             | `Machine Learning Model Management` | `1/Day`       | Model Management daily fee      |
+| `S2 Tier`                               | `S2`                             | `Machine Learning Model Management` | `1/Day`       | Model Management daily fee      |
+| `S3 Tier`                               | `S3`                             | `Machine Learning Model Management` | `1/Day`       | Model Management daily fee      |
 
 > **Note**: The spelling `Evaluation Ouput Tokens` matches the Retail Prices API meter name exactly and is intentional; do not change it to `Output` in queries or in this table.
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/machine-learning.md
@@ -60,7 +60,7 @@ Quantity: 100
 | ------------- | --------------------------------------------------- | ----------------------------------------------------------- |
 | `serviceName` | Always `Azure Machine Learning`                     | `Azure Machine Learning`                                    |
 | `productName` | Component type                                      | `Managed Model Hosting Service`, `Machine Learning service`, `Machine Learning Model Management` |
-| `region`      | Use `eastus2` for Llama-4 tokens and Model Management | `eastus2`, `swedencentral`                                  |
+| `region`      | Use `eastus2` or `swedencentral` for Llama-4 tokens; `eastus2` for Model Management | `eastus2`, `swedencentral`                                  |
 | `skuName`     | VM size for endpoints; tier for surcharges/mgmt     | `NC4asT4 v3`, `NCadsA100v4`, `Standard`, `PB`, `S1`         |
 | `meterName`   | Matches skuName + "Capacity Unit" or surcharge type | `NC4asT4 v3 Capacity Unit`, `Standard GPU Surcharge`, `Llama-4-Scout-17B-16E-In Tokens` |
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
@@ -12,13 +12,13 @@ billingConsiderations: [Reserved Instances]
 
 > **Trap (serviceName rebrand)**: The API `serviceName` is `Foundry Models`, NOT `Azure OpenAI Service`. Queries using `Azure OpenAI Service` return zero results. Always use `ServiceName 'Foundry Models'`.
 
-> **Trap (inflated totals)**: An unfiltered `ServiceName 'Foundry Models'` query returns hundreds of meters across all AI Foundry models (GPT, DeepSeek, Llama, Grok, Mistral, Phi, Cohere, Kimi, Qwen, BFL Flux, etc.). Always filter by `ProductName` to isolate OpenAI models.
+> **Trap (inflated totals)**: An unfiltered `ServiceName 'Foundry Models'` query returns hundreds of meters across OpenAI, non-OpenAI model families, `Managed Compute`, and `Microsoft Agent Pre-Purchase Plan`. Always filter by `ProductName` to isolate Azure OpenAI pricing.
 
 > **Trap (sub-cent embeddings)**: Embedding prices are sub-cent. The script shows minimal cost; use `Quantity` with a large value to see meaningful costs.
 
-> **Trap (mixed units)**: `unitOfMeasure` varies across products: `1K` or `1M` for tokens, `1/Hour` for PTU, `1 Hour` (with space) for fine-tune hosting, `1 Second` for video, `1/Day` for Assistants File Search storage, `1/Month` for monthly items, `100` for DALL-E images, `1` for Sora. Watch `1/Hour` vs `1 Hour` — they are different UoMs. Always check `unitOfMeasure` per meter.
+> **Trap (mixed units)**: `unitOfMeasure` varies widely: `Azure OpenAI GPT5` now spans both `1M` and `1K`; `Azure OpenAI Reasoning` spans `1K`, `1M`, and `1 Hour`; `Azure OpenAI Media` spans `1`, `1 Second`, `1K`, `1M`, and `1 Hour`; PTU stays `1/Hour`. Watch `1/Hour` vs `1 Hour` — they are different UoMs. Always check `unitOfMeasure` per meter.
 
-> **Trap (PTU reservations)**: Provisioned Throughput reservations use a separate `productName`: `Azure AI Foundry Provisioned Throughput Reservation`. Standard RI query patterns require a `ProductName` filter; unfiltered `PriceType: Reservation` queries under `Foundry Models` return PTU and Agent pre-purchase meters.
+> **Trap (PTU reservations)**: Provisioned Throughput reservations use the separate `productName` `Azure AI Foundry Provisioned Throughput Reservation` with `reservationTerm` values `1 Month` and `1 Year`. Standard RI query patterns require a `ProductName` filter; unfiltered `PriceType: Reservation` queries under `Foundry Models` also return `Microsoft Agent Pre-Purchase Plan` meters.
 
 > **Agent instruction**: Model names change frequently. Always discover current models before querying. Run the discovery query below first, then construct pricing queries using the patterns in this file.
 
@@ -49,6 +49,13 @@ ProductName: Azure OpenAI Embedding
 SkuName: {text embedding 3 model} DZ
 Quantity: 500 # units of unitOfMeasure; 500K tokens when UoM is 1K
 
+### PTU reservations: exact reservation product
+
+ServiceName: Foundry Models
+ProductName: Azure AI Foundry Provisioned Throughput Reservation
+SkuName: Provisioned Managed {Global|Data Zone|Regional}
+PriceType: Reservation
+
 ## Key Fields
 
 | Parameter     | How to determine                              | Example values                                                      |
@@ -63,7 +70,7 @@ Quantity: 500 # units of unitOfMeasure; 500K tokens when UoM is 1K
 | Meter | productName | unitOfMeasure | Notes |
 | ----- | ----------- | ------------- | ----- |
 | `5.4 inp Gl 1M Tokens` | `Azure OpenAI GPT5` | `1M` | Direction: inp/Inp/in=input, opt/Opt/out=output |
-| `5.4 mini cd Inp Gl 1M Tokens` | `Azure OpenAI GPT5` | `1M` | `cd`/`cchd` = cached input (50-90% discount) |
+| `gpt-5-codex-inp-glbl Tokens` | `Azure OpenAI GPT5` | `1K` | GPT5 also has `1K` meters; do not assume all GPT5 is `1M` |
 | `o4-mini 0416 Inp glbl Tokens` | `Azure OpenAI Reasoning` | `1K` | Reasoning; deploy: glbl/Gl, DZone/Dz, regnl |
 | `text-embedding-3-large-regional Tokens` | `Azure OpenAI` | `1K` | Embeddings `1K`; DZ: separate `Azure OpenAI Embedding` |
 | `Provisioned Managed Global Unit` | `Azure OpenAI` | `1/Hour` | PTU hourly; also Regional, Data Zone variants |
@@ -82,9 +89,9 @@ Check `unitOfMeasure` from query results: if `1M`, divide token count by 1,000,0
 
 - **Deployment types**: Global is cheapest, Data Zone and Regional add ~10%. Prefer Global unless data residency requires otherwise
 - **Batch pricing**: ~50% discount for async workloads; meters include `Batch` in skuName
-- **Provisioned throughput (PTU)**: Consumption meters under `Azure OpenAI` (`Provisioned Managed Global/Data Zone/Regional`); reservations under `Azure AI Foundry Provisioned Throughput Reservation` with 1 Month and 1 Year terms
+- **Provisioned throughput (PTU)**: Consumption meters stay under `Azure OpenAI` (`Provisioned Managed Global/Data Zone/Regional`); reservations use `Azure AI Foundry Provisioned Throughput Reservation` with `1 Month` and `1 Year` terms
 - **Reasoning models**: o4-mini, codex-mini, o3-deep-research are under `Azure OpenAI Reasoning` productName. Query separately
 - **Media models**: Audio, TTS, Sora 2 video (per-second), and GPT-Image under `Azure OpenAI Media`. Query separately
-- **Fine-tuning**: Three billing dimensions: training tokens (per 1K), model hosting (per hour, charged even when idle), and inference tokens (per 1K). Current fine-tuning meters under `Azure OpenAI PP FT GPT4s` (GPT-4.1/4o, hosting via `Deployment Hosting Unit` UoM `1 Hour`) and `Azure OpenAI OSS Models` (GPT-OSS-20b/120b)
-- **Third-party models**: `Foundry Models` also hosts non-OpenAI families (`Azure Deepseek Models`, `Azure Fireworks Models`, `Azure Grok Models`, `Azure Mistral Models`, `Azure Phi Models`, `Azure Llama Models`, `MAI Models`, `Cohere Models`, `Azure Kimi`, `Qwen models` (note: lowercase `m`), `Azure BFL Flux Models`). Each has its own `productName`. Query with discovery first
+- **Fine-tuning**: Three billing dimensions: training tokens (per 1K), model hosting (per hour, charged even when idle), and inference tokens (per 1K). Current fine-tuning meters span `Azure OpenAI PP FT GPT4s`, `Azure OpenAI OSS Models`, and `Azure OpenAI Reasoning`
+- **Third-party models**: `Foundry Models` also hosts non-OpenAI families (`Azure Deepseek Models`, `Azure Fireworks Models`, `Azure Grok Models`, `Azure Mistral Models`, `Azure Phi Models`, `Azure Llama Models`, `MAI Models`, `Cohere Models`, `Azure Kimi`, `Qwen models`, `Azure BFL Flux Models`) plus `Managed Compute` and `Microsoft Agent Pre-Purchase Plan`. Query with discovery first
 - **Embeddings**: Data Zone text-embedding-3 models under separate `Azure OpenAI Embedding` product (see dual query patterns above)

--- a/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
@@ -56,6 +56,8 @@ ProductName: Azure AI Foundry Provisioned Throughput Reservation
 SkuName: Provisioned Managed {Global|Data Zone|Regional}
 PriceType: Reservation
 
+> **Trap (reservation term)**: This query returns both `1 Month` and `1 Year` reservationTerm rows and the scripts have no term filter; select the term from the `ReservationTerm` output field. `1 Year` MonthlyCost is correct (prepaid ÷ 12). For `1 Month` the uom is `1/Hour`, so the scripts multiply by 730 and overcount ~730×; read `UnitPrice` as the monthly price instead.
+
 ## Key Fields
 
 | Parameter     | How to determine                              | Example values                                                      |

--- a/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/openai-service.md
@@ -60,24 +60,24 @@ PriceType: Reservation
 
 ## Key Fields
 
-| Parameter     | How to determine                              | Example values                                                      |
-| ------------- | --------------------------------------------- | ------------------------------------------------------------------- |
-| `serviceName` | Always `Foundry Models` (see `apiServiceName`) | `Foundry Models`                                                    |
-| `productName` | Model family, use exact value from discovery | `Azure OpenAI`, `Azure OpenAI GPT5`, `Azure OpenAI Reasoning`, `Azure OpenAI Media`, `Azure OpenAI Embedding`, `Azure OpenAI PP FT GPT4s`, `Azure OpenAI OSS Models`, `Azure OpenAI Free Meter` |
-| `skuName`     | `{model} {direction} {deployment}`             | Deployment: `glbl`/`Gl`/`global`, `DZone`/`Dz`/`Data Zone`, `regnl`/`rgnl` |
-| `meterName`   | skuName + ` 1M Tokens` or ` Tokens`           | Unit varies: `1M` (large models) or `1K` (small/embedding)          |
+| Parameter     | How to determine                               | Example values                                                                                                                                                                                  |
+| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serviceName` | Always `Foundry Models` (see `apiServiceName`) | `Foundry Models`                                                                                                                                                                                |
+| `productName` | Model family, use exact value from discovery   | `Azure OpenAI`, `Azure OpenAI GPT5`, `Azure OpenAI Reasoning`, `Azure OpenAI Media`, `Azure OpenAI Embedding`, `Azure OpenAI PP FT GPT4s`, `Azure OpenAI OSS Models`, `Azure OpenAI Free Meter` |
+| `skuName`     | `{model} {direction} {deployment}`             | Deployment: `glbl`/`Gl`/`global`, `DZone`/`Dz`/`Data Zone`, `regnl`/`rgnl`                                                                                                                      |
+| `meterName`   | skuName + ` 1M Tokens` or ` Tokens`            | Unit varies: `1M` (large models) or `1K` (small/embedding)                                                                                                                                      |
 
 ## Meter Names
 
-| Meter | productName | unitOfMeasure | Notes |
-| ----- | ----------- | ------------- | ----- |
-| `5.4 inp Gl 1M Tokens` | `Azure OpenAI GPT5` | `1M` | Direction: inp/Inp/in=input, opt/Opt/out=output |
-| `gpt-5-codex-inp-glbl Tokens` | `Azure OpenAI GPT5` | `1K` | GPT5 also has `1K` meters; do not assume all GPT5 is `1M` |
-| `o4-mini 0416 Inp glbl Tokens` | `Azure OpenAI Reasoning` | `1K` | Reasoning; deploy: glbl/Gl, DZone/Dz, regnl |
-| `text-embedding-3-large-regional Tokens` | `Azure OpenAI` | `1K` | Embeddings `1K`; DZ: separate `Azure OpenAI Embedding` |
-| `Provisioned Managed Global Unit` | `Azure OpenAI` | `1/Hour` | PTU hourly; also Regional, Data Zone variants |
-| `Image-Dall-E-3 Std LowRes-regnl EP Images` | `Azure OpenAI` | `100` | Per 100 images |
-| `Sora 2 dzone Second` | `Azure OpenAI Media` | `1` | Video generation per-second |
+| Meter                                       | productName              | unitOfMeasure | Notes                                                     |
+| ------------------------------------------- | ------------------------ | ------------- | --------------------------------------------------------- |
+| `5.4 inp Gl 1M Tokens`                      | `Azure OpenAI GPT5`      | `1M`          | Direction: inp/Inp/in=input, opt/Opt/out=output           |
+| `gpt-5-codex-inp-glbl Tokens`               | `Azure OpenAI GPT5`      | `1K`          | GPT5 also has `1K` meters; do not assume all GPT5 is `1M` |
+| `o4-mini 0416 Inp glbl Tokens`              | `Azure OpenAI Reasoning` | `1K`          | Reasoning; deploy: glbl/Gl, DZone/Dz, regnl               |
+| `text-embedding-3-large-regional Tokens`    | `Azure OpenAI`           | `1K`          | Embeddings `1K`; DZ: separate `Azure OpenAI Embedding`    |
+| `Provisioned Managed Global Unit`           | `Azure OpenAI`           | `1/Hour`      | PTU hourly; also Regional, Data Zone variants             |
+| `Image-Dall-E-3 Std LowRes-regnl EP Images` | `Azure OpenAI`           | `100`         | Per 100 images                                            |
+| `Sora 2 dzone Second`                       | `Azure OpenAI Media`     | `1`           | Video generation per-second                               |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/speech.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/speech.md
@@ -69,28 +69,28 @@ Quantity: 100 # audio hours
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| ----- | ------- | ------------- | ----- |
-| `S1 Speech To Text` | `S1` | `1 Hour` | Core STT |
-| `S1 Neural Text To Speech Characters` | `S1` | `1M` | Core Neural TTS |
-| `S1 Speech Translation` | `S1` | `1 Hour` | Realtime translation |
-| `S1 Speech to Text Batch` | `S1` | `1 Hour` | Batch transcription |
-| `S1 Custom Speech to Text Batch` | `S1` | `1 Hour` | Custom batch transcription |
-| `Fast Transcription Speech To Text` | `Fast Transcription` | `1 Hour` | Fast/LLM transcription; also `Custom - Fast Transcription` SKU |
-| `Custom - Fast Transcription Speech To Text` | `Custom - Fast Transcription` | `1 Hour` | Custom model fast transcription (higher rate) |
-| `S1 Speaker Identification Transactions` | `S1` | `1K` | Speaker recognition identification |
-| `S1 Speaker Verification Transactions` | `S1` | `1K` | Speaker recognition verification |
-| `Neural HD Text to Speech Characters` | `Neural HD Text to Speech` | `1M` | HD prebuilt voices |
-| `S1 Custom Neural Realtime Characters` | `S1` | `1M` | Custom neural TTS |
-| `S1 Text To Speech Characters` | `S1` | `1M` | Standard non-neural TTS |
-| `S1 Custom Speech Model Hosting Unit` | `S1` | `1/Hour`, `1/Day` | Custom STT model hosting (dual-unit) |
-| `S1 Custom Voice Font Hosting Unit` | `S1` | `1/Hour`, `1/Day` | Custom voice hosting (dual-unit) |
-| `S1 Custom Neural Voice Model Hosting Unit` | `S1` | `1/Hour` | Custom neural voice hosting (no 1/Day variant) |
-| `TTS Standard Avatar Realtime Speech` | `TTS Standard Avatar Realtime` | `1 Minute` | Avatar; also Custom variant |
-| `Voice Live API Std - Standard Speech Audio Input Tokens` | `Voice Live API Std` | `1K` | Voice Live API; docs may call this tier Basic |
-| `CNV Neural HD Synthesis Characters` | `CNV Neural HD Synthesis` | `1M` | Custom Neural Voice HD synthesis |
-| `Commitment Tier Speech to Text Azure 2K Unit` | `Commitment Tier Speech to Text Azure 2K` | `1/Month` | Monthly flat fee (many variants) |
-| `Commitment Tier Speech to Text Azure 2K Speech To Text CT Overage` | `Commitment Tier Speech to Text Azure 2K` | `1 Hour` | Overage beyond included STT hours |
+| Meter                                                               | skuName                                   | unitOfMeasure     | Notes                                                          |
+| ------------------------------------------------------------------- | ----------------------------------------- | ----------------- | -------------------------------------------------------------- |
+| `S1 Speech To Text`                                                 | `S1`                                      | `1 Hour`          | Core STT                                                       |
+| `S1 Neural Text To Speech Characters`                               | `S1`                                      | `1M`              | Core Neural TTS                                                |
+| `S1 Speech Translation`                                             | `S1`                                      | `1 Hour`          | Realtime translation                                           |
+| `S1 Speech to Text Batch`                                           | `S1`                                      | `1 Hour`          | Batch transcription                                            |
+| `S1 Custom Speech to Text Batch`                                    | `S1`                                      | `1 Hour`          | Custom batch transcription                                     |
+| `Fast Transcription Speech To Text`                                 | `Fast Transcription`                      | `1 Hour`          | Fast/LLM transcription; also `Custom - Fast Transcription` SKU |
+| `Custom - Fast Transcription Speech To Text`                        | `Custom - Fast Transcription`             | `1 Hour`          | Custom model fast transcription (higher rate)                  |
+| `S1 Speaker Identification Transactions`                            | `S1`                                      | `1K`              | Speaker recognition identification                             |
+| `S1 Speaker Verification Transactions`                              | `S1`                                      | `1K`              | Speaker recognition verification                               |
+| `Neural HD Text to Speech Characters`                               | `Neural HD Text to Speech`                | `1M`              | HD prebuilt voices                                             |
+| `S1 Custom Neural Realtime Characters`                              | `S1`                                      | `1M`              | Custom neural TTS                                              |
+| `S1 Text To Speech Characters`                                      | `S1`                                      | `1M`              | Standard non-neural TTS                                        |
+| `S1 Custom Speech Model Hosting Unit`                               | `S1`                                      | `1/Hour`, `1/Day` | Custom STT model hosting (dual-unit)                           |
+| `S1 Custom Voice Font Hosting Unit`                                 | `S1`                                      | `1/Hour`, `1/Day` | Custom voice hosting (dual-unit)                               |
+| `S1 Custom Neural Voice Model Hosting Unit`                         | `S1`                                      | `1/Hour`          | Custom neural voice hosting (no 1/Day variant)                 |
+| `TTS Standard Avatar Realtime Speech`                               | `TTS Standard Avatar Realtime`            | `1 Minute`        | Avatar; also Custom variant                                    |
+| `Voice Live API Std - Standard Speech Audio Input Tokens`           | `Voice Live API Std`                      | `1K`              | Voice Live API; docs may call this tier Basic                  |
+| `CNV Neural HD Synthesis Characters`                                | `CNV Neural HD Synthesis`                 | `1M`              | Custom Neural Voice HD synthesis                               |
+| `Commitment Tier Speech to Text Azure 2K Unit`                      | `Commitment Tier Speech to Text Azure 2K` | `1/Month`         | Monthly flat fee (many variants)                               |
+| `Commitment Tier Speech to Text Azure 2K Speech To Text CT Overage` | `Commitment Tier Speech to Text Azure 2K` | `1 Hour`          | Overage beyond included STT hours                              |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/speech.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/speech.md
@@ -14,7 +14,9 @@ privateEndpoint: true
 
 > **Trap (no Standard SKU)**: Azure Speech has no `Standard` SKU; PAYG tier is `S1`. Querying `SkuName: Standard` returns zero results.
 
-> **Trap (mixed units)**: Meters use 8 different `unitOfMeasure` values (`1 Hour`, `1/Hour`, `1/Day`, `1 Minute`, `1/Month`, `1/Year`, `1K`, `1M`). The script's default `× 730` only works for `1 Hour` meters. Verify `unitOfMeasure` per meter.
+> **Trap (mixed units)**: Cloud `Azure Speech` meters use 7 `unitOfMeasure` values (`1 Hour`, `1/Hour`, `1/Day`, `1 Minute`, `1/Month`, `1K`, `1M`). `1/Year` belongs to `Azure Speech - Disconnected`. The script's default `× 730` only works for `1 Hour` meters.
+
+> **Trap (commitment components)**: Commitment SKUs have separate `Unit` and `CT Overage` meters. Query both exact meters and never apply `× 730` to `1/Month` charges.
 
 ## Query Pattern
 
@@ -66,15 +68,19 @@ Quantity: 100 # audio hours
 | `S1 Neural Text To Speech Characters` | `S1` | `1M` | Core Neural TTS |
 | `S1 Speech Translation` | `S1` | `1 Hour` | Realtime translation |
 | `S1 Speech to Text Batch` | `S1` | `1 Hour` | Batch transcription |
+| `S1 Custom Speech to Text Batch` | `S1` | `1 Hour` | Custom batch transcription |
 | `Fast Transcription Speech To Text` | `Fast Transcription` | `1 Hour` | Fast/LLM transcription; also `Custom - Fast Transcription` SKU |
 | `Custom - Fast Transcription Speech To Text` | `Custom - Fast Transcription` | `1 Hour` | Custom model fast transcription (higher rate) |
+| `S1 Speaker Identification Transactions` | `S1` | `1K` | Speaker recognition identification |
+| `S1 Speaker Verification Transactions` | `S1` | `1K` | Speaker recognition verification |
 | `Neural HD Text to Speech Characters` | `Neural HD Text to Speech` | `1M` | HD prebuilt voices |
 | `S1 Custom Neural Realtime Characters` | `S1` | `1M` | Custom neural TTS |
-| `S1 Text To Speech Characters` | `S1` | `1M` | Standard TTS (deprecated) |
+| `S1 Text To Speech Characters` | `S1` | `1M` | Standard non-neural TTS |
 | `S1 Custom Speech Model Hosting Unit` | `S1` | `1/Hour`, `1/Day` | Custom STT model hosting (dual-unit) |
 | `S1 Custom Voice Font Hosting Unit` | `S1` | `1/Hour`, `1/Day` | Custom voice hosting (dual-unit) |
 | `S1 Custom Neural Voice Model Hosting Unit` | `S1` | `1/Hour` | Custom neural voice hosting (no 1/Day variant) |
 | `TTS Standard Avatar Realtime Speech` | `TTS Standard Avatar Realtime` | `1 Minute` | Avatar; also Custom variant |
+| `Voice Live API Std - Standard Speech Audio Input Tokens` | `Voice Live API Std` | `1K` | Voice Live API; docs may call this tier Basic |
 | `CNV Neural HD Synthesis Characters` | `CNV Neural HD Synthesis` | `1M` | Custom Neural Voice HD synthesis |
 | `Commitment Tier Speech to Text Azure 2K Unit` | `Commitment Tier Speech to Text Azure 2K` | `1/Month` | Monthly flat fee (many variants) |
 
@@ -91,10 +97,11 @@ Hosting (1/Day):  Monthly = retailPrice × 30
 
 ## Notes
 
-- **Free tier**: 5 audio hours STT, 0.5M Neural TTS characters, 5 hours Speech Translation per month
-- **Commitment tiers**: STT (2K–100K hrs/mo), Custom STT, STT AddOn, Neural TTS (80M–4000M chars/mo); each has Unit + CT Overage meters
-- **Containers**: Connected tiers at ~95% of Azure pricing (`Commit Tier` or `Commitment Tier…Connected` prefix); Disconnected bills annually (`1/Year`) — exclude from monthly estimates
+- **Free tier**: 5 realtime STT audio hours/month shared across Standard + Custom (batch excluded), 0.5M Neural TTS characters, and 5 hours Speech Translation
+- **Commitment tiers**: STT (2K–100K hrs/mo), Custom STT, STT AddOn, Neural TTS (80M–4000M chars/mo); each has `Unit` + `CT Overage` meters
+- **Containers**: Connected tiers use `Commit Tier` or `Commitment Tier ... Connected`; `Azure Speech - Disconnected` bills annually (`1/Year`) and should stay separate from monthly cloud estimates
 - **Dual-unit hosting**: Custom Speech Model Hosting and Custom Voice Font Hosting have `1/Hour` (×730) and `1/Day` (×30) variants
-- **Voice Live API**: Token-based pricing (`1K` tokens) with sub-cent cached-token meters; 3 tiers (Lite/Std/Pro) + BYO
-- **Additional features**: Video Translation, TTS Avatar, Live Interpreter, Personal Voice, Voice Conversion — each has own SKU; per-minute or per-hour billing
+- **Voice Live API**: Token-based pricing (`1K` tokens) with sub-cent cached-token meters; query exact `Lite`, `Std`, `Pro`, or `BYO` meter names
+- **Capacity planning**: Collect audio hours, character volume, selected feature (STT, TTS, Avatar, Voice Live), and tier before estimating
+- **Additional features**: Live Interpreter, Personal Voice, Voice Conversion, and Avatar each have distinct SKUs and can bill per minute, hour, or token block
 - **Scope**: For other AI Services domains (Language, Vision, Translator), see `ai-services.md`

--- a/skills/azure-cost-calculator/references/services/ai-ml/speech.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/speech.md
@@ -43,6 +43,13 @@ ProductName: Azure Speech
 SkuName: Commitment Tier Speech to Text Azure 2K
 MeterName: Commitment Tier Speech to Text Azure 2K Unit
 
+### Commitment tier: STT Azure 2K (overage)
+
+ServiceName: Foundry Tools
+ProductName: Azure Speech
+SkuName: Commitment Tier Speech to Text Azure 2K
+MeterName: Commitment Tier Speech to Text Azure 2K Speech To Text CT Overage
+
 ### Fast Transcription
 
 ServiceName: Foundry Tools
@@ -83,6 +90,7 @@ Quantity: 100 # audio hours
 | `Voice Live API Std - Standard Speech Audio Input Tokens` | `Voice Live API Std` | `1K` | Voice Live API; docs may call this tier Basic |
 | `CNV Neural HD Synthesis Characters` | `CNV Neural HD Synthesis` | `1M` | Custom Neural Voice HD synthesis |
 | `Commitment Tier Speech to Text Azure 2K Unit` | `Commitment Tier Speech to Text Azure 2K` | `1/Month` | Monthly flat fee (many variants) |
+| `Commitment Tier Speech to Text Azure 2K Speech To Text CT Overage` | `Commitment Tier Speech to Text Azure 2K` | `1 Hour` | Overage beyond included STT hours |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/translator.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/translator.md
@@ -33,7 +33,14 @@ ProductName: Translator Text
 SkuName: S1
 MeterName: S1 Document Characters
 
-### Commitment tier overage: Azure 250M (regional)
+### Commitment tier: Azure 250M (regional base fee)
+
+ServiceName: Foundry Tools
+ProductName: Translator Text
+SkuName: Commitment Tier Azure 250M
+MeterName: Commitment Tier Azure 250M Unit
+
+### Commitment tier: Azure 250M (regional overage)
 
 ServiceName: Foundry Tools
 ProductName: Translator Text
@@ -91,7 +98,7 @@ Region: Global
 Per-character (1M):  Monthly = retailPrice × Quantity
 Daily tiers (1/Day): Monthly = retailPrice × 30
 Hourly app (1 Hour): Monthly = retailPrice × 730
-Monthly commitments (1/Month): Monthly = basePrice + max(0, billableUsage) × overagePrice
+Monthly commitments (1/Month): Monthly = max(0, actualUsage - includedQuantity) × overageRate + commitmentFee
 Annual disconnected (1/Year): Monthly = retailPrice ÷ 12
 Free grant:          BillableChars = max(0, totalChars - 2M)
 ```
@@ -102,4 +109,3 @@ Free grant:          BillableChars = max(0, totalChars - 2M)
 - `Translator Text` covers regional `S1`, `S2`, `S3`, `S4`, `C2`, `C3`, `C4`, and `D3`; Global `Azure Translator` also exposes parallel `S2`, `S3`, `S4`, `C2`, `C3`, `C4`, and `D3` families plus `S1 Standard`, `S1 Image`, App, Emb, and product-specific hosting SKUs.
 - Daily tiers still appear in the API as exact base meters (`S2 Unit`, `S3 Unit`, `S4 Unit`, `C2 Unit`, `C3 Unit`, `C4 Unit`, `D3 Unit`) plus matching character overage meters.
 - Commitment families currently present are Azure 250M/1000M/4000M, Connected 250M/1000M/4000M, App 20K/50K/150K/400K hours, Emb 250M/1000M/4000M/10000M, and Disconnected 4000M/10000M.
-- Supports private endpoints through the Azure AI Services resource; see `ai-services.md` and `networking/private-link.md`.

--- a/skills/azure-cost-calculator/references/services/ai-ml/translator.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/translator.md
@@ -3,18 +3,18 @@ serviceName: Azure Translator
 category: ai-ml
 aliases: [Translator Text, Text Translation, Document Translation]
 apiServiceName: Foundry Tools
-primaryCost: "Per-character translation (per 1M chars); S1 pay-per-use + commitment tier discounts."
+primaryCost: "Per-character translation (1M chars) plus daily, monthly, hourly, or annual tier charges."
 hasFreeGrant: true
 privateEndpoint: true
 ---
 
 # Azure Translator
 
-> **Trap (serviceName rebrand)**: API `serviceName` is `Foundry Tools`, NOT `Azure Translator`. Queries using the display name return zero results.
+> **Trap (serviceName rebrand)**: API `serviceName` is `Foundry Tools`, not `Azure Translator`; the display name returns zero price rows.
 
-> **Trap (multiple products)**: Three `productName` values: `Translator Text` (regional), `Azure Translator` (Global-only), `Azure Translator - Disconnected` (annual). Always filter by `ProductName`.
+> **Trap (product-specific names)**: Always filter `ProductName`. Regional `Translator Text` uses `... Overage Characters` and `... CT Overage Characters`; Global `Azure Translator` uses `... Characters` and tier-specific hosting SKUs.
 
-> **Trap (mixed units + Global naming)**: `unitOfMeasure` varies: `1M`, `1/Day` (S2–S4, C2–C4, D3), `1 Hour` (Doc Translator App), `1/Month`, `1/Year` (disconnected); script auto-multiplies daily by 30. `Azure Translator` (Global) uses different names: `S1 Standard`/`S1 Standard Characters` vs `S1`/`S1 Characters`.
+> **Trap (mixed units + region scope)**: Billing mixes `1M`, `1/Day`, `1/Month`, `1/Year`, `1 Hour`, and `1K`. Use `Region: Global` for `Azure Translator`; divide disconnected annual meters by 12.
 
 ## Query Pattern
 
@@ -33,67 +33,73 @@ ProductName: Translator Text
 SkuName: S1
 MeterName: S1 Document Characters
 
-### Commitment tier (Azure 250M chars/month)
+### Commitment tier overage: Azure 250M (regional)
 
 ServiceName: Foundry Tools
 ProductName: Translator Text
 SkuName: Commitment Tier Azure 250M
-MeterName: Commitment Tier Azure 250M Unit
+MeterName: Commitment Tier Azure 250M CT Overage Characters
 
-### S1 standard text translation (Global product)
+### Document Translation App PAYG (Global)
 
 ServiceName: Foundry Tools
 ProductName: Azure Translator
-SkuName: S1 Standard
-MeterName: S1 Standard Characters
+SkuName: Standard Pay As You Go
+MeterName: Standard Pay As You Go App
 Region: Global
 
 ## Key Fields
 
-| Parameter     | How to determine                  | Example values                                                           |
-| ------------- | --------------------------------- | ------------------------------------------------------------------------ |
-| `serviceName` | Always `Foundry Tools` (API name) | `Foundry Tools`                                                          |
-| `productName` | Deployment model                  | `Translator Text`, `Azure Translator`, `Azure Translator - Disconnected` |
-| `skuName`     | Tier and feature                  | `S1`, `S1 Standard` (Global), `C2`, `Commitment Tier Azure 250M`, `Free`        |
-| `meterName`   | Billing dimension                 | `S1 Characters`, `S1 Standard Characters` (Global), `Custom Model Hosting Unit`  |
+| Parameter | How to determine | Example values |
+| --- | --- | --- |
+| `serviceName` | Always use the API identity | `Foundry Tools` |
+| `productName` | Pick the billing family first | `Translator Text`, `Azure Translator`, `Azure Translator - Disconnected` |
+| `skuName` | Match tier or commitment family | `S1`, `D3`, `Commitment Tier Azure 250M`, `Commitment Tier App 20K hours` |
+| `meterName` | Match the exact billing dimension for that product | `S1 Characters`, `D3 Overage Characters`, `Commitment Tier Azure 250M Characters` |
 
 ## Meter Names
 
-| Meter                              | skuName                      | productName        | unitOfMeasure | Notes                            |
-| ---------------------------------- | ---------------------------- | ------------------ | ------------- | -------------------------------- |
-| `S1 Characters`                    | `S1`                         | `Translator Text`  | `1M`          | Standard text translation        |
-| `S1 Document Characters`           | `S1`                         | `Translator Text`  | `1M`          | Document translation             |
-| `S1 Custom Translation Characters` | `S1`                         | `Translator Text`  | `1M`          | Custom model inference           |
-| `S1 Custom Training Characters`    | `S1`                         | `Translator Text`  | `1M`          | Custom model training            |
-| `Custom Model Hosting Unit`        | `(all)`                      | `Translator Text`  | `1/Month`     | Per model per region (all SKUs)  |
-| `C2 Unit`                          | `C2`                         | `Translator Text`  | `1/Day`       | 250M chars included              |
-| `S2–S4 Unit`                       | `S2`–`S4`                    | `Translator Text`  | `1/Day`       | Retiring daily tiers + overage   |
-| `C3–C4 Unit`                       | `C3`–`C4`                    | `Translator Text`  | `1/Day`       | Container tiers, 1B/10B chars    |
-| `D3 Unit`                          | `D3`                         | `Translator Text`  | `1/Day`       | Disconnected container           |
-| `S1 Standard Characters`           | `S1 Standard`                | `Azure Translator` | `1M`          | Global-only equiv of S1 regional |
-| `S1 Image Images`                  | `S1 Image`                   | `Azure Translator` | `1K`          | Image translation (Global-only)  |
-| `Commitment Tier Azure 250M Unit`  | `Commitment Tier Azure 250M` | `Translator Text`  | `1/Month`     | 250M chars included              |
-| `Standard Pay As You Go App`       | `Standard Pay As You Go`     | `Azure Translator` | `1 Hour`      | Doc Translation App PAYG         |
-| `Commitment Tier App {N} Unit`     | `Commitment Tier App {N}`    | `Azure Translator` | `1/Month`     | App commitment (20K–400K hours)  |
-| `...App Overage`                   | `Commitment Tier App {N}`    | `Azure Translator` | `1 Hour`      | App overage above commitment     |
-| `Commitment Tier Emb {N} Unit`     | `Commitment Tier Emb {N}`    | `Azure Translator` | `1/Month`     | Embeddings commitment (250M–10B) |
-| `...Emb {N} Characters`            | `Commitment Tier Emb {N}`    | `Azure Translator` | `1M`          | Embeddings overage chars         |
+| Meter | skuName | productName | unitOfMeasure | Notes |
+| --- | --- | --- | --- | --- |
+| `S1 Characters` | `S1` | `Translator Text` | `1M` | Standard text translation |
+| `S1 Document Characters` | `S1` | `Translator Text` | `1M` | Document translation |
+| `S1 Custom Translation Characters` | `S1` | `Translator Text` | `1M` | Custom model inference |
+| `S1 Custom Training Characters` | `S1` | `Translator Text` | `1M` | Custom model training |
+| `Custom Model Hosting Unit` | `S1` | `Translator Text` | `1/Month` | Also appears under `Free`, `S2`, `S3`, `S4`, `C2`, `C3`, and `C4` |
+| `S2 Unit` | `S2` | `Translator Text` | `1/Day` | Legacy daily tier base charge |
+| `S2 Overage Characters` | `S2` | `Translator Text` | `1M` | Regional S2 overage |
+| `C2 Unit` | `C2` | `Translator Text` | `1/Day` | Connected container base charge |
+| `C2 Overage Characters` | `C2` | `Translator Text` | `1M` | Connected container overage |
+| `C2 Custom Training Characters` | `C2` | `Translator Text` | `1M` | Connected container training |
+| `D3 Unit` | `D3` | `Translator Text` | `1/Day` | Disconnected daily tier base charge |
+| `D3 Overage Characters` | `D3` | `Translator Text` | `1M` | Disconnected daily tier overage |
+| `S1 Standard Characters` | `S1 Standard` | `Azure Translator` | `1M` | Global S1 standard text |
+| `S1 Image Images` | `S1 Image` | `Azure Translator` | `1K` | Global image translation |
+| `Commitment Tier Azure 250M Unit` | `Commitment Tier Azure 250M` | `Translator Text` | `1/Month` | Regional commitment base charge |
+| `Commitment Tier Azure 250M CT Overage Characters` | `Commitment Tier Azure 250M` | `Translator Text` | `1M` | Regional commitment overage |
+| `Commitment Tier Azure 250M Characters` | `Commitment Tier Azure 250M` | `Azure Translator` | `1M` | Global commitment overage name |
+| `Standard Pay As You Go App` | `Standard Pay As You Go` | `Azure Translator` | `1 Hour` | Document Translation App PAYG |
+| `Commitment Tier App 20K hours Unit` | `Commitment Tier App 20K hours` | `Azure Translator` | `1/Month` | App commitment base charge |
+| `Commitment Tier App 20K hours App Overage` | `Commitment Tier App 20K hours` | `Azure Translator` | `1 Hour` | App commitment overage |
+| `Commitment Tier Emb 250M Unit` | `Commitment Tier Emb 250M` | `Azure Translator` | `1/Month` | Embeddings commitment base charge |
+| `Commitment Tier Emb 250M Characters` | `Commitment Tier Emb 250M` | `Azure Translator` | `1M` | Embeddings commitment overage |
+| `Commitment Tier Disconnected 4000M Unit` | `Commitment Tier Disconnected 4000M` | `Azure Translator - Disconnected` | `1/Year` | Annual disconnected commitment |
 
 ## Cost Formula
 
 ```
 Per-character (1M):  Monthly = retailPrice × Quantity
-Hourly (1 Hour):     Monthly = retailPrice × 730
-Daily tiers (1/Day): Script auto-multiplies by 30
-Monthly (1/Month):   Monthly = retailPrice (use directly)
-Annual (1/Year):     Monthly = retailPrice ÷ 12
-Free grant:          Billable = max(0, chars − 2M free) then price per 1M
+Daily tiers (1/Day): Monthly = retailPrice × 30
+Hourly app (1 Hour): Monthly = retailPrice × 730
+Monthly commitments (1/Month): Monthly = basePrice + max(0, billableUsage) × overagePrice
+Annual disconnected (1/Year): Monthly = retailPrice ÷ 12
+Free grant:          BillableChars = max(0, totalChars - 2M)
 ```
 
 ## Notes
 
-- **Free tier**: 2M characters/month (standard + custom training combined) on Free SKU; custom model hosting still costs per model per region
-- **Retiring tiers**: S2–S4 retiring Oct 2026; use S1 pay-per-use + Commitment Tiers for new deployments
-- **Commitment tiers**: Azure (250M/1000M/4000M) and Connected (250M/1000M/4000M) variants; Connected tiers run in customer containers at slightly lower rates
-- **Containers**: C2–C4 (connected, daily + overage) and D3 (disconnected, daily); `Azure Translator - Disconnected` bills annually (4000M/10000M, ÷12 for monthly)
-- **Scope**: Part of Foundry Tools (AI Services); see `ai-services.md`. Supports private endpoints via AI Services resource (see `networking/private-link.md`)
+- Free SKU includes 2M characters/month, but `Custom Model Hosting Unit` still bills separately.
+- `Translator Text` covers regional `S1`, `S2`, `S3`, `S4`, `C2`, `C3`, `C4`, and `D3`; Global `Azure Translator` also exposes parallel `S2`, `S3`, `S4`, `C2`, `C3`, `C4`, and `D3` families plus `S1 Standard`, `S1 Image`, App, Emb, and product-specific hosting SKUs.
+- Daily tiers still appear in the API as exact base meters (`S2 Unit`, `S3 Unit`, `S4 Unit`, `C2 Unit`, `C3 Unit`, `C4 Unit`, `D3 Unit`) plus matching character overage meters.
+- Commitment families currently present are Azure 250M/1000M/4000M, Connected 250M/1000M/4000M, App 20K/50K/150K/400K hours, Emb 250M/1000M/4000M/10000M, and Disconnected 4000M/10000M.
+- Supports private endpoints through the Azure AI Services resource; see `ai-services.md` and `networking/private-link.md`.

--- a/skills/azure-cost-calculator/references/services/ai-ml/translator.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/translator.md
@@ -57,40 +57,40 @@ Region: Global
 
 ## Key Fields
 
-| Parameter | How to determine | Example values |
-| --- | --- | --- |
-| `serviceName` | Always use the API identity | `Foundry Tools` |
-| `productName` | Pick the billing family first | `Translator Text`, `Azure Translator`, `Azure Translator - Disconnected` |
-| `skuName` | Match tier or commitment family | `S1`, `D3`, `Commitment Tier Azure 250M`, `Commitment Tier App 20K hours` |
-| `meterName` | Match the exact billing dimension for that product | `S1 Characters`, `D3 Overage Characters`, `Commitment Tier Azure 250M Characters` |
+| Parameter     | How to determine                                   | Example values                                                                    |
+| ------------- | -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `serviceName` | Always use the API identity                        | `Foundry Tools`                                                                   |
+| `productName` | Pick the billing family first                      | `Translator Text`, `Azure Translator`, `Azure Translator - Disconnected`          |
+| `skuName`     | Match tier or commitment family                    | `S1`, `D3`, `Commitment Tier Azure 250M`, `Commitment Tier App 20K hours`         |
+| `meterName`   | Match the exact billing dimension for that product | `S1 Characters`, `D3 Overage Characters`, `Commitment Tier Azure 250M Characters` |
 
 ## Meter Names
 
-| Meter | skuName | productName | unitOfMeasure | Notes |
-| --- | --- | --- | --- | --- |
-| `S1 Characters` | `S1` | `Translator Text` | `1M` | Standard text translation |
-| `S1 Document Characters` | `S1` | `Translator Text` | `1M` | Document translation |
-| `S1 Custom Translation Characters` | `S1` | `Translator Text` | `1M` | Custom model inference |
-| `S1 Custom Training Characters` | `S1` | `Translator Text` | `1M` | Custom model training |
-| `Custom Model Hosting Unit` | `S1` | `Translator Text` | `1/Month` | Also appears under `Free`, `S2`, `S3`, `S4`, `C2`, `C3`, and `C4` |
-| `S2 Unit` | `S2` | `Translator Text` | `1/Day` | Legacy daily tier base charge |
-| `S2 Overage Characters` | `S2` | `Translator Text` | `1M` | Regional S2 overage |
-| `C2 Unit` | `C2` | `Translator Text` | `1/Day` | Connected container base charge |
-| `C2 Overage Characters` | `C2` | `Translator Text` | `1M` | Connected container overage |
-| `C2 Custom Training Characters` | `C2` | `Translator Text` | `1M` | Connected container training |
-| `D3 Unit` | `D3` | `Translator Text` | `1/Day` | Disconnected daily tier base charge |
-| `D3 Overage Characters` | `D3` | `Translator Text` | `1M` | Disconnected daily tier overage |
-| `S1 Standard Characters` | `S1 Standard` | `Azure Translator` | `1M` | Global S1 standard text |
-| `S1 Image Images` | `S1 Image` | `Azure Translator` | `1K` | Global image translation |
-| `Commitment Tier Azure 250M Unit` | `Commitment Tier Azure 250M` | `Translator Text` | `1/Month` | Regional commitment base charge |
-| `Commitment Tier Azure 250M CT Overage Characters` | `Commitment Tier Azure 250M` | `Translator Text` | `1M` | Regional commitment overage |
-| `Commitment Tier Azure 250M Characters` | `Commitment Tier Azure 250M` | `Azure Translator` | `1M` | Global commitment overage name |
-| `Standard Pay As You Go App` | `Standard Pay As You Go` | `Azure Translator` | `1 Hour` | Document Translation App PAYG |
-| `Commitment Tier App 20K hours Unit` | `Commitment Tier App 20K hours` | `Azure Translator` | `1/Month` | App commitment base charge |
-| `Commitment Tier App 20K hours App Overage` | `Commitment Tier App 20K hours` | `Azure Translator` | `1 Hour` | App commitment overage |
-| `Commitment Tier Emb 250M Unit` | `Commitment Tier Emb 250M` | `Azure Translator` | `1/Month` | Embeddings commitment base charge |
-| `Commitment Tier Emb 250M Characters` | `Commitment Tier Emb 250M` | `Azure Translator` | `1M` | Embeddings commitment overage |
-| `Commitment Tier Disconnected 4000M Unit` | `Commitment Tier Disconnected 4000M` | `Azure Translator - Disconnected` | `1/Year` | Annual disconnected commitment |
+| Meter                                              | skuName                              | productName                       | unitOfMeasure | Notes                                                             |
+| -------------------------------------------------- | ------------------------------------ | --------------------------------- | ------------- | ----------------------------------------------------------------- |
+| `S1 Characters`                                    | `S1`                                 | `Translator Text`                 | `1M`          | Standard text translation                                         |
+| `S1 Document Characters`                           | `S1`                                 | `Translator Text`                 | `1M`          | Document translation                                              |
+| `S1 Custom Translation Characters`                 | `S1`                                 | `Translator Text`                 | `1M`          | Custom model inference                                            |
+| `S1 Custom Training Characters`                    | `S1`                                 | `Translator Text`                 | `1M`          | Custom model training                                             |
+| `Custom Model Hosting Unit`                        | `S1`                                 | `Translator Text`                 | `1/Month`     | Also appears under `Free`, `S2`, `S3`, `S4`, `C2`, `C3`, and `C4` |
+| `S2 Unit`                                          | `S2`                                 | `Translator Text`                 | `1/Day`       | Legacy daily tier base charge                                     |
+| `S2 Overage Characters`                            | `S2`                                 | `Translator Text`                 | `1M`          | Regional S2 overage                                               |
+| `C2 Unit`                                          | `C2`                                 | `Translator Text`                 | `1/Day`       | Connected container base charge                                   |
+| `C2 Overage Characters`                            | `C2`                                 | `Translator Text`                 | `1M`          | Connected container overage                                       |
+| `C2 Custom Training Characters`                    | `C2`                                 | `Translator Text`                 | `1M`          | Connected container training                                      |
+| `D3 Unit`                                          | `D3`                                 | `Translator Text`                 | `1/Day`       | Disconnected daily tier base charge                               |
+| `D3 Overage Characters`                            | `D3`                                 | `Translator Text`                 | `1M`          | Disconnected daily tier overage                                   |
+| `S1 Standard Characters`                           | `S1 Standard`                        | `Azure Translator`                | `1M`          | Global S1 standard text                                           |
+| `S1 Image Images`                                  | `S1 Image`                           | `Azure Translator`                | `1K`          | Global image translation                                          |
+| `Commitment Tier Azure 250M Unit`                  | `Commitment Tier Azure 250M`         | `Translator Text`                 | `1/Month`     | Regional commitment base charge                                   |
+| `Commitment Tier Azure 250M CT Overage Characters` | `Commitment Tier Azure 250M`         | `Translator Text`                 | `1M`          | Regional commitment overage                                       |
+| `Commitment Tier Azure 250M Characters`            | `Commitment Tier Azure 250M`         | `Azure Translator`                | `1M`          | Global commitment overage name                                    |
+| `Standard Pay As You Go App`                       | `Standard Pay As You Go`             | `Azure Translator`                | `1 Hour`      | Document Translation App PAYG                                     |
+| `Commitment Tier App 20K hours Unit`               | `Commitment Tier App 20K hours`      | `Azure Translator`                | `1/Month`     | App commitment base charge                                        |
+| `Commitment Tier App 20K hours App Overage`        | `Commitment Tier App 20K hours`      | `Azure Translator`                | `1 Hour`      | App commitment overage                                            |
+| `Commitment Tier Emb 250M Unit`                    | `Commitment Tier Emb 250M`           | `Azure Translator`                | `1/Month`     | Embeddings commitment base charge                                 |
+| `Commitment Tier Emb 250M Characters`              | `Commitment Tier Emb 250M`           | `Azure Translator`                | `1M`          | Embeddings commitment overage                                     |
+| `Commitment Tier Disconnected 4000M Unit`          | `Commitment Tier Disconnected 4000M` | `Azure Translator - Disconnected` | `1/Year`      | Annual disconnected commitment                                    |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
@@ -57,27 +57,27 @@ MeterName: Video Modification Input Content Minutes
 
 ## Key Fields
 
-| Parameter     | How to determine                 | Example values                                                     |
-| ------------- | -------------------------------- | ------------------------------------------------------------------ |
-| `serviceName` | Always `Foundry Tools`           | `Foundry Tools`                                                    |
-| `productName` | Always `Azure Video Indexer`     | `Azure Video Indexer`                                              |
+| Parameter     | How to determine                 | Example values                                                      |
+| ------------- | -------------------------------- | ------------------------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools`           | `Foundry Tools`                                                     |
+| `productName` | Always `Azure Video Indexer`     | `Azure Video Indexer`                                               |
 | `skuName`     | Preset tier, matches meter name  | `Basic Audio Indexing Analysis`, `Advanced Video Indexing Analysis` |
 | `meterName`   | Preset + "Input Content Minutes" | `Basic Audio Indexing Analysis Input Content Minutes`               |
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| ----- | ------- | ------------- | ----- |
-| `Basic Audio Indexing Analysis Input Content Minutes` | `Basic Audio Indexing Analysis` | `1` | Transcription, translation, captions |
-| `Standard Audio Indexing Analysis Input Content Minutes` | `Standard Audio Indexing Analysis` | `1` | Basic + speakers, sentiment, NER |
-| `Advanced Audio Indexing Analysis Input Content Minutes` | `Advanced Audio Indexing Analysis` | `1` | All audio AI models |
-| `Basic Video Indexing Analysis Input Content Minutes` | `Basic Video Indexing Analysis` | `1` | Objects, labels, OCR, keyframes |
-| `Standard Video Indexing Analysis Input Content Minutes` | `Standard Video Indexing Analysis` | `1` | Basic + face recognition, celebrities |
-| `Advanced Video Indexing Analysis Input Content Minutes` | `Advanced Video Indexing Analysis` | `1` | All video AI models |
-| `Video Modification Input Content Minutes` | `Video Modification` | `1` | Face redaction + encoding |
-| `Basic Audio Analysis Input Content Minutes` | `Basic Audio Analysis` | `1` | Legacy, use Basic Audio Indexing |
-| `Standard Audio Analysis Input Content Minutes` | `Standard Audio Analysis` | `1` | Legacy, use Advanced Audio Indexing |
-| `Standard Video Analysis Input Content Minutes` | `Standard Video Analysis` | `1` | Legacy, use Advanced Video Indexing |
+| Meter                                                    | skuName                            | unitOfMeasure | Notes                                 |
+| -------------------------------------------------------- | ---------------------------------- | ------------- | ------------------------------------- |
+| `Basic Audio Indexing Analysis Input Content Minutes`    | `Basic Audio Indexing Analysis`    | `1`           | Transcription, translation, captions  |
+| `Standard Audio Indexing Analysis Input Content Minutes` | `Standard Audio Indexing Analysis` | `1`           | Basic + speakers, sentiment, NER      |
+| `Advanced Audio Indexing Analysis Input Content Minutes` | `Advanced Audio Indexing Analysis` | `1`           | All audio AI models                   |
+| `Basic Video Indexing Analysis Input Content Minutes`    | `Basic Video Indexing Analysis`    | `1`           | Objects, labels, OCR, keyframes       |
+| `Standard Video Indexing Analysis Input Content Minutes` | `Standard Video Indexing Analysis` | `1`           | Basic + face recognition, celebrities |
+| `Advanced Video Indexing Analysis Input Content Minutes` | `Advanced Video Indexing Analysis` | `1`           | All video AI models                   |
+| `Video Modification Input Content Minutes`               | `Video Modification`               | `1`           | Face redaction + encoding             |
+| `Basic Audio Analysis Input Content Minutes`             | `Basic Audio Analysis`             | `1`           | Legacy, use Basic Audio Indexing      |
+| `Standard Audio Analysis Input Content Minutes`          | `Standard Audio Analysis`          | `1`           | Legacy, use Advanced Audio Indexing   |
+| `Standard Video Analysis Input Content Minutes`          | `Standard Video Analysis`          | `1`           | Legacy, use Advanced Video Indexing   |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/video-indexer.md
@@ -13,7 +13,7 @@ privateEndpoint: true
 
 > **Trap (unitOfMeasure)**: All meters use `unitOfMeasure: "1"`, which the pricing scripts treat as unitless (monthly multiplier `1`, not `730`). Always set `Quantity` to the number of content-minutes processed.
 
-> **Trap (legacy meters)**: The API returns 3 legacy meters (without "Indexing" in the name) alongside 7 current meters. Always filter by `SkuName` or `MeterName` to avoid mixing legacy and current presets.
+> **Trap (legacy meters)**: The API returns 3 legacy meters: `Basic Audio Analysis`, `Standard Audio Analysis`, and `Standard Video Analysis`; alongside 7 current meters. Always filter by `SkuName` or `MeterName` to avoid mixing legacy and current presets.
 
 ## Query Pattern
 
@@ -75,7 +75,7 @@ MeterName: Video Modification Input Content Minutes
 | `Standard Video Indexing Analysis Input Content Minutes` | `Standard Video Indexing Analysis` | `1` | Basic + face recognition, celebrities |
 | `Advanced Video Indexing Analysis Input Content Minutes` | `Advanced Video Indexing Analysis` | `1` | All video AI models |
 | `Video Modification Input Content Minutes` | `Video Modification` | `1` | Face redaction + encoding |
-| `Basic Audio Analysis Input Content Minutes` | `Basic Audio Analysis` | `1` | Legacy, use Basic Audio Indexing  |
+| `Basic Audio Analysis Input Content Minutes` | `Basic Audio Analysis` | `1` | Legacy, use Basic Audio Indexing |
 | `Standard Audio Analysis Input Content Minutes` | `Standard Audio Analysis` | `1` | Legacy, use Advanced Audio Indexing |
 | `Standard Video Analysis Input Content Minutes` | `Standard Video Analysis` | `1` | Legacy, use Advanced Video Indexing |
 
@@ -93,7 +93,9 @@ With modification: Total = audio + video + (modification_retailPrice × modified
 - **No commitment tiers**: Unlike other Foundry Tools sub-services, Video Indexer has no volume commitments or RI
 - **Audio + Video billed separately**: Indexing a video with both audio and video analysis incurs two charges; query each preset and sum
 - **Legacy meters**: 3 legacy presets (Basic Audio Analysis, Standard Audio Analysis, Standard Video Analysis) remain in the API but are absent from the pricing page. Use current "Indexing" equivalents for new estimates
-- **Regional availability**: Basic Video Indexing Analysis is unavailable in 6 regions (brazilsoutheast, jioindiawest, koreasouth, and 3 US Gov regions)
+- **Regional pricing**: Prices vary by region; always query the user's target region instead of assuming East US rates
+- **Regional availability**: Basic Video Indexing Analysis is unavailable in 6 regions (brazilsoutheast, jioindiawest, koreasouth, usgovarizona, usgovtexas, usgovvirginia)
+- **DoD regions**: usdodcentral and usdodeast return no Azure Video Indexer meters for any preset
 - **Arc-enabled**: Same pricing as cloud; only Basic Audio and Basic Video Indexing presets are supported on Arc
 - **Capacity planning**: `Quantity: 1` = 1 minute of content processed; typical media library: estimate total content-minutes across all files
 - **Scope**: Part of Foundry Tools (AI Services). See `ai-services.md` for umbrella patterns and other sub-services

--- a/skills/azure-cost-calculator/references/services/ai-ml/vision.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/vision.md
@@ -86,12 +86,12 @@ MeterName: Commitment Tier Azure 500K Unit
 | `S0 Training` | `S0` | `Azure Custom Vision` | `1 Hour` | Custom Vision training |
 | `S0 Image Storage` | `S0` | `Azure Custom Vision` | `1K` | Custom Vision image storage |
 | `Video Retrieval - Summary Vision` | `Video Retrieval - Summary` | `Azure Vision` | `1 Hour` | Video summarization |
-| `P{1|2|3} Unit` | `P{1|2|3}` | `Azure Vision` | `1/Day` | Vision P1/P3 daily-only; P2 adds overage |
-| `P{4|5|6} Overage Transactions` | `P{4|5|6}` | `Azure Vision` | `1K` | Vision overage-only tiers |
-| `P{1|2|3} Unit` | `P{1|2|3}` | `Azure Vision - Face` | `1/Day` | Face daily fee; storage billed separately |
-| `Overage Transactions` | `P{1|2|3}` | `Azure Vision - Face` | `1K` | Face tiered overage |
-| `Commitment Tier Azure {500K|2000K|8000K|16000K} Unit` | `Commitment Tier Azure {500K|2000K|8000K|16000K}` | `Azure Vision` | `1/Month` | Monthly base fee |
-| `Commitment Tier Azure {500K|2000K|8000K|16000K} CT Overage Transactions` | `Commitment Tier Azure {500K|2000K|8000K|16000K}` | `Azure Vision` | `1K` | Overage beyond included usage |
+| `P{1/2/3} Unit` | `P{1/2/3}` | `Azure Vision` | `1/Day` | Vision P1/P3 daily-only; P2 adds overage |
+| `P{4/5/6} Overage Transactions` | `P{4/5/6}` | `Azure Vision` | `1K` | Vision overage-only tiers |
+| `P{1/2/3} Unit` | `P{1/2/3}` | `Azure Vision - Face` | `1/Day` | Face daily fee; storage billed separately |
+| `Overage Transactions` | `P{1/2/3}` | `Azure Vision - Face` | `1K` | Face tiered overage |
+| `Commitment Tier Azure {500K/2000K/8000K/16000K} Unit` | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision` | `1/Month` | Monthly base fee |
+| `Commitment Tier Azure {500K/2000K/8000K/16000K} CT Overage Transactions` | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision` | `1K` | Overage beyond included usage |
 
 ## Cost Formula
 
@@ -110,7 +110,7 @@ Free grant:                Billable = max(0, totalUsage − includedFreeUsage)
 
 - **Free tiers**: Image Analysis 5K txns/mo, Face 30K txns/mo, Spatial Analysis 1 camera/mo, Azure Custom Vision free transactions/training
 - **Tier breakpoints**: Image Analysis Group 1 and 1-1 use 0/1K/10K/100K; Face Standard uses 0/1K/5K/100K; choose the matching tier row
-- **Commitment tiers**: Azure `500K|2000K|8000K|16000K` and Connected variants use monthly base fee + `CT Overage Transactions`; disconnected tiers bill annually (`1/Year`)
+- **Commitment tiers**: Azure `500K/2000K/8000K/16000K` and Connected variants use monthly base fee + `CT Overage Transactions`; disconnected tiers bill annually (`1/Year`)
 - **P-series**: Vision P1/P3 daily-only (`1/Day`); P2 daily + overage; P4–P6 overage-only. Face P1–P3: daily fee + tiered overage + storage
 - **Scope**: See `ai-services.md` for full Foundry Tools umbrella. Additional active meters include Image Retrieval, Shelf Product Recognition, and Video Retrieval Query
 - **Capacity planning**: `Quantity: 1` = 1,000 transactions when `unitOfMeasure` is `1K`; 1 Spatial Analysis unit = 1 camera-hour

--- a/skills/azure-cost-calculator/references/services/ai-ml/vision.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/vision.md
@@ -57,41 +57,41 @@ MeterName: Commitment Tier Azure 500K Unit
 
 ## Key Fields
 
-| Parameter     | How to determine                    | Example values                                                            |
-| ------------- | ----------------------------------- | ------------------------------------------------------------------------- |
-| `serviceName` | Always `Foundry Tools`              | `Foundry Tools`                                                           |
+| Parameter     | How to determine                    | Example values                                                                              |
+| ------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| `serviceName` | Always `Foundry Tools`              | `Foundry Tools`                                                                             |
 | `productName` | Vision sub-product or legacy family | `Azure Vision`, `Azure Vision - Face`, `Azure Vision - Disconnected`, `Azure Custom Vision` |
-| `skuName`     | Tier or feature, varies by product  | `Image Analysis Group 1`, `Standard`, `P1`, `Commitment Tier Azure 500K` |
-| `meterName`   | Specific operation being billed     | `Image Analysis Group 1 Transactions`, `Standard Transactions`            |
+| `skuName`     | Tier or feature, varies by product  | `Image Analysis Group 1`, `Standard`, `P1`, `Commitment Tier Azure 500K`                    |
+| `meterName`   | Specific operation being billed     | `Image Analysis Group 1 Transactions`, `Standard Transactions`                              |
 
 ## Meter Names
 
-| Meter | skuName | productName | unitOfMeasure | Notes |
-| ----- | ------- | ----------- | ------------- | ----- |
-| `Image Analysis Group 1 Transactions` | `Image Analysis Group 1` | `Azure Vision` | `1K` | Tiered: Tag, Face detect, Thumbnail |
-| `Image Analysis Group 2 Transactions` | `Image Analysis Group 2` | `Azure Vision` | `1K` | Tiered: Describe |
-| `Standard Transactions` | `Standard` | `Azure Vision - Face` | `1K` | Tiered: Face detection/identify |
-| `Face Storage` | `Standard` | `Azure Vision - Face` | `1K` | Per 1K faces stored |
-| `Standard Faces` | `Standard` | `Azure Vision - Face` | `1M` | Face IDs stored for training |
-| `Liveness Transactions` | `Liveness` | `Azure Vision - Face` | `1K` | Face liveness detection |
-| `Liveness and Verification Transactions` | `Liveness and Verification` | `Azure Vision - Face` | `1K` | Liveness + face verification |
-| `Spatial Analysis Video Stream Edge` | `Spatial Analysis` | `Azure Vision` | `1 Hour` | Per camera-hour |
-| `Video Retrieval and Description - Ingestion Vision` | `Video Retrieval and Description - Ingestion` | `Azure Vision` | `1 Hour` | Video ingestion |
-| `Vectorize Image Transactions` | `Vectorize Image` | `Azure Vision` | `1K` | Image embeddings |
-| `Vectorize Text Transactions` | `Vectorize Text` | `Azure Vision` | `1K` | Text embeddings |
-| `Image Analysis Group 1-1 Transactions` | `Image Analysis Group 1-1` | `Azure Vision` | `1K` | Tiered: same tiers as Group 1 |
-| `Custom Image Classification Training` | `Custom Image Classification` | `Azure Vision` | `1 Hour` | Custom model training |
-| `Custom Object Detection Training` | `Custom Object Detection` | `Azure Vision` | `1 Hour` | Custom model training |
-| `S0 Transactions` | `S0` | `Azure Custom Vision` | `1K` | Custom Vision inference |
-| `S0 Training` | `S0` | `Azure Custom Vision` | `1 Hour` | Custom Vision training |
-| `S0 Image Storage` | `S0` | `Azure Custom Vision` | `1K` | Custom Vision image storage |
-| `Video Retrieval - Summary Vision` | `Video Retrieval - Summary` | `Azure Vision` | `1 Hour` | Video summarization |
-| `P{1/2/3} Unit` | `P{1/2/3}` | `Azure Vision` | `1/Day` | Vision P1/P3 daily-only; P2 adds overage |
-| `P{4/5/6} Overage Transactions` | `P{4/5/6}` | `Azure Vision` | `1K` | Vision overage-only tiers |
-| `P{1/2/3} Unit` | `P{1/2/3}` | `Azure Vision - Face` | `1/Day` | Face daily fee; storage billed separately |
-| `Overage Transactions` | `P{1/2/3}` | `Azure Vision - Face` | `1K` | Face tiered overage |
-| `Commitment Tier Azure {500K/2000K/8000K/16000K} Unit` | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision` | `1/Month` | Monthly base fee |
-| `Commitment Tier Azure {500K/2000K/8000K/16000K} CT Overage Transactions` | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision` | `1K` | Overage beyond included usage |
+| Meter                                                                     | skuName                                           | productName           | unitOfMeasure | Notes                                     |
+| ------------------------------------------------------------------------- | ------------------------------------------------- | --------------------- | ------------- | ----------------------------------------- |
+| `Image Analysis Group 1 Transactions`                                     | `Image Analysis Group 1`                          | `Azure Vision`        | `1K`          | Tiered: Tag, Face detect, Thumbnail       |
+| `Image Analysis Group 2 Transactions`                                     | `Image Analysis Group 2`                          | `Azure Vision`        | `1K`          | Tiered: Describe                          |
+| `Standard Transactions`                                                   | `Standard`                                        | `Azure Vision - Face` | `1K`          | Tiered: Face detection/identify           |
+| `Face Storage`                                                            | `Standard`                                        | `Azure Vision - Face` | `1K`          | Per 1K faces stored                       |
+| `Standard Faces`                                                          | `Standard`                                        | `Azure Vision - Face` | `1M`          | Face IDs stored for training              |
+| `Liveness Transactions`                                                   | `Liveness`                                        | `Azure Vision - Face` | `1K`          | Face liveness detection                   |
+| `Liveness and Verification Transactions`                                  | `Liveness and Verification`                       | `Azure Vision - Face` | `1K`          | Liveness + face verification              |
+| `Spatial Analysis Video Stream Edge`                                      | `Spatial Analysis`                                | `Azure Vision`        | `1 Hour`      | Per camera-hour                           |
+| `Video Retrieval and Description - Ingestion Vision`                      | `Video Retrieval and Description - Ingestion`     | `Azure Vision`        | `1 Hour`      | Video ingestion                           |
+| `Vectorize Image Transactions`                                            | `Vectorize Image`                                 | `Azure Vision`        | `1K`          | Image embeddings                          |
+| `Vectorize Text Transactions`                                             | `Vectorize Text`                                  | `Azure Vision`        | `1K`          | Text embeddings                           |
+| `Image Analysis Group 1-1 Transactions`                                   | `Image Analysis Group 1-1`                        | `Azure Vision`        | `1K`          | Tiered: same tiers as Group 1             |
+| `Custom Image Classification Training`                                    | `Custom Image Classification`                     | `Azure Vision`        | `1 Hour`      | Custom model training                     |
+| `Custom Object Detection Training`                                        | `Custom Object Detection`                         | `Azure Vision`        | `1 Hour`      | Custom model training                     |
+| `S0 Transactions`                                                         | `S0`                                              | `Azure Custom Vision` | `1K`          | Custom Vision inference                   |
+| `S0 Training`                                                             | `S0`                                              | `Azure Custom Vision` | `1 Hour`      | Custom Vision training                    |
+| `S0 Image Storage`                                                        | `S0`                                              | `Azure Custom Vision` | `1K`          | Custom Vision image storage               |
+| `Video Retrieval - Summary Vision`                                        | `Video Retrieval - Summary`                       | `Azure Vision`        | `1 Hour`      | Video summarization                       |
+| `P{1/2/3} Unit`                                                           | `P{1/2/3}`                                        | `Azure Vision`        | `1/Day`       | Vision P1/P3 daily-only; P2 adds overage  |
+| `P{4/5/6} Overage Transactions`                                           | `P{4/5/6}`                                        | `Azure Vision`        | `1K`          | Vision overage-only tiers                 |
+| `P{1/2/3} Unit`                                                           | `P{1/2/3}`                                        | `Azure Vision - Face` | `1/Day`       | Face daily fee; storage billed separately |
+| `Overage Transactions`                                                    | `P{1/2/3}`                                        | `Azure Vision - Face` | `1K`          | Face tiered overage                       |
+| `Commitment Tier Azure {500K/2000K/8000K/16000K} Unit`                    | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision`        | `1/Month`     | Monthly base fee                          |
+| `Commitment Tier Azure {500K/2000K/8000K/16000K} CT Overage Transactions` | `Commitment Tier Azure {500K/2000K/8000K/16000K}` | `Azure Vision`        | `1K`          | Overage beyond included usage             |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/ai-ml/vision.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/vision.md
@@ -12,9 +12,9 @@ privateEndpoint: true
 
 > **Trap (serviceName)**: API `serviceName` is `Foundry Tools`, NOT `Azure Vision`. Always filter by `ProductName` to isolate Vision meters from the 300+ Foundry Tools meters.
 
-> **Trap (multiple products)**: Three products: `Azure Vision`, `Azure Vision - Face`, `Azure Vision - Disconnected`. Liveness meters exist under BOTH Vision and Face products—filter by `productName` to avoid double-counting. Disconnected bills annually (`1/Year`).
+> **Trap (multiple products)**: Four products: `Azure Vision`, `Azure Vision - Face`, `Azure Vision - Disconnected`, and `Azure Custom Vision`. Liveness meters exist under BOTH Vision and Face products; disconnected bills annually (`1/Year`).
 
-> **Trap (tiered pricing)**: Image Analysis and Face transaction meters return multiple rows per tier bracket. The script's `totalMonthlyCost` sums all tiers; calculate manually based on volume.
+> **Trap (tiered pricing)**: Image Analysis Group 1/1-1/2 and Face `Standard Transactions` or `Overage Transactions` return multiple rows by `tierMinimumUnits`. The script's `totalMonthlyCost` sums all tiers; calculate manually from the matching bracket.
 
 ## Query Pattern
 
@@ -41,19 +41,26 @@ SkuName: Spatial Analysis
 MeterName: Spatial Analysis Video Stream Edge
 InstanceCount: 3 # 3 cameras
 
-### Video Retrieval: ingestion
+### Custom Vision: S0 inference
+
+ServiceName: Foundry Tools
+ProductName: Azure Custom Vision
+SkuName: S0
+MeterName: S0 Transactions
+
+### Commitment tier: Azure 500K base fee
 
 ServiceName: Foundry Tools
 ProductName: Azure Vision
-SkuName: Video Retrieval and Description - Ingestion
-MeterName: Video Retrieval and Description - Ingestion Vision
+SkuName: Commitment Tier Azure 500K
+MeterName: Commitment Tier Azure 500K Unit
 
 ## Key Fields
 
 | Parameter     | How to determine                    | Example values                                                            |
 | ------------- | ----------------------------------- | ------------------------------------------------------------------------- |
 | `serviceName` | Always `Foundry Tools`              | `Foundry Tools`                                                           |
-| `productName` | Vision sub-product                  | `Azure Vision`, `Azure Vision - Face`, `Azure Vision - Disconnected`      |
+| `productName` | Vision sub-product or legacy family | `Azure Vision`, `Azure Vision - Face`, `Azure Vision - Disconnected`, `Azure Custom Vision` |
 | `skuName`     | Tier or feature, varies by product  | `Image Analysis Group 1`, `Standard`, `P1`, `Commitment Tier Azure 500K` |
 | `meterName`   | Specific operation being billed     | `Image Analysis Group 1 Transactions`, `Standard Transactions`            |
 
@@ -71,30 +78,39 @@ MeterName: Video Retrieval and Description - Ingestion Vision
 | `Spatial Analysis Video Stream Edge` | `Spatial Analysis` | `Azure Vision` | `1 Hour` | Per camera-hour |
 | `Video Retrieval and Description - Ingestion Vision` | `Video Retrieval and Description - Ingestion` | `Azure Vision` | `1 Hour` | Video ingestion |
 | `Vectorize Image Transactions` | `Vectorize Image` | `Azure Vision` | `1K` | Image embeddings |
-| `Vectorize Text Transactions` | `Vectorize Text` | `Azure Vision` | `1K` | Text embeddings; sub-cent |
+| `Vectorize Text Transactions` | `Vectorize Text` | `Azure Vision` | `1K` | Text embeddings |
 | `Image Analysis Group 1-1 Transactions` | `Image Analysis Group 1-1` | `Azure Vision` | `1K` | Tiered: same tiers as Group 1 |
 | `Custom Image Classification Training` | `Custom Image Classification` | `Azure Vision` | `1 Hour` | Custom model training |
 | `Custom Object Detection Training` | `Custom Object Detection` | `Azure Vision` | `1 Hour` | Custom model training |
+| `S0 Transactions` | `S0` | `Azure Custom Vision` | `1K` | Custom Vision inference |
+| `S0 Training` | `S0` | `Azure Custom Vision` | `1 Hour` | Custom Vision training |
+| `S0 Image Storage` | `S0` | `Azure Custom Vision` | `1K` | Custom Vision image storage |
 | `Video Retrieval - Summary Vision` | `Video Retrieval - Summary` | `Azure Vision` | `1 Hour` | Video summarization |
-| `P1 Unit` | `P1` | `Azure Vision` | `1/Day` | P-series daily fee; P1/P3 daily-only, P2 daily + overage |
-| `P4 Overage Transactions` | `P4` | `Azure Vision` | `1K` | P4–P6 overage-only, no daily fee |
-| `Commitment Tier Azure 500K Unit` | `Commitment Tier Azure 500K` | `Azure Vision` | `1/Month` | Monthly commitment; 4 tiers: 500K–16M |
+| `P{1|2|3} Unit` | `P{1|2|3}` | `Azure Vision` | `1/Day` | Vision P1/P3 daily-only; P2 adds overage |
+| `P{4|5|6} Overage Transactions` | `P{4|5|6}` | `Azure Vision` | `1K` | Vision overage-only tiers |
+| `P{1|2|3} Unit` | `P{1|2|3}` | `Azure Vision - Face` | `1/Day` | Face daily fee; storage billed separately |
+| `Overage Transactions` | `P{1|2|3}` | `Azure Vision - Face` | `1K` | Face tiered overage |
+| `Commitment Tier Azure {500K|2000K|8000K|16000K} Unit` | `Commitment Tier Azure {500K|2000K|8000K|16000K}` | `Azure Vision` | `1/Month` | Monthly base fee |
+| `Commitment Tier Azure {500K|2000K|8000K|16000K} CT Overage Transactions` | `Commitment Tier Azure {500K|2000K|8000K|16000K}` | `Azure Vision` | `1K` | Overage beyond included usage |
 
 ## Cost Formula
 
 ```
 Transaction meters (1K):   Monthly = retailPrice × (transactions / 1000)
+Tiered meters:             Apply the retailPrice for the bracket matching `tierMinimumUnits`
 Hourly meters (1 Hour):    Monthly = retailPrice × hoursUsed
 Daily meters (1/Day):      Monthly = retailPrice × 30 (script auto-multiplies)
-Monthly meters (1/Month):  Monthly = retailPrice (commitment tier base fee)
+Monthly meters (1/Month):  Monthly = commitment_retailPrice + (overage_retailPrice × excessQuantity)
 Spatial Analysis:          Monthly = retailPrice × 730 × cameraCount
 Annual meters (1/Year):    Monthly = retailPrice ÷ 12
+Free grant:                Billable = max(0, totalUsage − includedFreeUsage)
 ```
 
 ## Notes
 
-- **Free tiers**: Image Analysis 5K txns/mo, Face 30K txns/mo, Spatial Analysis 1 camera/mo, Custom Training free hours
-- **Commitment tiers**: Azure (500K–16M txns/mo) and Connected container variants offer volume discounts with overage, not RI. Disconnected (`1/Year`): divide by 12
+- **Free tiers**: Image Analysis 5K txns/mo, Face 30K txns/mo, Spatial Analysis 1 camera/mo, Azure Custom Vision free transactions/training
+- **Tier breakpoints**: Image Analysis Group 1 and 1-1 use 0/1K/10K/100K; Face Standard uses 0/1K/5K/100K; choose the matching tier row
+- **Commitment tiers**: Azure `500K|2000K|8000K|16000K` and Connected variants use monthly base fee + `CT Overage Transactions`; disconnected tiers bill annually (`1/Year`)
 - **P-series**: Vision P1/P3 daily-only (`1/Day`); P2 daily + overage; P4–P6 overage-only. Face P1–P3: daily fee + tiered overage + storage
-- **Scope**: See `ai-services.md` for full Foundry Tools umbrella. Additional Vision meters: Image Retrieval, Shelf Product Recognition, Video Retrieval (Query/Summary)
+- **Scope**: See `ai-services.md` for full Foundry Tools umbrella. Additional active meters include Image Retrieval, Shelf Product Recognition, and Video Retrieval Query
 - **Capacity planning**: `Quantity: 1` = 1,000 transactions when `unitOfMeasure` is `1K`; 1 Spatial Analysis unit = 1 camera-hour

--- a/tests/evals/azure-cost-calculator/tasks/ai-ml/machine-learning-studio/s1-plan.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/ai-ml/machine-learning-studio/s1-plan.yaml
@@ -1,0 +1,61 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:ai-ml/machine-learning-studio/s1-plan
+name: Happy Path - Machine Learning Studio classic S1 plan
+description: >
+  Tests monthly cost estimation for Machine Learning Studio (classic) S1 Production Web API.
+  Validates daily plan billing is normalized to a monthly estimate and the agent returns a currency-formatted total.
+tags:
+  - happy-path
+  - single-service
+  - ai-ml
+  - service:machine-learning-studio
+inputs:
+  prompt: "What is the monthly cost for Machine Learning Studio classic S1 Production Web API with 3 endpoints in South Central US and no overage?"
+expected:
+  output_contains:
+    - "Machine Learning Studio"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Machine Learning Studio( \\(classic\\))?|ML Studio"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: endpoint-count-acknowledged
+    config:
+      contains:
+        - "3"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "What is the monthly cost for Machine Learning Studio classic S1 Production Web API with 3 endpoints in South Central US and no overage?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct daily plan billing model for Machine Learning Studio (classic).
+        (3) Accounts for 3 endpoints as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/ai-ml/machine-learning-studio/s1-plan.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/ai-ml/machine-learning-studio/s1-plan.yaml
@@ -33,8 +33,8 @@ graders:
   - type: text
     name: endpoint-count-acknowledged
     config:
-      contains:
-        - "3"
+      regex_match:
+        - "\\b3\\b"
     weight: 0.5
   - type: prompt
     name: complete-estimate-quality


### PR DESCRIPTION
## Summary

Refreshes all 15 ai-ml service reference files against the current Azure Retail Prices API. Each file was independently validated by dual pricing-investigator agents (with tiebreaker where needed), cross-checked against a compliance-reviewer, and committed separately.

## Changes per file

| File | Key changes |
|---|---|
| ai-services.md | Corrected broad-query count; added Voice Live API meter |
| bot-service.md | Added explicit `Region: Global` to query patterns; added US Gov meter note |
| content-safety.md | Added current Conn and disconnected annual commitment meters |
| discovery.md | Updated priced region count 12 → 15; added `centralus`, `francecentral`, `koreacentral` |
| document-intelligence.md | Added commitment overage meter query; corrected Connected tier naming |
| foundry-agents.md | Added memory meter zero-result trap; normalized meter table with exact skuNames |
| genomics.md | Minor prose clarifications; no API changes needed |
| language.md | Added PII Redaction Pages meter; added commitment tier ranges; refreshed meter inventory |
| machine-learning-studio.md | Fixed cost formulas; added region gap notes; **added missing eval task** |
| machine-learning.md | Added Virtual Machines billing dependency; added Llama-4 and Model Management meters |
| openai-service.md | Added Managed Compute and Agent Pre-Purchase traps; added explicit PTU reservation query pattern |
| speech.md | Added batch, speaker recognition, and Voice Live API meters; corrected mixed-unit trap |
| translator.md | Replaced placeholder meter names with exact API values; added App and Embeddings meters |
| video-indexer.md | Added regional pricing caveats; expanded unsupported region list |
| vision.md | Added Azure Custom Vision product; added commitment tier coverage; refreshed meter inventory |

## Eval tasks

All 15 services have eval task coverage. machine-learning-studio had no eval task — one was created at `tests/evals/azure-cost-calculator/tasks/ai-ml/machine-learning-studio/s1-plan.yaml`.

## Validation

Each file passed `Validate-ServiceReference.ps1 -CheckAliasUniqueness -CheckRoutingFileSync` and `waza check` in the sub-agent environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Azure AI/ML pricing guidance across multiple services with clearer product/region filtering, correct meter/tier selection, and more accurate billing-unit handling (monthly vs annual conversions, commitments vs overages, free-grant behavior).
  - Expanded and corrected “Meter Names” and key-lookup guidance (including added mappings and regional availability notes) for services such as Foundry Models, Translator, Speech, Vision, OpenAI, Bot Service, Machine Learning, and others.
- **Tests**
  - Added an evaluation task validating monthly cost estimates for Machine Learning Studio (classic) S1 plans, including assumptions, endpoint counts, currency formatting, and required pricing-script usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->