### PR TITLE
Refresh containers service references against live pricing API

### DIFF
--- a/skills/azure-cost-calculator/references/services/containers/container-instances.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-instances.md
@@ -41,6 +41,24 @@ MeterName: Standard Windows Software Duration
 ServiceName: Container Instances
 ProductName: Container Instances
 SkuName: Standard Spot
+MeterName: Standard Spot vCPU Duration
+
+ServiceName: Container Instances
+ProductName: Container Instances
+SkuName: Standard Spot
+MeterName: Standard Spot Memory Duration
+
+### Confidential containers (hardware-based TEE isolation)
+
+ServiceName: Container Instances
+ProductName: Container Instances
+SkuName: Confidential containers ACI
+MeterName: Confidential containers ACI vCPU Duration
+
+ServiceName: Container Instances
+ProductName: Container Instances
+SkuName: Confidential containers ACI
+MeterName: Confidential containers ACI Memory Duration
 
 ### GPU containers: substitute {gpu}: K80, P100, V100
 
@@ -70,6 +88,9 @@ SkuName: {gpu}
 ```
 Linux Standard:
   Monthly = (vCPU_price × vCPUs × 730) + (memory_price × GiB × 730)
+
+Spot / Confidential:
+  Same as Linux Standard, using the matching SKU's vCPU and memory meter prices
 
 Windows Standard:
   Monthly = Linux cost + (windows_per_second × vCPUs × 730 × 3600)

--- a/skills/azure-cost-calculator/references/services/containers/container-registry.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-registry.md
@@ -51,8 +51,8 @@ Monthly = registryUnitPrice × 30 + storagePrice × max(0, totalGB - includedGB)
 ACR Tasks (add if used):
   + taskVcpuPrice × max(0, vCPUSeconds - 6000)   # first 6,000 vCPU-sec/month free
 
-Geo-replication (Premium only, per additional replica region):
-  + replicaUnitPrice × 30 + replicaStoragePrice × replicaGB
+Geo-replication (Premium only; replicaGB = storage per replica region):
+  + (replicaUnitPrice × 30 + replicaStoragePrice × replicaGB) × additionalReplicaRegions
 ```
 
 ## Notes

--- a/skills/azure-cost-calculator/references/services/containers/container-registry.md
+++ b/skills/azure-cost-calculator/references/services/containers/container-registry.md
@@ -47,6 +47,12 @@ Quantity: 50 # excess GB beyond included tier quota
 
 ```
 Monthly = registryUnitPrice × 30 + storagePrice × max(0, totalGB - includedGB)
+
+ACR Tasks (add if used):
+  + taskVcpuPrice × max(0, vCPUSeconds - 6000)   # first 6,000 vCPU-sec/month free
+
+Geo-replication (Premium only, per additional replica region):
+  + replicaUnitPrice × 30 + replicaStoragePrice × replicaGB
 ```
 
 ## Notes
@@ -54,7 +60,7 @@ Monthly = registryUnitPrice × 30 + storagePrice × max(0, totalGB - includedGB)
 - Premium tier is required for geo-replication, content trust, and private endpoints
 - ACR Tasks compute: first 6,000 vCPU-seconds/month free, then `retailPrice` per vCPU-second (tiered meter; ignore script's `totalMonthlyCost`)
 - Geo-replication (Premium only): each replica region adds a `Premium Registry Replication Unit` daily charge + `Premium GB Registry Replication Data Stored` per GB
-- Private endpoints require Premium tier
+- Private endpoints require Premium tier; see `networking/private-link.md` for Private Endpoint and DNS zone pricing
 
 ## Included Storage by Tier
 


### PR DESCRIPTION
## Summary

Refreshes the two `services/containers/` reference files against the live Azure Retail Prices API, following the `.github/agents/service-reference.md` orchestration pattern (two independent `pricing-investigator` runs + one `compliance-reviewer` per service, aggregated by consensus).

**Pricing data was already current** for both files: every meter name, SKU, and unit in the existing tables matched the API verbatim across both independent investigations. No data edits were needed. Changes are limited to correctness/completeness gaps surfaced by the compliance review.

## container-instances

- Confirmed all 16 meters / 6 SKUs (Standard, Standard Spot, Confidential containers ACI, K80/P100/V100 GPU) against the API. No RI, no free grant, regional. Private Endpoint correctly omitted (ACI uses VNet injection, not Private Link).
- Split the Spot query into separate vCPU and memory blocks so the pricing script computes each meter correctly (the combined query mishandles the `1 GB Hour` memory meter, as the file's own trap warns).
- Added the missing Confidential containers query pattern (meters were in the table but had no query block).
- Extended the cost formula to cover the Spot and Confidential variants.

## container-registry

- Confirmed all 8 meters (Basic/Standard/Premium Registry Unit `1/Day`, Data Stored, tiered Task vCPU Duration, geo-replication and connected-registry Premium meters) against the API. `hasFreeGrant`/`privateEndpoint` YAML correct.
- Extended the cost formula to include the ACR Tasks and geo-replication components already documented in the Meter Names table and Notes.
- Added the `networking/private-link.md` cross-reference to the private endpoint note, matching peer service references.

## Consensus notes

- The two pricing investigators agreed on all meters/SKUs/units for both services; no tiebreaker was needed.
- Declined three compliance suggestions as over-reach given repo conventions: rewriting ACR's `{Tier}` placeholder query (an accepted convention used by redis-cache, api-management, firewall, front-door, etc.), adding a Key Fields table (optional; tiers already documented), and rewording `primaryCost`.
- Deliberately excluded two edge artifacts from ACR: the Global-only `Standard Registry Unit - Free` free-account anchor meter and the pricing-page "Dedicated agent pool (preview)" rate (absent from the API). Neither affects standard cost estimation.

## Validation

- `pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync` passes for both files.
- Both stay under the 120-line limit (ACI 108, ACR 71).
- Existing eval-task coverage retained (`container-instances/linux-standard-multi-vcpu.yaml`, `container-registry/premium-with-storage.yaml`); both target unchanged scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Azure Container Instances pricing guidance to include Standard Spot and Confidential container meters/SKUs, along with updated spot/confidential cost calculation formulas.
  * Enhanced Azure Container Registry cost guidance with optional ACR Tasks charges and Premium geo-replication costs (replica regions and replicated storage).
  * Updated guidance for private endpoints to point to the relevant Private Link documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->