### PR TITLE
Refresh compute service references against live pricing API

### DIFF
--- a/skills/azure-cost-calculator/references/services/compute/app-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/app-service.md
@@ -45,13 +45,13 @@ SkuName: ASIP
 | Parameter     | How to determine       | Example values                               |
 | ------------- | ---------------------- | -------------------------------------------- |
 | `productName` | Plan tier + OS variant | See Product Names table                      |
-| `skuName`     | Plan tier + size or fee | `B1`, `S1`, `P1 v3`, `P1v4`, `I1`, `I1 v2`, `Stamp`, `ASIP` |
+| `skuName`     | Plan tier + size or fee | `B1`, `S1`, `P1 v3`, `P1v4`, `I1`, `I1 v2`, `I1v4`, `Stamp`, `ASIP` |
 
 ## Meter Names
 
 | Meter | unitOfMeasure | Notes |
 | --- | --- | --- |
-| _Varies by tier_ | `1 Hour` | Most meters append ` App` to the SKU (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), ASIP, IDH v2 |
+| _Varies by tier_ | `1 Hour` | Most meters append ` App` to the SKU (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), Iv4 (`I1v4`), ASIP, IDH v2 |
 
 ## Cost Formula
 
@@ -68,7 +68,7 @@ Isolated v1/v2 = (platformFee_retailPrice × 730) + (instance_retailPrice × 730
 - **Functions on Dedicated plans** (B1/S1/P1v3) bill through App Service; no meters under `Functions`
 - **Logic Apps Standard** creates WS-type plans but bills through `Logic Apps` meters, not App Service
 - Private endpoints require Basic tier or higher
-- RIs are available for Premium v3, Premium v4, and Isolated v2 compute. For Isolated v1, only the `Stamp Fee` reservation is available (3-Year); Isolated v1 compute SKUs (`I1`, `I2`, `I3`) do not return reservation rows. RIs are not available for Basic, Standard, or Premium v2
+- RIs are available for Premium v3, Premium v4, Isolated v2, and Isolated v4 compute. For Isolated v1, only the `Stamp Fee` reservation is available (3-Year); Isolated v1 compute SKUs (`I1`, `I2`, `I3`) do not return reservation rows. RIs are not available for Basic, Standard, or Premium v2
 
 ## Product Names
 
@@ -81,6 +81,7 @@ Isolated v1/v2 = (platformFee_retailPrice × 730) + (instance_retailPrice × 730
 | Premium v4  | `Azure App Service Premium v4 Plan - Linux`  | `Azure App Service Premium v4 Plan`  |
 | Isolated v1 | `Azure App Service Isolated Plan - Linux`    | `Azure App Service Isolated Plan`    |
 | Isolated v2 | `Azure App Service Isolated v2 Plan - Linux` | `Azure App Service Isolated v2 Plan` |
+| Isolated v4 | `Azure App Service Isolated v4 Plan - Linux` | `Azure App Service Isolated v4 Plan` |
 
 ## Common SKUs
 

--- a/skills/azure-cost-calculator/references/services/compute/app-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/app-service.md
@@ -51,7 +51,7 @@ SkuName: ASIP
 
 | Meter | unitOfMeasure | Notes |
 | --- | --- | --- |
-| _Varies by tier_ | `1 Hour` | Most meters append ` App` to the SKU (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), Iv4 (`I1v4`), ASIP, IDH v2 |
+| _Varies by tier_ | `1 Hour` | Most meters append an `App` suffix (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), Iv4 (`I1v4`), ASIP, IDH v2 |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/compute/app-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/app-service.md
@@ -42,16 +42,16 @@ SkuName: ASIP
 
 ## Key Fields
 
-| Parameter     | How to determine       | Example values                               |
-| ------------- | ---------------------- | -------------------------------------------- |
-| `productName` | Plan tier + OS variant | See Product Names table                      |
+| Parameter     | How to determine        | Example values                                                      |
+| ------------- | ----------------------- | ------------------------------------------------------------------- |
+| `productName` | Plan tier + OS variant  | See Product Names table                                             |
 | `skuName`     | Plan tier + size or fee | `B1`, `S1`, `P1 v3`, `P1v4`, `I1`, `I1 v2`, `I1v4`, `Stamp`, `ASIP` |
 
 ## Meter Names
 
-| Meter | unitOfMeasure | Notes |
-| --- | --- | --- |
-| _Varies by tier_ | `1 Hour` | Most meters append an `App` suffix (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), Iv4 (`I1v4`), ASIP, IDH v2 |
+| Meter            | unitOfMeasure | Notes                                                                                                                                            |
+| ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| _Varies by tier_ | `1 Hour`      | Most meters append an `App` suffix (`P1 v3 App`, `I1 v2 App`). Bare-SKU exceptions: Basic Linux (`B1`), Pv4 (`P1v4`), Iv4 (`I1v4`), ASIP, IDH v2 |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/compute/batch.md
+++ b/skills/azure-cost-calculator/references/services/compute/batch.md
@@ -35,8 +35,8 @@ InstanceCount: 4
 
 ## Meter Names
 
-| Meter                      | unitOfMeasure | Notes                                                                                                                                         |
-| -------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Meter                      | unitOfMeasure | Notes                                                                                                                     |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | _(VM size, e.g. `D4s v5`)_ | `1 Hour`      | Meter name mirrors ARM SKU without `Standard_` prefix; Spot adds ` Spot` suffix, Low Priority adds ` Low Priority` suffix |
 
 > Additional costs: OS disk (Managed Disks), data egress (Bandwidth), and any mounted storage (Azure Files, Blob). Query each service separately.

--- a/skills/azure-cost-calculator/references/services/compute/container-apps.md
+++ b/skills/azure-cost-calculator/references/services/compute/container-apps.md
@@ -88,7 +88,7 @@ Dynamic: Monthly = sessions × session_price × 730
 - Free grant (180K vCPU-s + 360K GiB-s + 2M requests) is per subscription, shared across all Container Apps
 - Idle vs Active: vCPU idle ~1/8 of active; memory idle = active; min replicas > 0 = active rate; scale-to-zero = no charges
 - Dynamic Sessions: code interpreter billed per session-hour; custom pools on Dedicated use Dedicated meters only
-- Private endpoints incur `Dedicated Plan Management` fee on any plan type (Consumption+PE: add a separate `SkuName: Dedicated`, `meterName: Dedicated Plan Management` query — it is not returned by the Standard SKU query); Savings Plan data available as `savingsPlan[]` arrays in API (~15–17% off PAYG; 1-Year/3-Year); no Reservation pricing
+- Private endpoints incur `Dedicated Plan Management` fee on any plan type (Consumption+PE: add a separate `SkuName: Dedicated`, `meterName: Dedicated Plan Management` query — it is not returned by the Standard SKU query); no Reservation or Savings Plan pricing (API returns `savingsPlan: null` for all meters)
 
 ## Manual Calculation Example
 10M req/mo, 0.5 vCPU, 1 GiB, 0.8s avg duration:

--- a/skills/azure-cost-calculator/references/services/compute/container-apps.md
+++ b/skills/azure-cost-calculator/references/services/compute/container-apps.md
@@ -40,12 +40,12 @@ SkuName: Dynamic Sessions
 
 ## Key Fields
 
-| Parameter     | How to determine                           | Example values                                       |
-| ------------- | ------------------------------------------ | ---------------------------------------------------- |
-| `serviceName` | Always `Azure Container Apps`              | `Azure Container Apps`                               |
-| `productName` | Always `Azure Container Apps`              | `Azure Container Apps`                               |
+| Parameter     | How to determine                           | Example values                                        |
+| ------------- | ------------------------------------------ | ----------------------------------------------------- |
+| `serviceName` | Always `Azure Container Apps`              | `Azure Container Apps`                                |
+| `productName` | Always `Azure Container Apps`              | `Azure Container Apps`                                |
 | `skuName`     | Plan type; determines billing model        | `Standard`, `Dedicated`, `Hybrid`, `Dynamic Sessions` |
-| `meterName`   | Resource dimension within plan (see below) | `Standard vCPU Active Usage`, `Dedicated vCPU Usage` |
+| `meterName`   | Resource dimension within plan (see below) | `Standard vCPU Active Usage`, `Dedicated vCPU Usage`  |
 
 ## Meter Names
 

--- a/skills/azure-cost-calculator/references/services/compute/functions.md
+++ b/skills/azure-cost-calculator/references/services/compute/functions.md
@@ -46,24 +46,24 @@ ProductName: Flex Consumption
 
 ## Key Fields
 
-| Parameter     | How to determine                          | Example values                                            |
-| ------------- | ----------------------------------------- | --------------------------------------------------------- |
-| `serviceName` | Always `Functions`                        | `Functions`                                               |
-| `productName` | Plan type                                 | `Functions`, `Premium Functions`, `Flex Consumption`      |
-| `skuName`     | Plan tier within product                  | `Standard`, `Premium`, `Always Ready`, `On Demand`        |
-| `meterName`   | Billing dimension (executions / duration) | `Standard Total Executions`, `On Demand Execution Time`   |
+| Parameter     | How to determine                          | Example values                                          |
+| ------------- | ----------------------------------------- | ------------------------------------------------------- |
+| `serviceName` | Always `Functions`                        | `Functions`                                             |
+| `productName` | Plan type                                 | `Functions`, `Premium Functions`, `Flex Consumption`    |
+| `skuName`     | Plan tier within product                  | `Standard`, `Premium`, `Always Ready`, `On Demand`      |
+| `meterName`   | Billing dimension (executions / duration) | `Standard Total Executions`, `On Demand Execution Time` |
 
 ## Meter Names
 
-| Plan              | Meter                                                           | Unit                   | Free Grant |
-| ----------------- | --------------------------------------------------------------- | ---------------------- | ---------- |
-| Consumption       | `Standard Total Executions`                                     | per 10 exec            | 1M exec    |
-| Consumption       | `Standard Execution Time`                                       | per 1 GB-s             | 400K GB-s  |
-| Premium           | `Premium vCPU Duration`                                         | 1 Hour                 | -          |
-| Premium           | `Premium Memory Duration`                                       | 1 GiB Hour             | -          |
+| Plan              | Meter                                                                                     | Unit                   | Free Grant |
+| ----------------- | ----------------------------------------------------------------------------------------- | ---------------------- | ---------- |
+| Consumption       | `Standard Total Executions`                                                               | per 10 exec            | 1M exec    |
+| Consumption       | `Standard Execution Time`                                                                 | per 1 GB-s             | 400K GB-s  |
+| Premium           | `Premium vCPU Duration`                                                                   | 1 Hour                 | -          |
+| Premium           | `Premium Memory Duration`                                                                 | 1 GiB Hour             | -          |
 | Flex Always Ready | `Always Ready Baseline` / `Always Ready Execution Time` / `Always Ready Total Executions` | per GB-s / per 10 exec | -          |
-| Flex On Demand    | `On Demand Execution Time`                                      | per 1 GB-s             | 100K GB-s  |
-| Flex On Demand    | `On Demand Total Executions`                                    | per 10 exec            | 250K exec  |
+| Flex On Demand    | `On Demand Execution Time`                                                                | per 1 GB-s             | 100K GB-s  |
+| Flex On Demand    | `On Demand Total Executions`                                                              | per 10 exec            | 250K exec  |
 
 ## Cost Formula
 
@@ -92,9 +92,9 @@ Dedicated: Monthly = App Service Plan retailPrice × 730 × instanceCount (see a
 
 ## Premium Plan Sizes (Elastic Premium)
 
-| Plan | vCPUs | Memory (GiB) | Notes                                                                          |
-| ---- | ----- | ------------ | ------------------------------------------------------------------------------ |
-| EP1  | 1     | 3.5          | (vCPU_price × 1 × 730) + (memory_price × 3.5 × 730)                           |
-| EP2  | 2     | 7            | (vCPU_price × 2 × 730) + (memory_price × 7 × 730)                             |
-| EP3  | 4     | 14           | (vCPU_price × 4 × 730) + (memory_price × 14 × 730)                            |
+| Plan | vCPUs | Memory (GiB) | Notes                                               |
+| ---- | ----- | ------------ | --------------------------------------------------- |
+| EP1  | 1     | 3.5          | (vCPU_price × 1 × 730) + (memory_price × 3.5 × 730) |
+| EP2  | 2     | 7            | (vCPU_price × 2 × 730) + (memory_price × 7 × 730)   |
+| EP3  | 4     | 14           | (vCPU_price × 4 × 730) + (memory_price × 14 × 730)  |
 > **Agent instruction**: The API returns generic `Premium vCPU Duration` and `Premium Memory Duration` meters with no EP1/EP2/EP3-specific meter. When the user says "Functions Premium EP2", query `Premium Functions` for the per-vCPU and per-GiB hourly rates, then multiply by EP2 specs above.

--- a/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
@@ -19,7 +19,7 @@ privateEndpoint: true
 
 > **Trap (Automatic mixed units)**: Automatic meters all report `1 Hour`, but control plane is per **cluster**-hour while workload meters are per **vCPU**-hour.
 
-> **Trap (Anyscale Global meters)**: Unfiltered queries include ~15 Global-only Anyscale meters (GPU/Compute/Memory). Each has a duplicate row at minimal price with `effectiveEndDate` (time-limited preview pricing). Filter with `-ProductName` or exclude Global region to avoid contamination.
+> **Trap (Anyscale Global meters)**: Unfiltered queries include 15 Global-only Anyscale meters (per-GPU-model, Compute, Memory) under `productName: Azure Kubernetes Service`. Filter with `-ProductName` or exclude the Global region to avoid contamination.
 
 ## Query Pattern
 
@@ -91,6 +91,6 @@ Automatic: Monthly = (controlPlane_retailPrice × 730 × clusterCount) + Σ(work
 - `billingConsiderations: [Reserved Instances, Spot Pricing]` applies to underlying VMs only, not AKS meters
 - Automatic control plane rate is flat across all regions; per-vCPU rates vary ~2.4× by region
 - Standard Load Balancer auto-provisioned for outbound traffic; billed via `billingNeeds`
-- Private endpoints require Standard pricing tier (not available on Free tier)
+- Private clusters (API server private endpoint) are supported on all pricing tiers, including Free; tiers differ only by uptime SLA (Standard) and Long Term Support (Premium)
 - Public IP addresses for outbound/ingress (see `networking/ip-addresses.md`), NAT Gateway, Azure Monitor, and data transfer may also apply as separate services
 - Anyscale (Ray on AKS) meters are Global-only under `productName: Azure Kubernetes Service` with per-resource-hour billing (GPU/Compute/Memory); query with region `Global` and the specific `Anyscale` skuName

--- a/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
@@ -53,26 +53,26 @@ InstanceCount: 3
 
 ## Key Fields
 
-| Parameter     | How to determine                           | Example values                                       |
-| ------------- | ------------------------------------------ | ---------------------------------------------------- |
+| Parameter     | How to determine                          | Example values                                                     |
+| ------------- | ----------------------------------------- | ------------------------------------------------------------------ |
 | `productName` | Differs by SKU, must include to avoid mix | `Azure Kubernetes Service`, `Azure Kubernetes Service - Automatic` |
-| `skuName`     | Cluster SKU type                           | `Standard`, `Automatic`                              |
-| `meterName`   | Tier-prefixed; see Meter Names table       | `Standard Uptime SLA`, `Automatic General Purpose`   |
+| `skuName`     | Cluster SKU type                          | `Standard`, `Automatic`                                            |
+| `meterName`   | Tier-prefixed; see Meter Names table      | `Standard Uptime SLA`, `Automatic General Purpose`                 |
 
 ## Meter Names
 
-| SKU       | Meter                                | unitOfMeasure | Notes                                                    |
-| --------- | ------------------------------------ | ------------- | -------------------------------------------------------- |
-| Standard  | `Standard Uptime SLA`                | `1 Hour`      | Per cluster-hour; management fee with uptime SLA         |
-| Standard  | `Standard Long Term Support`         | `1 Hour`      | Per cluster-hour; Premium tier (replaces Standard fee)   |
-| Automatic | `Automatic Hosted Control Plane`     | `1 Hour`      | Per cluster-hour; flat-rate cluster management           |
-| Automatic | `Automatic General Purpose`          | `1 Hour`      | Per vCPU-hour; standard workloads                        |
-| Automatic | `Automatic Compute Optimized`        | `1 Hour`      | Per vCPU-hour; CPU-intensive workloads                   |
-| Automatic | `Automatic Memory Optimized`         | `1 Hour`      | Per vCPU-hour; memory-intensive workloads                |
-| Automatic | `Automatic Storage Optimized`        | `1 Hour`      | Per vCPU-hour; storage-intensive workloads               |
-| Automatic | `Automatic GPU Accelerated`          | `1 Hour`      | Per vCPU-hour; GPU workloads (highest rate)              |
-| Automatic | `Automatic Confidential Compute`     | `1 Hour`      | Per vCPU-hour; confidential computing                    |
-| Automatic | `Automatic High Performance Compute` | `1 Hour`      | Per vCPU-hour; HPC workloads                             |
+| SKU       | Meter                                | unitOfMeasure | Notes                                                  |
+| --------- | ------------------------------------ | ------------- | ------------------------------------------------------ |
+| Standard  | `Standard Uptime SLA`                | `1 Hour`      | Per cluster-hour; management fee with uptime SLA       |
+| Standard  | `Standard Long Term Support`         | `1 Hour`      | Per cluster-hour; Premium tier (replaces Standard fee) |
+| Automatic | `Automatic Hosted Control Plane`     | `1 Hour`      | Per cluster-hour; flat-rate cluster management         |
+| Automatic | `Automatic General Purpose`          | `1 Hour`      | Per vCPU-hour; standard workloads                      |
+| Automatic | `Automatic Compute Optimized`        | `1 Hour`      | Per vCPU-hour; CPU-intensive workloads                 |
+| Automatic | `Automatic Memory Optimized`         | `1 Hour`      | Per vCPU-hour; memory-intensive workloads              |
+| Automatic | `Automatic Storage Optimized`        | `1 Hour`      | Per vCPU-hour; storage-intensive workloads             |
+| Automatic | `Automatic GPU Accelerated`          | `1 Hour`      | Per vCPU-hour; GPU workloads (highest rate)            |
+| Automatic | `Automatic Confidential Compute`     | `1 Hour`      | Per vCPU-hour; confidential computing                  |
+| Automatic | `Automatic High Performance Compute` | `1 Hour`      | Per vCPU-hour; HPC workloads                           |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
+++ b/skills/azure-cost-calculator/references/services/compute/kubernetes-service.md
@@ -19,7 +19,7 @@ privateEndpoint: true
 
 > **Trap (Automatic mixed units)**: Automatic meters all report `1 Hour`, but control plane is per **cluster**-hour while workload meters are per **vCPU**-hour.
 
-> **Trap (Anyscale Global meters)**: Unfiltered queries include 15 Global-only Anyscale meters (per-GPU-model, Compute, Memory) under `productName: Azure Kubernetes Service`. Filter with `-ProductName` or exclude the Global region to avoid contamination.
+> **Trap (Anyscale Global meters)**: Unfiltered queries include 15 Global-only Anyscale meters (per-GPU-model, Compute, Memory) that share `productName: Azure Kubernetes Service` with `Standard`, so `-ProductName` will not exclude them. Filter to a specific region for standard estimates; query the `Global` region with the target Anyscale `skuName` for Anyscale pricing.
 
 ## Query Pattern
 

--- a/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
+++ b/skills/azure-cost-calculator/references/services/compute/virtual-machines.md
@@ -29,12 +29,12 @@ ProductName: Virtual Machines Dsv5 Series Windows
 
 ## Key Fields
 
-| Parameter     | How to determine                            | Example values                                                                 |
-| ------------- | ------------------------------------------- | ------------------------------------------------------------------------------ |
-| `serviceName` | Always `Virtual Machines`                   | `Virtual Machines`                                                             |
-| `armSkuName`  | VM size from portal/Bicep `vmSize` property | `Standard_D2s_v5`, `Standard_B2ms`, `Standard_E4s_v5`                          |
+| Parameter     | How to determine                            | Example values                                                                                                                  |
+| ------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `serviceName` | Always `Virtual Machines`                   | `Virtual Machines`                                                                                                              |
+| `armSkuName`  | VM size from portal/Bicep `vmSize` property | `Standard_D2s_v5`, `Standard_B2ms`, `Standard_E4s_v5`                                                                           |
 | `productName` | Contains series + OS indicator              | `Virtual Machines Dsv5 Series` (Linux), `Virtual Machines Dsv5 Series Windows`, `Virtual Machines Dsv7-series Linux` (v7 Intel) |
-| `skuName`     | Size + pricing tier suffix                  | `D2s v5`, `D2s v5 Spot`, `D2s v5 Low Priority`                                 |
+| `skuName`     | Size + pricing tier suffix                  | `D2s v5`, `D2s v5 Spot`, `D2s v5 Low Priority`                                                                                  |
 
 ## Meter Names
 

--- a/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
+++ b/skills/azure-cost-calculator/references/services/compute/vmware-solution.md
@@ -66,7 +66,7 @@ Minimum 3 hosts per cluster.
 - Broadcom VCF subscription required separately (not in API)
 - Trial nodes exist for all SKUs at zero cost. Exclude from estimates
 - AV64: broadest availability (43 regions); AV52: most limited (5 regions)
-- RI terms: AV48 and AV64 support 1-Year, 3-Year, and 5-Year; AV36, AV36P, AV52 support 1-Year only
+- RI terms: AV48 supports 1-Year, 3-Year, and 5-Year; AV36P, AV52, AV64 support 1-Year and 3-Year; AV36 has no reservation pricing (Consumption only)
 - Max 16 hosts/cluster, 12 clusters/private cloud (up to 192 hosts)
 - SQL Server on AVS billed separately (skuName `SQL Server EE License for AVS`, Global region)
 - Legacy SKUs (CS28, CS36, VS20, VS36) exist under different productNames

--- a/skills/azure-cost-calculator/references/services/compute/windows-virtual-desktop.md
+++ b/skills/azure-cost-calculator/references/services/compute/windows-virtual-desktop.md
@@ -40,11 +40,11 @@ InstanceCount: 8
 
 ## Key Fields
 
-| Parameter     | How to determine                                        | Example values                                                                              |
-| ------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `serviceName` | Always `Windows Virtual Desktop`                        | `Windows Virtual Desktop`                                                                   |
-| `productName` | Always `Azure Virtual Desktop`                          | `Azure Virtual Desktop`                                                                     |
-| `skuName`     | Access tier: full desktop, app-only, upgrade, or HCI    | `Desktop & App Hosting`, `App Hosting`, `App to Desktop Upgrade`, `AVD for Azure Stack HCI` |
+| Parameter     | How to determine                                       | Example values                                                                              |
+| ------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `serviceName` | Always `Windows Virtual Desktop`                       | `Windows Virtual Desktop`                                                                   |
+| `productName` | Always `Azure Virtual Desktop`                         | `Azure Virtual Desktop`                                                                     |
+| `skuName`     | Access tier: full desktop, app-only, upgrade, or HCI   | `Desktop & App Hosting`, `App Hosting`, `App to Desktop Upgrade`, `AVD for Azure Stack HCI` |
 | `meterName`   | Varies by SKU, multiple meter name variants per region | See Meter Names table                                                                       |
 
 ## Meter Names


### PR DESCRIPTION
## Summary

Targeted refresh of all 8 compute service reference files. Each file was verified against the live Azure Retail Prices API by an independent `pricing-investigator` sub-agent, following the `.github/agents/service-reference.md` consensus pattern scoped to verification (not regeneration). Every substantive change was re-confirmed directly against the raw API / Microsoft Learn before editing. All edits pass `Validate-ServiceReference.ps1`.

Scope: correct stale claims and add newly released **common** tiers; minimize diff. Niche variants (e.g. App Service mem-optimized SKUs, AKS per-GPU-model Anyscale preview meters) deliberately left out.

## Changes (4 files)

| File | Type | Change |
| --- | --- | --- |
| `app-service.md` | docs | Added newly released **Isolated v4** tier: Product Names row, RI note (1/3-Year eligible), meter bare-SKU exception, Key Fields SKU example. |
| `container-apps.md` | fix | Removed false Savings Plan claim. Live API returns `savingsPlan: null` for all 758 items / Dedicated meters; neither Reservation nor Savings Plan pricing exists. |
| `kubernetes-service.md` | fix | (1) Anyscale trap no longer matched live data (16 Global rows, **zero** `effectiveEndDate`, no duplicate rows) — rewrote to the current 15-meter set. (2) Corrected "private endpoints require Standard tier" — Learn confirms Free tier includes all features; tiers differ only by uptime SLA / LTS. |
| `vmware-solution.md` | fix | Corrected per-SKU RI terms: only **AV48** offers 5-Year; AV36P/AV52/AV64 = 1/3-Year; **AV36** has no reservation (Consumption only). Region counts (28/27/16/5/43) re-verified accurate. |

## Verified, no changes needed (4 files)

`batch.md`, `functions.md`, `virtual-machines.md`, `windows-virtual-desktop.md` — all API identities, product/SKU/meter names, billing models, RI availability, and (for VMs) the v7 Intel `-series {OS}` vs AMD `Series` naming split confirmed accurate.

## Validation

- `Validate-ServiceReference.ps1 -CheckAliasUniqueness -CheckRoutingFileSync`: PASS on every changed file.
- No routing/catalog changes (all services already implemented).
- Eval tasks already exist for all 8 services; coverage contract unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure App Service pricing references with Isolated v4 SKUs and clarified Reserved Instance availability.
  * Clarified that Container Apps Private Endpoint charges use a separate Dedicated Plan Management meter and do not offer Reservation or Savings Plan pricing.
  * Added guidance to exclude Global Anyscale meters from AKS pricing queries.
  * Updated AKS documentation to reflect private cluster availability across all pricing tiers.
  * Corrected VMware Solution reservation term availability by SKU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->