### PR TITLE
Refresh databases service references against live pricing API

### DIFF
--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db-for-postgresql.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db-for-postgresql.md
@@ -11,9 +11,9 @@ privateEndpoint: true
 
 # Azure Cosmos DB for PostgreSQL
 
-> **Warning**: This service is on a retirement path. Microsoft recommends migrating to Azure Database for PostgreSQL Flexible Server with Elastic Clusters (Citus extension).
+> **Warning**: This service is on a retirement path. Microsoft recommends migrating to the Elastic Clusters feature of Azure Database for PostgreSQL (Citus extension).
 
-> **Trap (shared serviceName)**: The API `serviceName` is `Azure Database for PostgreSQL`, shared with Flexible Server. Always filter by `productName` containing `Cosmos DB for PostgreSQL` to isolate this service's meters.
+> **Trap (shared serviceName)**: The API `serviceName` is `Azure Database for PostgreSQL`, shared with Flexible Server, Single Server, and HorizonDB. Always filter by `productName` containing `Cosmos DB for PostgreSQL` to isolate this service's meters.
 
 ## Query Pattern
 
@@ -46,35 +46,37 @@ Quantity: 512 # storage size in GiB per node
 | ------------- | --------------------------------- | ----------------------------------------------------------- |
 | `serviceName` | Always the shared API name        | `Azure Database for PostgreSQL`                             |
 | `productName` | Node role or storage type         | See Product Names table below                               |
-| `skuName`     | `vCore` for compute, tier for storage | `vCore`, `1 vCore`, `General Purpose`                   |
+| `skuName`     | `vCore` for compute, fixed SKU for Burstable, tier for storage | `vCore`, `1 vCore`, `2m vCore`, `General Purpose` |
 | `meterName`   | `vCore` for compute, named for storage | `vCore`, `General Purpose Data Stored`                 |
 
 ## Meter Names
 
 | Meter                        | skuName           | productName (suffix)     | unitOfMeasure | Notes                        |
 | ---------------------------- | ----------------- | ------------------------ | ------------- | ---------------------------- |
-| `vCore`                      | `vCore`           | `Compute- Coordinator Node` | `1 Hour`   | Per-vCore rate; multiply by count |
-| `vCore`                      | `vCore`           | `Compute- Worker Node`   | `1 Hour`      | Per-vCore rate; multiply by count |
-| `vCore`                      | `1 vCore` – `8m vCore` | `Compute- Burstable` | `1 Hour`  | Fixed SKU; single-node only  |
+| `vCore`                      | `vCore`           | `Compute- Coordinator Node` | `1 Hour`   | Per-vCore rate; `1 vCore` PAYG alias has no RI |
+| `vCore`                      | `vCore`           | `Compute- Worker Node`   | `1 Hour`      | Per-vCore rate; `1 vCore` PAYG alias has no RI |
+| `vCore`                      | `1 vCore` – `8m vCore` | `Compute- Burstable` | `1 Hour`  | Fixed total hourly rate; do not multiply by vCores |
 | `General Purpose Data Stored`| `General Purpose` | `General Purpose Storage`| `1 GiB/Month` | GP SSD storage per node      |
-| `Backup LRS/GRS Data Stored` | `Backup LRS/GRS`  | `Backup Storage`         | `1 GiB/Month` | Currently free               |
+| `Backup LRS/GRS Data Stored` | `Backup LRS/GRS`  | `Backup Storage`         | `1 GiB/Month` | API currently returns zero price |
 
 ## Cost Formula
 
 ```
 Coordinator Compute = coordinator_retailPrice × coordinatorVCores × 730
 Worker Compute      = worker_retailPrice × workerVCores × workerNodeCount × 730
+Burstable Compute   = burstable_retailPrice × 730
 Storage             = storage_retailPrice × storageGiB × nodeCount
-Total               = Coordinator Compute + Worker Compute + Storage
+Multi-node Total    = Coordinator Compute + Worker Compute + Storage
+Burstable Total     = Burstable Compute + Storage
 ```
 
 ## Notes
 
-- Free tier: single-node cluster at no cost (`skuName: Free`). Only deduct when user confirms free-tier usage
+- Free tier: single-node cluster at no cost (`skuName: Free`). Ignore nonzero Free-row anomalies; only deduct when user confirms free-tier usage
 - Burstable: dev/test single-node only (1–2 vCores, plus memory-optimized 2m–8m vCores), does NOT support RI
 - Multi-node: 1 coordinator (query routing) + N workers (sharding/scale-out, min 2). Scale horizontally by adding workers
 - Worker vCores: 4, 8, 16, 32, 64, 96, 104; Coordinator vCores: 4, 8, 16, 32, 64, 96
-- Backup storage is currently free (up to 100% of provisioned storage)
+- Backup storage API meters still return zero price. Microsoft Learn says excess backup above 100% of provisioned storage is chargeable
 - High Availability doubles compute cost. No separate meter; multiply compute by 2
 - Shares `serviceName` with Azure Database for PostgreSQL Flexible Server (see `database-for-postgresql.md`)
 
@@ -86,7 +88,7 @@ SkuName: vCore
 MeterName: vCore
 PriceType: Reservation
 
-> **Trap (RI MonthlyCost)**: The script's `MonthlyCost` is wrong for RI; it multiplies by 730. Calculate: `unitPrice ÷ 12` (1-Year) or `unitPrice ÷ 36` (3-Year). RI is per-vCore; multiply by total vCore count (double if HA enabled).
+> **Trap (RI unitPrice)**: RI `unitPrice` is the total prepaid term price, not hourly despite `unitOfMeasure: 1 Hour`. The script's `MonthlyCost` divides by term months. RI is per-vCore; multiply by total vCore count (double if HA enabled).
 > For Worker node RI, use the same filters but set `ProductName` to `Azure Cosmos DB for PostgreSQL Compute- Worker Node`.
 
 ## Product Names

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
@@ -3,7 +3,7 @@ serviceName: Cosmos DB Garnet Cache
 category: databases
 aliases: [Garnet Cache, Redis-compatible Cache, Cosmos DB Cache, vCore Cache]
 apiServiceName: Azure Cosmos DB
-primaryCost: "vCPU-hours per tier × 730 + Premium SSD disk per GB × 730"
+primaryCost: "Total vCPU-hours × 730 + Premium SSD GB-hours when persistence is enabled"
 ---
 
 # Cosmos DB Garnet Cache
@@ -18,15 +18,15 @@ ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB Garnet Cache
 SkuName: General Purpose v6
 MeterName: General Purpose v6 vCore
-Quantity: 4 # number of vCPUs
+Quantity: 4 # total vCPUs across all nodes
 
-### Disk storage (e.g., 128 GB)
+### Disk storage with persistence (e.g., 128 GB)
 
 ServiceName: Azure Cosmos DB
 ProductName: Azure Cosmos DB Garnet Cache
 SkuName: Premium SSD Managed Disk
 MeterName: Premium SSD Managed Disk
-Quantity: 128 # disk size in GB
+Quantity: 128 # total disk GB across all nodes
 
 ## Key Fields
 
@@ -49,13 +49,13 @@ Quantity: 128 # disk size in GB
 | `Memory Optimized vCore` | `Memory Optimized` | `1 Hour` | High-memory workloads |
 | `Memory Optimized v6 vCore` | `Memory Optimized v6` | `1 Hour` | v6 generation |
 | `Storage Optimized vCore` | `Storage Optimized` | `1 Hour` | Most expensive; no v6 variant |
-| `Premium SSD Managed Disk` | `Premium SSD Managed Disk` | `1/Hour` | Per-GB disk; sub-cent hourly rate |
+| `Premium SSD Managed Disk` | `Premium SSD Managed Disk` | `1/Hour` | Per-GB disk; persistence only |
 
 ## Cost Formula
 
 ```
-Compute  = compute_retailPrice × vCPUCount × 730
-Storage  = disk_retailPrice × diskSizeGB × 730
+Compute  = compute_retailPrice × totalVCPUCount × 730
+Storage  = disk_retailPrice × totalDiskSizeGB × 730 # if persistence is enabled
 Monthly  = Compute + Storage
 ```
 
@@ -63,8 +63,8 @@ Monthly  = Compute + Storage
 
 - Redis-compatible caching layer in Azure Cosmos DB; uses the same `serviceName` as parent Cosmos DB
 - Five vCore tiers: General Purpose - Burstable, General Purpose, Compute Optimized, Memory Optimized, Storage Optimized. Tier is a never-assume parameter
-- Three tiers have v5 (no suffix) and v6 generations; Storage Optimized has v5 only
-- The disk meter (`Premium SSD Managed Disk`) has a sub-cent hourly rate; multiply by GB × 730 for meaningful monthly cost
-- Scale compute by adjusting vCPU count; each tier targets different workload profiles
+- General Purpose, Compute Optimized, and Memory Optimized have v6 variants; Burstable and Storage Optimized do not
+- The disk meter (`Premium SSD Managed Disk`) applies when persistence is enabled; multiply by total GB × 730
+- Scale by total nodes: shards × replication factor. Use total vCPUs and disk GB across all nodes
 - No Reserved Instances, Spot, or DevTest pricing available for this product
 - Parent service reference: see `databases/cosmos-db.md` for base Cosmos DB provisioned throughput and storage pricing

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db-garnet-cache.md
@@ -3,7 +3,7 @@ serviceName: Cosmos DB Garnet Cache
 category: databases
 aliases: [Garnet Cache, Redis-compatible Cache, Cosmos DB Cache, vCore Cache]
 apiServiceName: Azure Cosmos DB
-primaryCost: "Total vCPU-hours × 730 + Premium SSD GB-hours when persistence is enabled"
+primaryCost: "vCPU hourly rate × total vCPU count × 730 + Premium SSD GB-hours when persistence is enabled"
 ---
 
 # Cosmos DB Garnet Cache

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
@@ -59,7 +59,7 @@ SkuName: RUs
 | `AP1 100 RUs`                 | `AP1`   | `Azure Cosmos DB autoscale`         | `1/Hour`      | Autoscale RU unit                      |
 | `Standard Data Stored`        | `Standard` | `Azure Cosmos DB Analytics Storage` | `1 GB/Month` | Analytical store                       |
 | `Backup Data Stored`          | `Standard` | `Azure Cosmos DB Snapshot`       | `1 GB/Month`  | Periodic backup storage                |
-| `Cont 30D Bckp Continuous Backup` | `Backup` | `Azure Cosmos DB - PITR`       | `1 GB`        | Native continuous backup               |
+| `Cont 30D Bckp Continuous Backup` | `Backup` | `Azure Cosmos DB - PITR`       | `1 GB`        | Continuous backup; `1 GB` bills per GB-month |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
+++ b/skills/azure-cost-calculator/references/services/databases/cosmos-db.md
@@ -13,7 +13,7 @@ privateEndpoint: true
 > **Trap**: The storage meter is `'Data Stored'` (not `'1 GB Data Stored'`). You also need `-ProductName 'Azure Cosmos DB'` and `-SkuName 'RUs'` to filter to the transactional storage meter and avoid free-tier/multi-master variants.
 
 > **Trap (PITR vs Backup vault)**: Cosmos DB native PITR (`productName: Azure Cosmos DB - PITR`) is billed under `serviceName: Azure Cosmos DB` (Databases) at ~9× the per-GB rate of Azure Backup vault storage (`serviceName: Backup`, Storage). If users say "Azure Backup for Cosmos DB", clarify whether they mean native continuous backup (PITR) or vault-based backup (see `storage/backup.md`).
-> **Disambiguation heuristic**: "continuous backup tier", "PITR", "point-in-time restore", "30-day backup" → native Cosmos DB PITR. "Azure Backup vault", "Recovery Services Vault", "backup vault storage" → vault-based backup. If genuinely ambiguous, stop and ask.
+> **Agent instruction**: "continuous backup tier", "PITR", "point-in-time restore", "30-day backup" → native Cosmos DB PITR. "Azure Backup vault", "Recovery Services Vault", "backup vault storage" → vault-based backup. If genuinely ambiguous, stop and ask.
 
 ## Query Pattern
 
@@ -41,22 +41,25 @@ SkuName: RUs
 
 ## Key Fields
 
-| Parameter     | How to determine         | Example values                                                               |
-| ------------- | ------------------------ | ---------------------------------------------------------------------------- |
-| `serviceName` | Always `Azure Cosmos DB` | `Azure Cosmos DB`                                                            |
-| `productName` | Pricing model variant    | `Azure Cosmos DB`, `Azure Cosmos DB autoscale`, `Azure Cosmos DB serverless` |
-| `skuName`     | Throughput type          | `RUs`, `mRUs`, `AP1`                                                         |
-| `meterName`   | Resource being metered   | `100 RU/s`, `Data Stored`, `1M RUs`                                          |
+| Parameter     | How to determine         | Example values                                                                 |
+| ------------- | ------------------------ | ------------------------------------------------------------------------------ |
+| `serviceName` | Always `Azure Cosmos DB` | `Azure Cosmos DB`                                                              |
+| `productName` | Pricing model variant    | `Azure Cosmos DB`, `Azure Cosmos DB autoscale`, `Azure Cosmos DB serverless`, `Azure Cosmos DB - PITR` |
+| `skuName`     | Throughput or add-on     | `RUs`, `mRUs`, `AP1`, `Backup`, `Standard`                                     |
+| `meterName`   | Resource being metered   | `100 RU/s`, `Data Stored`, `1M RUs`, `Standard Data Stored`, `Backup Data Stored` |
 
 ## Meter Names
 
-| Meter                   | skuName | productName                  | Notes                                   |
-| ----------------------- | ------- | ---------------------------- | --------------------------------------- |
-| `100 RU/s`              | `RUs`   | `Azure Cosmos DB`            | Use `-Quantity N` where N = RU/s ÷ 100  |
-| `100 Multi-master RU/s` | `mRUs`  | `Azure Cosmos DB`            | For multi-region writes                 |
-| `Data Stored`           | `RUs`   | `Azure Cosmos DB`            | Per GB/month (provisioned + serverless) |
-| `1M RUs`                | `RUs`   | `Azure Cosmos DB serverless` | Per million RU consumed                 |
-| `AP1 100 RUs`           | `AP1`   | `Azure Cosmos DB autoscale`  | 1.5× standard rate, already baked in   |
+| Meter                         | skuName | productName                         | unitOfMeasure | Notes                                  |
+| ----------------------------- | ------- | ----------------------------------- | ------------- | -------------------------------------- |
+| `100 RU/s`                    | `RUs`   | `Azure Cosmos DB`                   | `1/Hour`      | Use `-Quantity N` where N = RU/s ÷ 100 |
+| `100 Multi-master RU/s`       | `mRUs`  | `Azure Cosmos DB`                   | `1/Hour`      | For multi-region writes                |
+| `Data Stored`                 | `RUs`   | `Azure Cosmos DB`                   | `1 GB/Month`  | Transactional storage                  |
+| `1M RUs`                      | `RUs`   | `Azure Cosmos DB serverless`        | `1M`          | Serverless consumed RUs                |
+| `AP1 100 RUs`                 | `AP1`   | `Azure Cosmos DB autoscale`         | `1/Hour`      | Autoscale RU unit                      |
+| `Standard Data Stored`        | `Standard` | `Azure Cosmos DB Analytics Storage` | `1 GB/Month` | Analytical store                       |
+| `Backup Data Stored`          | `Standard` | `Azure Cosmos DB Snapshot`       | `1 GB/Month`  | Periodic backup storage                |
+| `Cont 30D Bckp Continuous Backup` | `Backup` | `Azure Cosmos DB - PITR`       | `1 GB`        | Native continuous backup               |
 
 ## Cost Formula
 
@@ -78,15 +81,15 @@ Total              = Throughput + Storage
 
 - Free tier available (1000 RU/s + 25 GB free, one account per subscription)
 - **Free tier guidance**: Do NOT deduct the free tier (1000 RU/s + 25 GB) from estimates unless the user explicitly confirms they are using a free-tier-eligible account. Production workloads typically do not use the free tier (only one free-tier account per subscription). Always ask the user if uncertain.
-- Serverless pricing: per-RU consumed (different meter: `1M RUs` under productName `Azure Cosmos DB serverless`). Serverless has no separate storage meter; storage is billed via the base `Azure Cosmos DB` product's `Data Stored` meter at the same per-GB/month rate as provisioned.
-- Multi-region: multiply throughput cost by number of regions
+- Serverless pricing: per-RU consumed (different meter: `1M RUs` under productName `Azure Cosmos DB serverless`) plus transactional storage through the base `Azure Cosmos DB` product's `Data Stored` meter.
+- Multi-region: multiply provisioned throughput and transactional storage by number of regions; serverless accounts are single-region.
 - The storage query returns multiple skuName variants (`RUs`, `mRUs`, `RUm`, `Free Tier`); filter to `RUs` for standard provisioned
 - **Multi-region write (multi-master) costs ~2× single-region**: The `100 Multi-master RU/s` meter (skuName `mRUs`) is approximately double the price of the standard `100 RU/s` meter (skuName `RUs`). Always inform users about this multiplier when they request multi-region writes. For cost comparison, query both meters and show the per-region price difference.
-- **Autoscale provisioned throughput**: The API has a **separate product** (`Azure Cosmos DB autoscale`) with its own meter (`AP1 100 RUs`, skuName `AP1`). The autoscale rate is exactly 1.5× the standard provisioned rate and this premium is **already included** in the API price. Do NOT query the standard `100 RU/s` meter and manually multiply by 1.5. Instead, query the autoscale product directly. With autoscale, billing is based on the maximum RU/s set; calculate as `autoscale_price × (maxRUs / 100) × 730`.
+- **Autoscale provisioned throughput**: The API has a separate product (`Azure Cosmos DB autoscale`) with `AP1`-`AP4` 100-RU meters and entry-price meters. Do NOT query the standard `100 RU/s` meter and manually multiply by 1.5. Billing is based on the highest autoscaled RU/s used each hour; if hourly peaks are unknown, use `Tmax` as an upper-bound estimate.
 - **MongoDB vCore**: Cosmos DB for MongoDB vCore uses productName `Azure DocumentDB` with vCore-based billing (coordinator + worker nodes, per-vCore hourly). Do not use RU/s queries for vCore clusters.
-- **Backup costs (Databases, not Storage)**: Native continuous backup (`productName: Azure Cosmos DB - PITR`) and periodic snapshots (`productName: Azure Cosmos DB Snapshot`) are billed per-GB under `serviceName: Azure Cosmos DB` (Databases category). 7-day continuous is free; 30-day and on-demand are charged. Do NOT confuse with Azure Backup vault storage (`serviceName: Backup`) which has a much lower per-GB rate (see `storage/backup.md`).
+- **Backup costs (Databases, not Storage)**: Native continuous backup (`productName: Azure Cosmos DB - PITR`) and periodic backups (`productName: Azure Cosmos DB Snapshot`) are billed per-GB under `serviceName: Azure Cosmos DB`. 7-day continuous is zero-price; 30-day, restore, on-demand, and periodic redundancy meters are charged. Do NOT confuse with Azure Backup vault storage (`serviceName: Backup`).
 - **Add-on products**: Dedicated Gateway, Garnet Cache, Materialized Views, Analytics Storage, Graph API compute, and `Cosmos DB Compute Attached SSD Disk` have separate productNames under the same serviceName; query each individually.
-- **PE sub-resources** (never-assume): `Sql`, `MongoDB`, `Cassandra`, `Gremlin`, `Table`. Conditional: `SqlDedicated` (dedicated gateway), `Analytical` (Synapse Link)
+- **PE sub-resources** (never-assume): `Sql`, `MongoDB`, `Cassandra`, `Gremlin`, `Table`. Conditional: `SqlDedicated` (dedicated gateway), `Analytical` (analytical store managed PE)
 
 ## Reserved Instance Pricing
 

--- a/skills/azure-cost-calculator/references/services/databases/database-for-mariadb.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-mariadb.md
@@ -8,9 +8,11 @@ privateEndpoint: true
 
 # Azure Database for MariaDB
 
-> **Trap**: Unfiltered queries return ~30 meters across Basic, General Purpose, and Memory Optimized tiers plus multiple storage products. Always filter by `ProductName` to target one tier and generation.
+> **Trap**: Queries without a region filter return paginated rows across all regions; a single-region query returns ~30 rows covering all unique meter types. Always filter by `ProductName` to target one tier and generation.
 
-> **Warning**: Azure Database for MariaDB is **retired** (end-of-life September 2025). Do not recommend for new workloads. Use this reference only for legacy existing-resource estimates where Retail API meters are still returned. Direct new or migration estimates to Azure Database for MySQL (`database-for-mysql.md`).
+> **Trap**: `Azure Database for MariaDB Compute Reservation` is a zero-price `Consumption` artifact with empty `armRegionName`; it is not usable reservation pricing. Exclude it with explicit real `ProductName` filters.
+
+> **Warning**: Azure Database for MariaDB was **retired on 19 September 2025**. Do not recommend for new workloads. Use this reference only for legacy existing-resource estimates where Retail API meters are still returned. Direct new or migration estimates to Azure Database for MySQL (`database-for-mysql.md`).
 
 ## Query Pattern
 
@@ -44,14 +46,16 @@ InstanceCount: 8 # vCore count
 | --- | --- | --- |
 | `productName` | Tier + generation (exact match) | See Product Names below |
 | `skuName` | Per-vCore: `'vCore'`; Basic: `'1 vCore'`, `'2 vCore'` | `'vCore'`, `'2 vCore'` |
-| `meterName` | Always `'vCore'` for compute; tier-specific for storage | `'vCore'`, `'General Purpose Data Stored'` |
+| `meterName` | Usually `'vCore'` for compute; Basic 2-vCore uses `'2 vCore'`; tier-specific for storage | `'vCore'`, `'2 vCore'` |
 
 ## Meter Names
 
 | Meter | skuName | unitOfMeasure | Notes |
 | --- | --- | --- | --- |
 | `vCore` | `vCore` | `1 Hour` | Per-vCore rate for GP/MO Gen5; use InstanceCount |
-| `vCore` | `N vCore` | `1 Hour` | Total rate for N vCores (Basic, GP Gen4/Gen5) |
+| `vCore` | `N vCore` | `1 Hour` | Total rate for N vCores in GP Gen4/Gen5 and MO Gen5 |
+| `2 vCore` | `2 vCore` | `1 Hour` | Total rate for Basic Gen4/Gen5 2-vCore SKU only |
+| `Basic Data Stored` | `Basic` | `1 GB/Month` | Basic tier data storage |
 | `General Purpose Data Stored` | `General Purpose` | `1 GB/Month` | GP/MO data storage |
 | `Backup LRS Data Stored` | `Backup LRS` | `1 GB/Month` | Locally-redundant backup storage |
 | `Backup GRS Data Stored` | `Backup GRS` | `1 GB/Month` | Geo-redundant backup storage |
@@ -60,6 +64,7 @@ InstanceCount: 8 # vCore count
 
 ```
 Compute (per-vCore) = compute_retailPrice × 730 × vCoreCount
+Compute (fixed N-vCore SKU) = compute_retailPrice × 730
 Storage = storage_retailPrice × sizeGB
 Backup (excess) = backup_retailPrice × max(0, backupGB - provisionedStorageGB)
 Total = Compute + Storage + Backup (excess)
@@ -67,10 +72,13 @@ Total = Compute + Storage + Backup (excess)
 
 ## Notes
 
-- **Retired**: Service reached end-of-life September 2025; migrate to Azure Database for MySQL (`database-for-mysql.md`)
+- **Retired**: Service reached end-of-life on 19 September 2025; migrate to Azure Database for MySQL (`database-for-mysql.md`)
 - Basic: dev/test, 1–2 vCores only, no Private Endpoint support
 - GP: production workloads, Gen5 up to 64 vCores
 - MO: high-memory workloads, Gen5 up to 32 vCores
+- Reserved Instances: not available; `priceType=Reservation` returns no meters
+- GP/MO Gen5 `skuName='vCore'` is per-vCore for `InstanceCount`; `N vCore` SKUs are fixed total rates
+- Basic tier storage uses `Basic Data Stored`, not the General Purpose storage product
 - Backup: first backup equal to provisioned storage is free; excess charged per-GB/month (LRS or GRS)
 - Read replicas (GP/MO only): billed at full compute + storage rates
 - Private Endpoint supported for GP and MO tiers only (not Basic)
@@ -88,4 +96,6 @@ Total = Compute + Storage + Backup (excess)
 | MO, Gen5 | `Azure Database for MariaDB Single Server Memory Optimized - Compute Gen5` |
 | Basic Storage | `Azure Database for MariaDB Single Server Basic - Storage` |
 | GP/MO Storage | `Azure Database for MariaDB Single Server General Purpose - Storage` |
+| GP Large-Scale Storage | `Azure Database for MariaDB General Purpose - Large-Scale Storage` |
+| Perf Optimized Storage | `Azure Database for MariaDB Perf Optimized - Storage` |
 | Backup | `Azure Database for MariaDB Single Server - Backup Storage` |

--- a/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
@@ -3,20 +3,19 @@ serviceName: Azure Database for MySQL
 category: databases
 aliases: [MySQL, Azure MySQL, MySQL Flexible Server]
 billingConsiderations: [Reserved Instances]
-primaryCost: "vCore hourly rate × 730 + storage per-GB/month"
+primaryCost: "vCore hours × 730 + storage/IOPS/backup usage"
 privateEndpoint: true
 ---
 
 # Azure Database for MySQL Flexible Server
 
-> **Trap**: Unfiltered queries return ~80+ meters including retired Single Server (still in API). Always filter by `ProductName` containing "Flexible Server" unless pricing historical Single Server workloads.
+> **Trap**: Unfiltered queries return Flexible Server, retired Single Server, Extended Support, storage, backup, and add-on meters. Filter by `ProductName` and `MeterName`.
 >
-> **Trap (dual vCore meters)**: Per-vCore series (v5/v6) return two identical meters: `SkuName: 'vCore'` and `SkuName: '1 vCore'`. Use `SkuName: vCore` with `InstanceCount` for vCore count.
+> **Trap (vCore meters)**: Most per-vCore series return `SkuName: 'vCore'` and `SkuName: '1 vCore'`; use `SkuName: vCore` with `InstanceCount`. Business Critical Ev3 uses `SkuName: 1 vCore`.
 
 ## Query Pattern
 
 ### Compute: General Purpose (Ddsv5, 4 vCores)
-
 ServiceName: Azure Database for MySQL
 ProductName: Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute
 SkuName: vCore
@@ -24,59 +23,78 @@ MeterName: vCore
 InstanceCount: 4 # vCore count
 
 ### Storage (100 GB)
-
 ServiceName: Azure Database for MySQL
 ProductName: Azure Database for MySQL Flexible Server Storage
 SkuName: Storage
 MeterName: Storage Data Stored
 Quantity: 100 # storage size in GB
 
-## Key Fields
+### Additional IOPS (100 provisioned IOPS)
+ServiceName: Azure Database for MySQL
+ProductName: Azure Database for MySQL Flexible Server Storage
+SkuName: Additional IOPS
+MeterName: Additional IOPS
+Quantity: 100 # provisioned IOPS
 
-| Parameter     | How to determine                                                       | Example values                   |
-| ------------- | ---------------------------------------------------------------------- | -------------------------------- |
-| `productName` | Tier + series (exact match)                                            | See Product Names below          |
-| `skuName`     | Per-vCore series: `'vCore'`; Burstable: SKU name; Edsv5: `Standard_E*` | `'vCore'`, `'Standard_B4ms'`     |
-| `meterName`   | Per-vCore: `'vCore'`; Burstable: SKU code; Edsv5: `'N vCore'`          | `'vCore'`, `'B4MS'`, `'8 vCore'` |
+### Backup storage (100 GB beyond free grant)
+ServiceName: Azure Database for MySQL
+ProductName: Azure Database for MySQL Flexible Server Backup Storage
+SkuName: Backup Storage LRS
+MeterName: Backup Storage LRS Data Stored
+Quantity: 100 # billable backup GB
+
+## Key Fields
+| Parameter     | How to determine                                                        | Example values                              |
+| ------------- | ----------------------------------------------------------------------- | ------------------------------------------- |
+| `productName` | Tier + series or storage family (exact match)                           | See Product Names below                     |
+| `skuName`     | Per-vCore: `'vCore'`; Business Critical: `'1 vCore'`; fixed tiers: SKU  | `'vCore'`, `'1 vCore'`, `'Standard_B4ms'`   |
+| `meterName`   | Compute, storage, IOPS, backup, or add-on meter                         | `'vCore'`, `'Additional IOPS'`, `'B4MS'`    |
 
 ## Meter Names
-
-| Meter                            | skuName              | unitOfMeasure  | Notes                                                    |
-| -------------------------------- | -------------------- | -------------- | -------------------------------------------------------- |
-| `vCore`                          | `vCore`              | `1 Hour`       | Per-vCore rate, multiply via InstanceCount (GP/MO v5/v6) |
-| `B4MS`                           | `Standard_B4ms`      | `1 Hour`       | Fixed Burstable SKU, includes vCPU+RAM                   |
-| `8 vCore`                        | `Standard_E8d_v5`    | `1 Hour`       | Fixed MO Edsv5 size, includes vCPU+RAM                   |
-| `Storage Data Stored`            | `Storage`            | `1 GB/Month`   | Standard LRS data storage                                |
-| `Backup Storage LRS Data Stored` | `Backup Storage LRS` | `1 GB/Month`   | Backup storage (LRS); ZRS also available                 |
+| Meter                                  | skuName              | unitOfMeasure | Notes                                  |
+| -------------------------------------- | -------------------- | ------------- | -------------------------------------- |
+| `vCore`                                | `vCore`              | `1 Hour`      | Per-vCore GP/MO/Confidential           |
+| `vCore`                                | `1 vCore`            | `1 Hour`      | Business Critical Ev3                  |
+| `B4MS`                                 | `Standard_B4ms`      | `1 Hour`      | Fixed Burstable SKU                    |
+| `Storage Data Stored`                  | `Storage`            | `1 GB/Month`  | Standard LRS storage                   |
+| `Storage ZRS Data Stored`              | `Storage ZRS`        | `1 GB/Month`  | Standard ZRS storage                   |
+| `Additional IOPS`                      | `Additional IOPS`    | `1 IOPS/Month` | Pre-provisioned extra IOPS            |
+| `Paid IO LRS IO Rate Operations`       | `Paid IO LRS`        | `1M`          | Autoscale I/O per million operations   |
+| `SSD v2 Data Stored`                   | `SSD v2`             | `1 GiB/Month` | SSD v2 storage                         |
+| `SSD v2 IOPS Provisioned IOPS`         | `SSD v2 IOPS`        | `1/Month`     | SSD v2 provisioned IOPS                |
+| `Backup Storage LRS Data Stored`       | `Backup Storage LRS` | `1 GB/Month`  | Backup beyond free grant               |
+| `Storage GP Accelerated Logs`          | `Storage GP Accelerated Logs` | `1 Hour` | GP accelerated logs add-on             |
 
 ## Cost Formula
 
 ```
 Compute (per-vCore) = compute_retailPrice × 730 × vCoreCount
 Compute (Burstable/Edsv5) = compute_retailPrice × 730
-Storage = storage_retailPrice × sizeGB; Total = Compute + Storage
+Storage = storage_retailPrice × sizeGBOrGiB
+Provisioned IOPS/throughput = meter_retailPrice × quantity
+Autoscale I/O = io_retailPrice × (operations / 1,000,000)
+Backup = backup_retailPrice × max(0, backupGB - provisionedStorageGB)
+Total = Compute + Storage + optional IOPS/throughput + optional Backup
 ```
 
 ## Notes
-
-- Burstable: dev/test, does NOT support RI, max 20 vCores
-- GP/MO per-vCore + Confidential: support RI; v6 has disk-attached (Ddsv6/Edsv6) and non-disk (Dsv6/Esv6) variants
-- MO Edsv5: per-size SKU pricing (Standard_E2d_v5 through Standard_E104id_v5), no RI
-- HA doubles compute cost; backup equal to provisioned storage is free; Single Server is retired (meters remain in API)
+- Microsoft Learn names current tiers Burstable, General Purpose, and Memory-Optimized; API also returns Business Critical Ev3. Burstable and Business Critical Ev3 have no RI meters.
+- RI exists for specific GP/MO/Confidential products only; disk-attached v6 products (`Ddsv6`, `Dadsv6`, `Edsv6`, `Eadsv6`) return no RI meters.
+- HA doubles compute cost; backup equal to provisioned storage is free; Single Server is retired but meters and Extended Support remain in API.
+- Accelerated logs are billed for GP, included for Memory-Optimized, and unsupported for Burstable.
 
 ## Reserved Instance Pricing
 
-### RI for GP/MO Flexible Server (Ddsv5 example, per-vCore)
-
+### RI for GP Flexible Server (generic series, per-vCore)
 ServiceName: Azure Database for MySQL
-ProductName: Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute
+ProductName: Azure Database for MySQL Flexible Server General Purpose Series Compute
+SkuName: vCore
 MeterName: vCore
 PriceType: Reservation
 
-> **Trap (RI exclusions)**: Burstable and MO Edsv5 do NOT support RI. Only GP, MO per-vCore (v5/v6), and Confidential series are eligible. Monthly cost: `unitPrice ÷ 12 × vCoreCount` (1-Year) or `unitPrice ÷ 36 × vCoreCount` (3-Year).
+> **Trap (RI exclusions)**: Burstable, Business Critical Ev3, MO Edsv5 fixed-size, and disk-attached v6 products do NOT support RI. Monthly cost: `unitPrice ÷ 12 × vCoreCount` (1-Year) or `unitPrice ÷ 36 × vCoreCount` (3-Year).
 
 ## Product Names
-
 | Config             | productName                                                                       |
 | ------------------ | --------------------------------------------------------------------------------- |
 | GP, Ddsv5          | `Azure Database for MySQL Flexible Server General Purpose Ddsv5 Series Compute`   |
@@ -85,12 +103,15 @@ PriceType: Reservation
 | GP, Dadsv6         | `Azure Database for MySQL Flexible Server General Purpose Dadsv6 Series Compute`  |
 | GP, Dsv6           | `Azure Database for MySQL Flexible Server General Purpose Dsv6 Series Compute`    |
 | GP, Dasv6          | `Azure Database for MySQL Flexible Server General Purpose Dasv6 Series Compute`   |
+| GP, generic RI     | `Azure Database for MySQL Flexible Server General Purpose Series Compute`         |
+| BC, Ev3            | `Azure Database for MySQL Flexible Server Business Critical Ev3 Series Compute`   |
 | MO, Edsv5          | `Azure Database for MySQL Flexible Server Memory Optimized Edsv5 Series Compute`  |
 | MO, Eadsv5         | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
 | MO, Edsv6          | `Azure Database for MySQL Flexible Server Memory Optimized Edsv6 Series Compute`  |
 | MO, Eadsv6         | `Azure Database for MySQL Flexible Server Memory Optimized Eadsv6 Series Compute` |
 | MO, Esv6           | `Azure Database for MySQL Flexible Server Memory Optimized Esv6 Series Compute`   |
 | MO, Easv6          | `Azure Database for MySQL Flexible Server Memory Optimized Easv6 Series Compute`  |
+| MO, generic RI     | `Azure Database for MySQL Flexible Server Memory Optimized Series Compute`        |
 | Confidential       | `Azure Database for MySQL Flexible Server Confidential Compute ECadsv6 Series`    |
 | Burstable, BS      | `Azure Database for MySQL Flexible Server Burstable BS Series Compute`            |
 | Storage            | `Azure Database for MySQL Flexible Server Storage`                                |

--- a/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-mysql.md
@@ -3,7 +3,7 @@ serviceName: Azure Database for MySQL
 category: databases
 aliases: [MySQL, Azure MySQL, MySQL Flexible Server]
 billingConsiderations: [Reserved Instances]
-primaryCost: "vCore hours × 730 + storage/IOPS/backup usage"
+primaryCost: "vCore hourly rate × vCore count × 730 + storage/IOPS/backup usage"
 privateEndpoint: true
 ---
 
@@ -73,7 +73,8 @@ Compute (Burstable/Edsv5) = compute_retailPrice × 730
 Storage = storage_retailPrice × sizeGBOrGiB
 Provisioned IOPS/throughput = meter_retailPrice × quantity
 Autoscale I/O = io_retailPrice × (operations / 1,000,000)
-Backup = backup_retailPrice × max(0, backupGB - provisionedStorageGB)
+Billable Backup GB = max(0, totalBackupGB - provisionedStorageGB)  # free grant = provisioned storage, applied once
+Backup = backup_retailPrice × billableBackupGB
 Total = Compute + Storage + optional IOPS/throughput + optional Backup
 ```
 

--- a/skills/azure-cost-calculator/references/services/databases/database-for-postgresql.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-for-postgresql.md
@@ -3,22 +3,22 @@ serviceName: Azure Database for PostgreSQL
 category: databases
 aliases: [PostgreSQL, Postgres, Azure Postgres, PostgreSQL Flexible Server]
 billingConsiderations: [Reserved Instances]
-primaryCost: "vCore hourly rate × 730 + storage per-GB/month"
+primaryCost: "vCore hourly rate × 730 + storage per-GB/GiB-month"
 privateEndpoint: true
 ---
 
 # Azure Database for PostgreSQL Flexible Server
 
-> **Trap (productName inconsistency)**: `productName` has inconsistent naming across series. Some use `General Purpose - Ddsv5` (with hyphen) while others use `General Purpose Dadsv5` (no hyphen). The Esv3 product uses `Az DB for PGSQL`, storage uses `Az DB for PostgreSQL`, all others use `Azure Database for PostgreSQL`. Always use the exact string from discovery.
+> **Trap (productName inconsistency)**: Compute products use the full `Azure Database for PostgreSQL` prefix, but storage uses the abbreviated `Az DB for PostgreSQL` prefix. Series names differ by local-disk and AMD letters (`Ddsv5`, `Dadsv5`, `Dasv6`); do not insert hyphens. Always use exact discovery strings.
 
-> **Trap (v6 skuName)**: v6 and Confidential Compute series have **two** SKU patterns: `SkuName: 1 vCore` / `MeterName: 1 vCore` and `SkuName: vCore` / `MeterName: vCore` (same per-vCore rate). Unlike v4/v5, v6 does **not** have `SkuName: N vCore` variants (e.g., `4 vCore`). Use `SkuName: vCore` with `InstanceCount` for scaling.
+> **Trap (v6 skuName)**: v6 and Confidential Compute series can use `SkuName: 1 vCore` / `MeterName: 1 vCore`, `SkuName: vCore` / `MeterName: vCore`, or only one of those patterns depending on series. Unlike v4/v5, do not assume `SkuName: N vCore`; use exact discovery and `InstanceCount` for scaling.
 
 ## Query Pattern
 
 ### Compute (General Purpose, Ddsv5 series, 4 vCores)
 
 ServiceName: Azure Database for PostgreSQL
-ProductName: Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute
+ProductName: Azure Database for PostgreSQL Flexible Server General Purpose Ddsv5 Series Compute
 SkuName: vCore
 MeterName: vCore
 InstanceCount: 4 # vCore count
@@ -44,35 +44,44 @@ Quantity: 100 # storage size in GB
 | Parameter     | How to determine                   | Example values                                              |
 | ------------- | ---------------------------------- | ----------------------------------------------------------- |
 | `productName` | Tier + series (exact match)        | See Product Names table below                               |
-| `skuName`     | v4/v5: `'N vCore'` or `'vCore'`; v6: `'vCore'` | `'4 vCore'`, `'vCore'`                                     |
-| `meterName`   | Always `'vCore'` for per-vCore compute | `'vCore'`, `'Storage Data Stored'`                          |
+| `skuName`     | Series-specific exact value            | `'4 vCore'`, `'vCore'`, `'1 vCore'`, `'B4ms'`               |
+| `meterName`   | Compute/storage/performance component  | `'vCore'`, `'1 vCore'`, `'Storage Data Stored'`             |
 
 ## Meter Names
 
-| Meter                            | skuName              | unitOfMeasure | Notes                                       |
-| -------------------------------- | -------------------- | ------------- | ------------------------------------------- |
-| `vCore`                          | `N vCore` or `vCore` | `1 Hour`      | All series; use InstanceCount for sizing    |
-| `Storage Data Stored`            | `Storage`            | `1 GB/Month`  | Standard LRS storage                        |
-| `Backup Storage LRS Data Stored` | `Backup Storage LRS` | `1 GB/Month`  | Backup beyond free grant                    |
-| `IOPS Scaling Provisioned IOPS`  | `IOPS Scaling`       | `1/Month`     | Per additional provisioned IOP              |
+| Meter                                      | skuName                  | unitOfMeasure | Notes                                    |
+| ------------------------------------------ | ------------------------ | ------------- | ---------------------------------------- |
+| `vCore`                                    | `N vCore`, `vCore`, or VM size | `1 Hour` | GP/MO/Mdsv2 per-vCore compute           |
+| `1 vCore`                                  | `1 vCore`                | `1 Hour`      | v6/Confidential per-vCore compute        |
+| `B1MS`, `B2S`, `B* vCore`                  | `B1MS`, `B2S`, `B*`      | `1 Hour`      | Burstable fixed-size compute             |
+| `Storage Data Stored`                      | `Storage`                | `1 GB/Month`  | Premium SSD storage                      |
+| `Premium SSD v2 Storage Data Stored`       | `Premium SSD v2 Storage` | `1 GiB/Month` | Premium SSD v2 capacity                  |
+| `IOPS Scaling Provisioned IOPS`            | `IOPS Scaling`           | `1/Month`     | Premium SSD extra provisioned IOPS       |
+| `Premium SSD v2 IOPS Provisioned IOPS`     | `Premium SSD v2 IOPS`    | `1/Month`     | Premium SSD v2 extra provisioned IOPS    |
+| `Premium SSDv2 Throughput Prov Throughput (MBps)` | `Premium SSDv2 Throughput` | `1/Month` | Premium SSD v2 extra throughput          |
+| `Ultra Disk Storage Data Stored`           | `Ultra Disk Storage`     | `1 GB/Month`  | Ultra Disk capacity                      |
+| `Ultra Disk IOPS Provisioned IOPS`         | `Ultra Disk IOPS`       | `1/Month` | Ultra Disk extra provisioned IOPS        |
+| `Ultra Disk Throughput Prov Throughput (MBps)` | `Ultra Disk Throughput` | `1/Month` | Ultra Disk extra throughput              |
+| `Backup Storage LRS Data Stored`           | `Backup Storage LRS`     | `1 GB/Month`  | Backup beyond free grant                 |
 
 ## Cost Formula
 
 ```
-Monthly Compute = compute_retailPrice × 730 × vCoreCount
-Monthly Storage = storage_retailPrice × sizeGB
-Total = Compute + Storage (+ optional IOPS + Backup)
+Monthly Compute = compute_retailPrice × 730 × vCoreCount (or fixed burstable retailPrice × 730)
+Monthly Storage = storage_retailPrice × sizeGB_or_GiB
+Monthly Performance = (iops_retailPrice × provisionedIOPS) + (throughput_retailPrice × provisionedMBps)
+Total = Compute + Storage + optional Performance + Backup (+ HA uplift)
 ```
 
 ## Notes
 
 - Burstable: dev/test workloads, does NOT support RI. Uses fixed SKU names (B1MS, B2S, B4ms, etc.)
-- GP: production workloads, supports RI. Per-vCore pricing with InstanceCount
-- MO: high-memory workloads, supports RI. Same per-vCore pattern as GP
-- Mdsv2: ultra-high-memory workloads. Uses fixed VM-size SKUs (M128dms_v2, etc.), no RI
-- High Availability doubles compute cost (deploys a standby replica); no separate HA meter
+- GP: production workloads. Selected GP series support RI; verify with `PriceType: Reservation`
+- MO: high-memory workloads. Selected MO series support RI; verify with `PriceType: Reservation`
+- Mdsv2 and Confidential Compute: fixed or `1 vCore` SKUs, no RI in the API
+- High Availability doubles deployment costs (standby replica); no separate HA meter
 - Backup storage: first backup equal to DB size is free; excess charged per-GB/month (LRS only)
-- Storage options: Standard (GB), Premium Managed Disk V2 (GiB + IOPS + throughput), Ultra Disk (GB + IOPS + throughput)
+- Storage options: Premium SSD (GB), Premium SSD v2 (GiB + IOPS + throughput), Ultra Disk (GB + IOPS + throughput)
 - Single Server was retired in 2025; all new deployments use Flexible Server. Legacy Single Server meters still appear in the API but are not supported for new estimates
 - Cosmos DB for PostgreSQL and HorizonDB meters share this serviceName; filter by productName
 
@@ -80,20 +89,32 @@ Total = Compute + Storage (+ optional IOPS + Backup)
 
 | Config              | productName                                                                            |
 | ------------------- | -------------------------------------------------------------------------------------- |
-| GP, Ddsv5           | `Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute` |
+| GP, Dsv3            | `Azure Database for PostgreSQL Flexible Server General Purpose Dsv3 Series Compute`    |
+| GP, Ddsv4           | `Azure Database for PostgreSQL Flexible Server General Purpose Ddsv4 Series Compute`   |
+| GP, Ddsv5           | `Azure Database for PostgreSQL Flexible Server General Purpose Ddsv5 Series Compute`   |
 | GP, Dadsv5          | `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv5 Series Compute`  |
 | GP, Ddsv6           | `Azure Database for PostgreSQL Flexible Server General Purpose Ddsv6 Series Compute`   |
 | GP, Dadsv6          | `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv6 Series Compute`  |
 | GP, Dsv6            | `Azure Database for PostgreSQL Flexible Server General Purpose Dsv6 Series Compute`    |
 | GP, Dasv6           | `Azure Database for PostgreSQL Flexible Server General Purpose Dasv6 Series Compute`   |
+| MO, Esv3            | `Azure Database for PostgreSQL Flexible Server Memory Optimized Esv3 Series Compute`   |
+| MO, Edsv4           | `Azure Database for PostgreSQL Flexible Server Memory Optimized Edsv4 Series Compute`  |
 | MO, Edsv5           | `Azure Database for PostgreSQL Flexible Server Memory Optimized Edsv5 Series Compute`  |
 | MO, Eadsv5          | `Azure Database for PostgreSQL Flexible Server Memory Optimized Eadsv5 Series Compute` |
+| MO, Ebdsv5          | `Azure Database for PostgreSQL Flexible Server Memory Optimized Ebdsv5 Series Compute` |
 | MO, Edsv6           | `Azure Database for PostgreSQL Flexible Server Memory Optimized Edsv6 Series Compute`  |
 | MO, Eadsv6          | `Azure Database for PostgreSQL Flexible Server Memory Optimized Eadsv6 Series Compute` |
 | MO, Esv6            | `Azure Database for PostgreSQL Flexible Server Memory Optimized Esv6 Series Compute`   |
 | MO, Easv6           | `Azure Database for PostgreSQL Flexible Server Memory Optimized Easv6 Series Compute`  |
 | Mdsv2               | `Azure Database for PostgreSQL Flexible Server Mdsv2 Series Compute`                   |
-| Confidential   | `Azure Database for PostgreSQL Flexible Server Confidential Compute DCadsv6 Series Compute` |
+| Conf, DCadsv5       | `Azure Database for PostgreSQL Flexible Server Confidential Compute DCadsv5 Series Compute` |
+| Conf, DCadsv6       | `Azure Database for PostgreSQL Flexible Server Confidential Compute DCadsv6 Series Compute` |
+| Conf, DCasv5        | `Azure Database for PostgreSQL Flexible Server Confidential Compute DCasv5 Series Compute` |
+| Conf, DCesv6        | `Azure Database for PostgreSQL Flexible Server Confidential Compute DCesv6 Series Compute` |
+| Conf, ECadsv5       | `Azure Database for PostgreSQL Flexible Server Confidential Compute ECadsv5 Series Compute` |
+| Conf, ECadsv6       | `Azure Database for PostgreSQL Flexible Server Confidential Compute ECadsv6 Series Compute` |
+| Conf, ECasv5        | `Azure Database for PostgreSQL Flexible Server Confidential Compute ECasv5 Series Compute` |
+| Conf, ECesv6        | `Azure Database for PostgreSQL Flexible Server Confidential Compute ECesv6 Series Compute` |
 | Burstable, BS       | `Azure Database for PostgreSQL Flexible Server Burstable BS Series Compute`            |
 | Storage             | `Az DB for PostgreSQL Flexible Server Storage`                                         |
 | Backup              | `Azure Database for PostgreSQL Flexible Server Backup Storage`                         |

--- a/skills/azure-cost-calculator/references/services/databases/database-migration-service.md
+++ b/skills/azure-cost-calculator/references/services/databases/database-migration-service.md
@@ -2,17 +2,18 @@
 serviceName: Azure Database Migration Service
 category: databases
 aliases: [DMS, Database Migration, DB Migration Service]
-primaryCost: "Instance hourly rate × 730 (all tiers have paid meters except 1-vCore Free)"
+primaryCost: "Standard/offline is free; Premium or legacy compute uses retailPrice × 730 × instanceCount"
 hasFreeGrant: true
+privateEndpoint: true
 ---
 
 # Azure Database Migration Service
 
 > **Trap**: Meter names (`4 vCore`, `8 vCore`, `16 vCore`) repeat across General Purpose Compute and Premium Compute products. Always filter by `productName` to select the correct tier.
 
-> **Trap (Free vs Paid meters)**: Only the `1 vCore vCore - Free` meter (Basic Compute) and General Purpose Storage return zero cost. All other Basic and General Purpose meters (`1 vCore`, `2 vCore`, `4 vCore`, `8 vCore`, `16 vCore`) have nonzero hourly rates. Do not assume Basic/General Purpose tiers are free — query the API and use the returned `retailPrice`.
+> **Trap (Standard vs legacy meters)**: Microsoft pricing docs list Standard Compute (1, 2, and 4 vCores) as free, but the Retail Prices API still returns legacy Basic and General Purpose compute meters with nonzero rates. For modern offline/Standard migrations, treat compute as free. For existing classic instances or explicit API-meter estimates, query the API and use the returned `retailPrice`.
 
-> **Note**: Premium 4-vCore includes a 183-day free period per instance. Ask the user whether instances are still within the free period or provide the instance age to apply the grant deduction.
+> **Note**: Premium 4-vCore includes a 183-day free period per instance. Ask whether instances are still within the free period or provide the instance age to apply the grant deduction.
 
 ## Query Pattern
 
@@ -32,56 +33,67 @@ SkuName: 4 vCore
 MeterName: 4 vCore
 InstanceCount: 1
 
+### Premium 4-vCore free-grant confirmation
+
+ServiceName: Azure Database Migration Service
+ProductName: Azure Database Migration Service Premium Compute
+SkuName: 4 vCore
+MeterName: 4 vCore
+Region: Global
+
 ## Key Fields
 
-| Parameter     | How to determine                                     | Example values                                            |
-| ------------- | ---------------------------------------------------- | --------------------------------------------------------- |
-| `serviceName` | Always `Azure Database Migration Service`            | `Azure Database Migration Service`                        |
-| `productName` | Tier: Basic, General Purpose, or Premium             | `...Basic Compute`, `...General Purpose Compute`, `...Premium Compute` |
-| `skuName`     | vCore count                                          | `1 vCore`, `2 vCore`, `4 vCore`, `8 vCore`, `16 vCore`    |
-| `meterName`   | Same as skuName; Basic free = `1 vCore vCore - Free` | `4 vCore`, `1 vCore vCore - Free`                         |
+| Parameter     | How to determine                                      | Example values                                            |
+| ------------- | ----------------------------------------------------- | --------------------------------------------------------- |
+| `serviceName` | Always `Azure Database Migration Service`             | `Azure Database Migration Service`                        |
+| `productName` | Tier: Basic, General Purpose, Premium, or Storage     | `...Basic Compute`, `...General Purpose Compute`, `...Premium Compute` |
+| `skuName`     | vCore count or `General Purpose` for storage          | `1 vCore`, `2 vCore`, `4 vCore`, `8 vCore`, `16 vCore`    |
+| `meterName`   | Same as skuName; Basic free and storage add suffixes  | `4 vCore`, `1 vCore vCore - Free`, `General Purpose Data Stored - Free` |
 
 ## Meter Names
 
 | Meter                  | skuName    | productName                  | unitOfMeasure | Notes            |
 | ---------------------- | ---------- | ---------------------------- | ------------- | ---------------- |
-| `1 vCore vCore - Free` | `1 vCore`  | `...Basic Compute`           | `1 Hour`      | Always free      |
-| `1 vCore`              | `1 vCore`  | `...Basic Compute`           | `1 Hour`      | Paid             |
-| `2 vCore`              | `2 vCore`  | `...Basic Compute`           | `1 Hour`      | Paid             |
-| `4 vCore`              | `4 vCore`  | `...General Purpose Compute` | `1 Hour`      | Paid             |
-| `8 vCore`              | `8 vCore`  | `...General Purpose Compute` | `1 Hour`      | Paid             |
-| `16 vCore`             | `16 vCore` | `...General Purpose Compute` | `1 Hour`      | Paid             |
-| `4 vCore`              | `4 vCore`  | `...Premium Compute`         | `1 Hour`      | Paid (online)    |
-| `8 vCore`              | `8 vCore`  | `...Premium Compute`         | `1 Hour`      | Paid (online)    |
-| `16 vCore`             | `16 vCore` | `...Premium Compute`         | `1 Hour`      | Paid (online)    |
-| `General Purpose Data Stored - Free` | `General Purpose` | `...General Purpose Storage` | `1 GB/Month` | Always free |
+| `1 vCore vCore - Free` | `1 vCore`  | `...Basic Compute`           | `1 Hour`      | Free legacy row  |
+| `1 vCore`              | `1 vCore`  | `...Basic Compute`           | `1 Hour`      | Legacy paid row  |
+| `2 vCore`              | `2 vCore`  | `...Basic Compute`           | `1 Hour`      | Legacy paid row  |
+| `4 vCore`              | `4 vCore`  | `...General Purpose Compute` | `1 Hour`      | Legacy paid row  |
+| `8 vCore`              | `8 vCore`  | `...General Purpose Compute` | `1 Hour`      | Legacy paid row  |
+| `16 vCore`             | `16 vCore` | `...General Purpose Compute` | `1 Hour`      | Legacy paid row  |
+| `4 vCore`              | `4 vCore`  | `...Premium Compute`         | `1 Hour`      | Paid after grant |
+| `8 vCore`              | `8 vCore`  | `...Premium Compute`         | `1 Hour`      | API legacy size  |
+| `16 vCore`             | `16 vCore` | `...Premium Compute`         | `1 Hour`      | API legacy size  |
+| `General Purpose Data Stored - Free` | `General Purpose` | `...General Purpose Storage` | `1 GB/Month` | Free; two tier rows |
 
 ## Cost Formula
 
 ```
-Basic / General Purpose = compute_retailPrice × 730 × instanceCount
-Premium (outside free period) = compute_retailPrice × 730 × instanceCount
-Premium 4-vCore (within 183-day free period) = max(0, totalHours - remainingFreeGrantHours) × compute_retailPrice × instanceCount
+Modern Standard/offline = 0 (Microsoft pricing docs list Standard Compute as free)
+Legacy Basic / General Purpose = compute_retailPrice × 730 × instanceCount
+Premium after free period = compute_retailPrice × 730 × instanceCount
+Premium 4-vCore within 183-day free period = max(0, totalHours - remainingFreeGrantHours) × compute_retailPrice × instanceCount
 Storage = free (retailPrice returns 0)
 Total = sum of applicable tier costs
 ```
 
 ## Notes
 
-- Only `1 vCore vCore - Free` (Basic) and Storage meters are zero cost; all other meters have nonzero rates
-- Basic tier (1–2 vCores) and General Purpose (4, 8, 16 vCores): paid per-vCore/hour for offline migrations
-- Premium tier (4, 8, 16 vCores): paid per-vCore/hour for online (continuous-sync) migrations
-- Premium 4-vCore includes a 183-day free period per instance; ask for instance age or planned migration duration
+- Microsoft pricing docs list Standard tier (1, 2, and 4 vCores) as free for offline migrations
+- The API still exposes legacy Basic and General Purpose paid meters; use them only for existing classic instances or explicit API-meter estimates
+- Premium tier is required for online migrations; 4-vCore includes a 183-day free period per instance
+- Premium 8-vCore and 16-vCore meters exist in the API, but public pricing docs focus on 4-vCore
 - Capacity: 4 vCores supports ~2 parallel table migrations; scale up for larger databases
-- Storage (General Purpose Storage) is always free (zero cost)
+- Storage (General Purpose Storage) returns two zero-priced tier rows (`TierMinUnits` 0 and 50)
+- DMS can connect to source and target databases using private endpoints; price those endpoint resources separately
 - Often deployed via Azure Migrate hub (see migrate.md for migration project costing)
-- Classic DMS retired March 2026; new experience uses Azure portal or Azure SQL Migration extension
+- Classic DMS retired March 2026; classic instances have a one-year maximum lifetime from creation
+- Pricing page mentions a database savings plan for Premium vCores, but the Retail Prices API returned no reservation or savings-plan price rows
 
 ## Product Names
 
 | Config          | productName                                                |
 | --------------- | ---------------------------------------------------------- |
-| Basic           | `Azure Database Migration Service Basic Compute`           |
-| General Purpose | `Azure Database Migration Service General Purpose Compute` |
+| Basic legacy    | `Azure Database Migration Service Basic Compute`           |
+| GP legacy       | `Azure Database Migration Service General Purpose Compute` |
 | Premium         | `Azure Database Migration Service Premium Compute`         |
 | Storage         | `Azure Database Migration Service General Purpose Storage` |

--- a/skills/azure-cost-calculator/references/services/databases/horizondb.md
+++ b/skills/azure-cost-calculator/references/services/databases/horizondb.md
@@ -37,7 +37,7 @@ ServiceName: Azure Database for PostgreSQL
 ProductName: Azure HorizonDB Backup Storage
 SkuName: HorizonDB Backup Storage
 MeterName: HorizonDB Backup Storage Data Stored
-Quantity: 50 # backup GB beyond included grant
+Quantity: 50 # billable backup GB (total − cluster size)
 
 ## Key Fields
 
@@ -62,7 +62,7 @@ Quantity: 50 # backup GB beyond included grant
 ```
 Monthly Compute = compute_retailPrice × 730 × vCoreCount
 Monthly Storage = storage_retailPrice × sizeGB
-Billable Backup GB = max(0, backupGB - clusterSizeGB)
+Billable Backup GB = max(0, totalBackupGB - clusterSizeGB)  # free grant = cluster size, applied once
 Monthly Backup  = backup_retailPrice × billableBackupGB
 Total = Compute + Storage + Backup
 ```

--- a/skills/azure-cost-calculator/references/services/databases/horizondb.md
+++ b/skills/azure-cost-calculator/references/services/databases/horizondb.md
@@ -3,7 +3,8 @@ serviceName: Azure HorizonDB
 category: databases
 aliases: [Horizon DB, Distributed PostgreSQL]
 apiServiceName: Azure Database for PostgreSQL
-primaryCost: "vCore hourly rate × 730 + storage per-GB/month + backup per-GB/month"
+primaryCost: "vCore hourly rate × 730 + storage per-GB/month + billable backup over free grant"
+privateEndpoint: true
 ---
 
 # Azure HorizonDB
@@ -30,13 +31,13 @@ SkuName: HorizonDB storage
 MeterName: HorizonDB storage Data Stored
 Quantity: 100 # storage size in GB
 
-### Backup storage (50 GB)
+### Backup storage (50 GB beyond free grant)
 
 ServiceName: Azure Database for PostgreSQL
 ProductName: Azure HorizonDB Backup Storage
 SkuName: HorizonDB Backup Storage
 MeterName: HorizonDB Backup Storage Data Stored
-Quantity: 50 # backup size in GB
+Quantity: 50 # backup GB beyond included grant
 
 ## Key Fields
 
@@ -51,22 +52,30 @@ Quantity: 50 # backup size in GB
 | Meter                                  | unitOfMeasure | Notes                          |
 | -------------------------------------- | ------------- | ------------------------------ |
 | `1 vCore`                              | `1 Hour`      | Per-vCore compute; use InstanceCount for sizing |
+| `1 vCore Free Tier`                    | `1 Hour`      | API-only zero-price meter; use only with confirmed entitlement |
 | `HorizonDB storage Data Stored`        | `1 GB/Month`  | Data storage per GB            |
 | `HorizonDB Backup Storage Data Stored` | `1 GB/Month`  | Backup storage per GB          |
+| `Backup 0 meter Data Stored`           | `1 GB/Month`  | Included backup grant meter    |
 
 ## Cost Formula
 
 ```
 Monthly Compute = compute_retailPrice × 730 × vCoreCount
 Monthly Storage = storage_retailPrice × sizeGB
-Monthly Backup  = backup_retailPrice × backupGB
+Billable Backup GB = max(0, backupGB - clusterSizeGB)
+Monthly Backup  = backup_retailPrice × billableBackupGB
 Total = Compute + Storage + Backup
 ```
 
 ## Notes
 
-- Azure HorizonDB is in **limited preview** (early access); availability is constrained by region and enrollment. Confirm the user has access and verify the target region supports HorizonDB before estimating. Retail Prices API meters may change or be removed before GA.
+- Azure HorizonDB is in **public preview**; Retail Prices API meters may change before GA
+- Microsoft Learn currently lists Central US, East US, West US 2, West US 3, Sweden Central, and Australia East. Verify target region support before estimating
 - Storage productName uses lowercase 's' (`Azure HorizonDB storage`); use exact casing
 - Shares `serviceName` with PostgreSQL Flexible Server (see `databases/database-for-postgresql.md`)
-- Storage and vCore count are never-assume parameters: always ask the user
+- Storage, vCore count, replica count, and billable backup beyond the included grant are never-assume parameters: always ask the user
+- Backup storage equal to the cluster size has no extra charge; use the paid backup meter only for excess backup consumption
+- API exposes `1 vCore Free Tier`, but Microsoft Learn and the pricing page do not define a free compute tier. Use paid compute unless the user confirms entitlement
+- Private Link is supported; virtual network injection is not. Price private endpoints via `networking/private-link.md`
+- AI model usage is billed at Microsoft Foundry rates if enabled
 - No Reserved Instance pricing available in the API

--- a/skills/azure-cost-calculator/references/services/databases/redis-cache.md
+++ b/skills/azure-cost-calculator/references/services/databases/redis-cache.md
@@ -3,13 +3,12 @@ serviceName: Redis Cache
 category: databases
 aliases: [Azure Cache for Redis, Redis, Azure Redis, Managed Redis]
 billingConsiderations: [Reserved Instances]
-primaryCost: "Cache instance hours based on tier and size × 730 × shardCount"
+primaryCost: "Cache or cache-instance hours by tier and size × 730 × cache/node count"
 privateEndpoint: true
 ---
 
 # Azure Cache for Redis
-
-> **Trap (duplicate meters)**: Standard and Premium tiers return **two meters per size**, e.g., `C1 Cache` AND `C1 Cache Instance`. The `{Size} Cache` meter is the **total cluster cost** (2 nodes with HA); `{Size} Cache Instance` is exactly **half** (per-node). **Use `{Size} Cache` for total cost matching the Azure Portal.** Basic, Enterprise, and Enterprise Flash tiers only have `{Size} Cache` (no `Cache Instance` variant). Always include `ProductName` to filter by tier.
+> **Trap (duplicate meters)**: Standard and Premium tiers return **two meters per size**, e.g., `C1 Cache` AND `C1 Cache Instance`. The `{Size} Cache` meter is the **total cluster cost** (2 nodes with HA); `{Size} Cache Instance` is exactly **half** (per-node). **Use `{Size} Cache` for total cost matching the Azure Portal.** Basic, Enterprise, and Enterprise Flash only have `{Size} Cache`; Azure Managed Redis only has `{Size} Cache Instance`. Always include `ProductName` to filter by tier.
 
 > **Trap (Premium P1 ambiguity)**: Querying `meterName eq 'P1 Cache Instance'` returns **multiple results**: Consumption pricing (per-node hourly) AND Reservation pricing (1-Year/3-Year). Always filter with `type eq 'Consumption'` or `priceType eq 'Consumption'` to get deterministic results.
 
@@ -44,40 +43,62 @@ ServiceName: Redis Cache
 ProductName: Azure Redis Cache Premium
 MeterName: {Size} Cache Instance
 PriceType: Consumption
-InstanceCount: 3 # number of shards in cluster
+InstanceCount: 6 # nodes in sharded cluster (shards × nodes per shard)
+
+### Enterprise {Size}
+
+ServiceName: Redis Cache
+ProductName: Azure Redis Cache Enterprise
+MeterName: {Size} Cache
+PriceType: Consumption
+
+### Enterprise Flash {Size}
+
+ServiceName: Redis Cache
+ProductName: Azure Redis Cache Enterprise Flash
+MeterName: {Size} Cache
+PriceType: Consumption
+
+### Azure Managed Redis {Size}: per cache instance
+
+ServiceName: Redis Cache
+ProductName: Azure Managed Redis - Balanced
+MeterName: {Size} Cache Instance
+PriceType: Consumption
 
 ## Key Fields
 
 | Parameter     | How to determine                  | Example values                                              |
 | ------------- | --------------------------------- | ----------------------------------------------------------- |
 | `serviceName` | Always `Redis Cache`              | `Redis Cache`                                               |
-| `productName` | Tier selection                    | `Azure Redis Cache Basic/Standard/Premium`                  |
-| `skuName`     | Cache size                        | `C0`–`C6`, `P1`–`P5`, `E1`–`E400`, `F300`–`F1500`         |
-| `meterName`   | Size + meter type                 | `C1 Cache`, `P1 Cache Instance`, `E10 Cache`, `F700 Cache` |
+| `productName` | Tier selection                    | `Azure Redis Cache Premium`, `Azure Managed Redis - Balanced` |
+| `skuName`     | Cache size                        | `C0`–`C6`, `P1`–`P5`, `E1`–`E400`, `F300`–`F1500`, `B0`–`B1000` |
+| `meterName`   | Size + meter type                 | `C1 Cache`, `P1 Cache Instance`, `E10 Cache`, `A700 Cache Instance` |
 
 ## Meter Names
 
 | Meter pattern        | unitOfMeasure | Tiers                        | Notes                                    |
 | -------------------- | ------------- | ---------------------------- | ---------------------------------------- |
-| `{Size} Cache`       | `1 Hour`      | Basic, Standard, Premium, Enterprise, Enterprise Flash | Total cluster cost (includes HA nodes)  |
-| `{Size} Cache Instance` | `1 Hour`  | Standard, Premium, Managed Redis | Per-node cost; half of `{Size} Cache` for Standard/Premium |
+| `{Size} Cache`       | `1 Hour`      | Basic, Standard, Premium, Enterprise, Enterprise Flash | Total cluster cost for Standard/Premium |
+| `{Size} Cache Instance` | `1 Hour`  | Standard, Premium, Azure Managed Redis | Per-node cost for Standard/Premium; cache instance cost for Managed Redis |
 
 ## Cost Formula
 
 ```
 Using {Size} Cache (total):    Monthly = retailPrice × 730 × cacheCount
-Using {Size} Cache Instance:   Monthly = retailPrice × 730 × shardCount × nodesPerShard
+Using {Size} Cache Instance:   Monthly = retailPrice × 730 × instanceCount
 ```
 
 ## Notes
 
 - Basic tier has no SLA or replication (dev/test only); use `ProductName` to disambiguate tiers
 - Standard tier includes replication (2 nodes); Enterprise tiers use Redis Stack modules (RediSearch, RedisJSON, etc.)
-- Private Endpoint requires Premium tier or higher (not available on Basic/Standard); see `networking/private-link.md` for PE pricing
+- Private Endpoint is supported on Basic, Standard, Premium, Enterprise, Enterprise Flash, and Azure Managed Redis; see `networking/private-link.md` for PE pricing
+- Azure Managed Redis uses product names like `Azure Managed Redis - Balanced` and `A/B/M/X{Size} Cache Instance` meters
 
 ## Reserved Instance Pricing
 
-RIs available for **Premium** (P1-P5), **Enterprise** (E1, E10, E20, E50, E100 only — not E5/E200/E400), **Enterprise Flash**, and **Azure Managed Redis** tiers. Divide `retailPrice` by 12 (1-Year) or 36 (3-Year) for monthly cost.
+RIs available for **Premium** (P1-P5), **Enterprise** (E1, E10, E20, E50, E100 only; not E5/E200/E400), **Enterprise Flash**, and Azure Managed Redis sizes returned by `PriceType: Reservation`. Basic and Standard return no RI meters. Divide `retailPrice` by 12 (1-Year) or 36 (3-Year) for monthly cost.
 
 ### RI for Premium: substitute {Size} with P1-P5
 

--- a/skills/azure-cost-calculator/references/services/databases/sql-database.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-database.md
@@ -3,35 +3,41 @@ serviceName: SQL Database
 category: databases
 aliases: [Azure SQL, SQL DB]
 billingConsiderations: [Azure Hybrid Benefit, Reserved Instances]
-primaryCost: "vCore hourly rate × 730 + storage per-GB/month"
+primaryCost: "vCore hourly rate × 730 + storage/backup per-GB/month"
+hasFreeGrant: true
 privateEndpoint: true
 ---
 
 # Azure SQL Database
 
-> **Trap (inflated totals)**: Omitting `SkuName` returns all vCore sizes summed. Always filter by `ProductName`, `SkuName`, and `MeterName`; the service has 39 products spanning vCore, DTU, Serverless, Elastic Pool, storage, and backup.
+> **Trap (inflated totals)**: Omitting `SkuName` returns all vCore sizes summed. Always filter by `ProductName`, `SkuName`, and `MeterName`; the service has 39 products spanning vCore, DTU, Serverless, Elastic Pool, storage, backup, and add-ons.
 
 > **Trap (DTU billing)**: DTU tiers (Basic/Standard/Premium) use `unitOfMeasure: 1/Day`. The script auto-multiplies by 30 for these meters, so `MonthlyCost` is already the monthly cost.
 
-> **Trap (Zone Redundancy)**: GP zone-redundant deployments have separate compute meters (`Zone Redundancy vCore`) and storage meters (`General Purpose Zone Redundancy Data Stored` at ~2× standard rate). The ZR compute meter is an **additive hourly surcharge**. BC includes zone-redundant HA in base price (no separate ZR meter).
+> **Trap (Zone Redundancy)**: GP zone-redundant deployments have separate compute meters (`Zone Redundancy vCore`) and storage meters (`General Purpose Zone Redundancy Data Stored` at ~2× standard rate). The ZR compute meter is an additive hourly surcharge. BC includes zone-redundant HA in base price (no separate ZR meter).
 
 ## Query Pattern
 
 ### vCore compute (e.g., 2 vCore GP; swap productName for Business Critical)
-
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Compute Gen5
 SkuName: 2 vCore
 MeterName: vCore
 
 ### Storage (use Quantity for provisioned GB)
-
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Storage
 MeterName: General Purpose Data Stored
 Quantity: 256
 
-> For Business Critical: use `ProductName: ...Business Critical - Storage` and `MeterName: Business Critical Data Stored`.
+### Backup storage (PITR over included allowance; swap productName for LTR)
+ServiceName: SQL Database
+ProductName: SQL Database Single/Elastic Pool PITR Backup Storage
+SkuName: Backup LRS
+MeterName: LRS Data Stored
+Quantity: 100
+
+> For LTR: use `ProductName: SQL Database - LTR Backup Storage` and `MeterName: Backup LRS Data Stored`.
 
 ## Key Fields
 
@@ -39,45 +45,57 @@ Quantity: 256
 | ------------- | ------------------------------------------------- | ------------------------------------------ |
 | `serviceName` | Always `SQL Database`                             | `SQL Database`                             |
 | `productName` | Deployment type + tier + generation               | See Product Names section below            |
-| `skuName`     | vCore count, selects the size                     | `1 vCore`, `2 vCore`, `4 vCore`, `8 vCore` |
-| `meterName`   | Always `vCore` for compute, or storage meter name | `vCore`, `General Purpose Data Stored`     |
+| `skuName`     | vCore count, DTU tier, or backup redundancy       | `1 vCore`, `2 vCore`, `S0`, `Backup LRS`   |
+| `meterName`   | Compute, storage, backup, license, or I/O meter   | `vCore`, `General Purpose Data Stored`     |
 
 ## Meter Names
 
-| Meter                           | unitOfMeasure | Notes                                  |
-| ------------------------------- | ------------- | -------------------------------------- |
-| `vCore`                         | `1 Hour`      | Compute meter for all tiers            |
-| `Zone Redundancy vCore`         | `1 Hour`      | GP zone-redundancy compute surcharge   |
-| `General Purpose Data Stored`   | `1 GB/Month`  | Storage for General Purpose tier       |
-| `Business Critical Data Stored` | `1 GB/Month`  | Storage for Business Critical tier     |
-| `Hyperscale Data Stored`        | `1 GB/Month`  | Storage for Hyperscale tier            |
+| Meter                                      | unitOfMeasure | Notes                                  |
+| ------------------------------------------ | ------------- | -------------------------------------- |
+| `vCore`                                    | `1 Hour`      | Compute meter for vCore tiers          |
+| `Zone Redundancy vCore`                    | `1 Hour`      | GP zone-redundancy compute surcharge   |
+| `General Purpose Data Stored`              | `1 GB/Month`  | Storage for General Purpose tier       |
+| `General Purpose Zone Redundancy Data Stored` | `1 GB/Month` | ZR storage for General Purpose tier    |
+| `Business Critical Data Stored`            | `1 GB/Month`  | Storage for Business Critical tier     |
+| `Hyperscale Data Stored`                   | `1 GB/Month`  | Storage for Hyperscale tier            |
+| `General Purpose IO Rate Operations`       | `1M`          | Optional GP I/O operations             |
+| `General Purpose Zone Redundancy IO Rate Operations` | `1M` | Optional GP ZR I/O operations          |
+| `Business Critical IO Rate Operations`     | `1M`          | Optional BC I/O operations             |
+| `Hyperscale IO Rate Operations`            | `1M`          | Optional Hyperscale I/O operations     |
+| `LRS Data Stored`                          | `1 GB/Month`  | PITR backup over included allowance    |
+| `Backup LRS Data Stored`                   | `1 GB/Month`  | LTR backup storage                     |
 
 ## Cost Formula
 
 ```
-Monthly Compute = retailPrice × 730 | Monthly Storage = storage_retailPrice × sizeInGB
-Total = Compute + Storage
+Monthly Compute = compute_retailPrice × 730
+Monthly Storage = storage_retailPrice × sizeInGB
+Monthly IO = (ioOperations / 1,000,000) × io_retailPrice
+Monthly Backup = backup_retailPrice × billableBackupGB
+Total = Compute + Storage + IO + Backup
 Zone-Redundant GP = (base_retailPrice + zr_retailPrice) × 730 + zr_storage_retailPrice × sizeInGB
 ```
 
 ## Notes
 
-- **Storage**: GP and BC storage billed separately per-GB for configured max size (not usage). Default 32 GB. Backup storage equal to max data size is free.
-- **DTU model**: Basic (5 DTU), Standard (S0–S12), Premium (P1–P15): `1/Day` billing; compute+storage bundled
-- **Tier guide**: GP for standard workloads; BC includes zone-redundant HA in base price; Hyperscale for up to 100 TB with log-based architecture
-- **Serverless**: License-included pricing (higher per-vCore rate); no separate SQL License query needed
-- **Capacity**: vCore count determines compute capacity; double vCores for ~2× throughput
+- **Storage**: vCore GP, BC, and Hyperscale storage is billed separately for configured max size. Standard/Premium DTU storage products exist for storage beyond bundled tier limits.
+- **Backups**: PITR backup storage up to the database/max data size is included; bill overage with `SQL Database Single/Elastic Pool PITR Backup Storage`. LTR is billed separately from the first retained GB with `SQL Database - LTR Backup Storage`.
+- **DTU model**: Basic (5 DTU), Standard (S0-S12), Premium (P1-P15), and elastic pools use `1/Day` DTU/eDTU billing.
+- **Free offer**: Up to 10 General Purpose databases per subscription can use the free offer (100,000 vCore seconds, 32 GB data, 32 GB backup per month). Do not deduct unless the user explicitly selected the free offer.
+- **Tier guide**: GP for standard workloads; BC includes zone-redundant HA in base price; Hyperscale for large databases with separate storage and optional named replicas.
+- **Serverless**: Use serverless compute products for auto-pause/autoscale workloads; filter `MeterName: vCore` because zero-price `* vCore - Free` rows also exist.
+- **Capacity**: vCore count determines compute capacity; double vCores for ~2× throughput.
 
 ## Reserved Instance Pricing
 
-### RI compute (omit SkuName; unitPrice is per-vCore; swap productName for BC/Hyperscale)
-
+### RI compute (SkuName is per-vCore; swap productName for BC/Hyperscale)
 ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - Compute Gen5
+SkuName: vCore
 MeterName: vCore
 PriceType: Reservation
 
-> **Trap (RI skuName)**: RI `skuName='vCore'` (no count prefix). `-SkuName '8 vCore'` returns zero results. Calculate: `unitPrice × vCoreCount ÷ 12` (1Y) or `÷ 36` (3Y). RI prices are already license-excluded; do NOT subtract SQL License.
+> **Trap (RI skuName)**: RI `skuName='vCore'` (no count prefix). `-SkuName '8 vCore'` returns zero results. Calculate: `unitPrice × vCoreCount ÷ 12` (1Y) or `÷ 36` (3Y). RI prices are already license-excluded; do NOT subtract SQL License. For GP zone redundancy RI, use `SkuName: vCore ZR Zone Redundancy` and `MeterName: Zone Redundancy vCore`.
 
 ## Product Names
 
@@ -89,7 +107,9 @@ PriceType: Reservation
 | Hyperscale, Gen5                             | `SQL Database SingleDB/Elastic Pool Hyperscale - Compute Gen5`               |
 | Storage (General Purpose)                    | `SQL Database Single/Elastic Pool General Purpose - Storage`                 |
 | Storage (Business Critical)                  | `SQL Database Single/Elastic Pool Business Critical - Storage`               |
-| Storage (Hyperscale SingleDB)                | `SQL Database SingleDB Hyperscale - Storage`                                 |
+| Storage (Hyperscale)                         | `SQL Database SingleDB Hyperscale - Storage` / `SQL Database Hyperscale - Storage` |
+| PITR Backup Storage                          | `SQL Database Single/Elastic Pool PITR Backup Storage`                       |
+| LTR Backup Storage                           | `SQL Database - LTR Backup Storage`                                          |
 
 ## Azure Hybrid Benefit
 
@@ -97,4 +117,4 @@ ServiceName: SQL Database
 ProductName: SQL Database Single/Elastic Pool General Purpose - SQL License
 Region: Global
 
-> AHUB: compute `retailPrice` IS the AHUB rate. PAYG = compute + `sql_license_retailPrice` per vCore. **Do NOT subtract.** Swap productName for BC. See shared.md AHUB section.
+> AHUB: compute `retailPrice` IS the AHUB rate. PAYG = compute + `sql_license_retailPrice` per vCore. Do NOT subtract. Swap productName for BC or Hyperscale (`SQL Database SingleDB/Elastic Pool Hyperscale - SQL License`). See shared.md AHUB section.

--- a/skills/azure-cost-calculator/references/services/databases/sql-database.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-database.md
@@ -10,7 +10,7 @@ privateEndpoint: true
 
 # Azure SQL Database
 
-> **Trap (inflated totals)**: Omitting `SkuName` returns all vCore sizes summed. Always filter by `ProductName`, `SkuName`, and `MeterName`; the service has 39 products spanning vCore, DTU, Serverless, Elastic Pool, storage, backup, and add-ons.
+> **Trap (inflated totals)**: Omitting `SkuName` returns all vCore sizes summed. Filter `ProductName` always, plus `SkuName`/`MeterName` for multi-meter products; single-meter products like SQL License need only `ProductName`. The service has 39 products spanning vCore, DTU, Serverless, Elastic Pool, storage, backup, and add-ons.
 
 > **Trap (DTU billing)**: DTU tiers (Basic/Standard/Premium) use `unitOfMeasure: 1/Day`. The script auto-multiplies by 30 for these meters, so `MonthlyCost` is already the monthly cost.
 

--- a/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
@@ -3,13 +3,13 @@ serviceName: SQL Managed Instance
 category: databases
 aliases: [SQL MI, Azure SQL MI, Managed Instance]
 billingConsiderations: [Azure Hybrid Benefit, Reserved Instances]
-primaryCost: "vCore hourly rate × 730 + storage per-GB/month"
+primaryCost: "vCore hourly rate × 730 + storage/backup per-GB/month"
 privateEndpoint: true
 ---
 
 # Azure SQL Managed Instance
 
-> **Trap (Inflated totals)**: Omitting `SkuName` returns all vCore sizes summed in `totalMonthlyCost`. Always include `SkuName` for compute queries.
+> **Trap (Inflated totals)**: Omitting `ProductName`, `SkuName`, or `MeterName` can sum every compute size, storage, backup, and add-on meter. Always filter all three for estimates.
 
 > **Trap (Zone Redundancy)**: Zone-redundant deployments have separate meters (`Zone Redundancy vCore`) with skuNames like `8 vCore Zone Redundancy`. The ZR meter is an **additive hourly surcharge**, NOT a multiplier. Sum both hourly rates, then × 730. For GP Premium Series and GP Premium Series Memory Optimized, the generic `vCore ZR Zone Redundancy` skuName returns an anomalous near-zero rate; always use numbered ZR SKUs (e.g., `8 vCore Zone Redundancy`) for consumption queries.
 
@@ -32,6 +32,14 @@ SkuName: General Purpose
 MeterName: General Purpose Data Stored
 Quantity: 256
 
+### PITR backup over included allowance
+
+ServiceName: SQL Managed Instance
+ProductName: SQL Managed Instance PITR Backup Storage
+SkuName: Backup LRS
+MeterName: LRS Data Stored
+Quantity: 100
+
 ## Key Fields
 
 | Parameter     | How to determine                               | Example values                                                                               |
@@ -43,49 +51,61 @@ Quantity: 256
 
 ## Meter Names
 
-| Meter                                          | unitOfMeasure | Notes                              |
-| ---------------------------------------------- | ------------- | ---------------------------------- |
-| `vCore`                                        | `1 Hour`      | Compute meter for all tiers/series |
-| `Zone Redundancy vCore`                        | `1 Hour`      | Zone-redundancy compute surcharge  |
-| `General Purpose Data Stored`                  | `1 GB/Month`  | Storage for GP tier                |
-| `General Purpose Zone Redundancy Data Stored`  | `1 GB/Month`  | ZR storage for GP (2× base rate)   |
-| `Business Critical Data Stored`                | `1 GB/Month`  | Storage for BC tier                |
-| `Business Critical Zone Redundancy Data Stored`| `1 GB/Month`  | ZR storage for BC (2× base rate)   |
+| Meter                                          | unitOfMeasure | Notes                                  |
+| ---------------------------------------------- | ------------- | -------------------------------------- |
+| `vCore`                                        | `1 Hour`      | Compute meter for all tiers/series     |
+| `Zone Redundancy vCore`                        | `1 Hour`      | Zone-redundancy compute surcharge      |
+| `General Purpose Data Stored`                  | `1 GB/Month`  | Storage for GP tier                    |
+| `General Purpose Zone Redundancy Data Stored`  | `1 GB/Month`  | ZR storage for GP                      |
+| `Business Critical Data Stored`                | `1 GB/Month`  | Storage for BC tier                    |
+| `Business Critical Zone Redundancy Data Stored`| `1 GB/Month`  | ZR storage for BC                      |
+| `General Purpose IO Rate Operations`           | `1M`          | Optional IO operations                 |
+| `Business Critical IO Rate Operations`         | `1M`          | Optional IO operations                 |
+| `Additional IOPS`                              | `1 IOPS/Month`| Next-gen GP provisioned IOPS add-on    |
+| `Additional IOPS - Zone Redundant`             | `1 IOPS/Month`| ZR provisioned IOPS add-on             |
+| `Addl Memory Additional Memory`                | `1 GB/Hour`   | Optional GP additional memory          |
+| `Addl Mm Additional Memory`                    | `1 GB/Hour`   | Optional BC Premium additional memory  |
+| `LRS Data Stored`                              | `1 GB/Month`  | PITR backup over included allowance    |
+| `LTR Backup LRS Data Stored`                   | `1 GB/Month`  | LTR backup storage                     |
 
 ## Cost Formula
 ```
 compute_retailPrice = SKU-total hourly (queried with SkuName) | sql_license_retailPrice = per-vCore hourly (queried without SkuName)
 PAYG Monthly = (compute_retailPrice + sql_license_retailPrice × vCoreCount) × 730 + storage_retailPrice × sizeInGB
 AHUB Monthly = compute_retailPrice × 730 + storage_retailPrice × sizeInGB
+Monthly Backup = backup_retailPrice × billableBackupGB
+Monthly IO = (ioOperations / 1,000,000) × io_retailPrice + extraIOPS × iops_retailPrice
+Monthly Memory = memory_retailPrice × extraMemoryGB × 730
 Zone-Redundant = substitute (compute_retailPrice + zr_retailPrice) for compute_retailPrice above
 ```
 
 ## Notes
-- **Storage**: GP and BC storage billed separately per-GB. For BC, swap productName to `...Business Critical - Storage` and meterName to `Business Critical Data Stored`. PITR backup equal to max storage is free; excess uses `SQL Managed Instance PITR Backup Storage`. LTR backup uses `SQL Managed Instance - LTR Backup Storage` (LRS/ZRS/RA-GRS/RA-GZRS). GP also has `Additional IOPS` meter for provisioned IOPS beyond baseline.
-- **Tiers & Hardware**: GP/BC 4–80 vCores. BC includes In-Memory OLTP. Gen5 default; Premium Series / Memory Optimized offer newer hardware. Gen4 exists in API but is deprecated.
+- **Storage**: GP and BC storage are billed separately per configured max GB. For BC, swap productName to `...Business Critical - Storage` and meterName to `Business Critical Data Stored`.
+- **Backups**: PITR backup equal to max storage is included; bill overage with `SQL Managed Instance PITR Backup Storage`. LTR uses `SQL Managed Instance - LTR Backup Storage` with LRS/ZRS/RA-GRS/RA-GZRS variants.
+- **Next-gen GP**: Microsoft Learn says billing still reflects General Purpose; the API has no `Next` productName. Bill baseline GP compute/storage plus optional IOPS and memory add-on meters. Zone redundancy is not available.
+- **Tiers & Hardware**: GP/BC 4–80 vCores in API. BC includes In-Memory OLTP. Gen5 default; Premium Series / Memory Optimized offer newer hardware. Gen4 exists in API but is deprecated.
+- **Private endpoints**: Supported with target sub-resource `managedInstance`; SQL traffic uses port 1433 and requires hostname-based DNS.
 
 ## Reserved Instance Pricing
-### RI compute (swap productName for BC; omit SkuName; unitPrice is per-vCore)
+### RI compute (swap productName for BC; unitPrice is per-vCore)
 
 ServiceName: SQL Managed Instance
 ProductName: SQL Managed Instance General Purpose - Compute Gen5
+SkuName: vCore
 MeterName: vCore
 PriceType: Reservation
 
-> **Trap (RI skuName)**: RI uses `skuName='vCore'` (no count prefix). `-SkuName '8 vCore'` returns zero. Calculate: `unitPrice × vCoreCount ÷ 12` (1Y) or `÷ 36` (3Y).
+> **Trap (RI skuName)**: RI uses `skuName='vCore'` (no count prefix). `-SkuName '8 vCore'` returns zero. Calculate: `unitPrice × vCoreCount ÷ 12` (1Y) or `÷ 36` (3Y). For ZR RI, use `SkuName: vCore ZR Zone Redundancy` and `MeterName: Zone Redundancy vCore`. RI prices are already license-excluded; do NOT subtract SQL License.
 
 ## Azure Hybrid Benefit
-
-### SQL License meter (Global-only, per-vCore; needed for PAYG total; swap productName for BC)
-
 ServiceName: SQL Managed Instance
 ProductName: SQL Managed Instance General Purpose - SQL License
+SkuName: vCore
 Region: Global
 
-The compute meter returns the **base rate** (AHUB price). The SQL License meter is an **additive** PAYG charge; Azure bills both under PAYG, only compute under AHUB. Omit `SkuName` for the license query; it returns a per-vCore hourly rate. PAYG Monthly = `(compute_retailPrice + sql_license_retailPrice × vCoreCount) × 730 + storage`. AHUB Monthly = `compute_retailPrice × 730 + storage`. NEVER subtract. NEVER apply a percentage discount.
+> **Note**: AHUB: compute `retailPrice` IS the AHUB rate. PAYG = `(compute_retailPrice + sql_license_retailPrice × vCoreCount) × 730 + storage + backup`. Do NOT subtract. Swap `productName` for BC license.
 
 ## Product Names
-
 | Config                                          | productName                                                                        |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------- |
 | General Purpose, Gen5                           | `SQL Managed Instance General Purpose - Compute Gen5`                              |

--- a/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/databases/sql-managed-instance.md
@@ -9,7 +9,7 @@ privateEndpoint: true
 
 # Azure SQL Managed Instance
 
-> **Trap (Inflated totals)**: Omitting `ProductName`, `SkuName`, or `MeterName` can sum every compute size, storage, backup, and add-on meter. Always filter all three for estimates.
+> **Trap (Inflated totals)**: Omitting `ProductName`, `SkuName`, or `MeterName` can sum every compute size, storage, backup, and add-on meter. Filter `ProductName` always, plus `SkuName`/`MeterName` for multi-meter products (compute, storage, backup, add-ons); single-meter products like SQL License need only `ProductName`.
 
 > **Trap (Zone Redundancy)**: Zone-redundant deployments have separate meters (`Zone Redundancy vCore`) with skuNames like `8 vCore Zone Redundancy`. The ZR meter is an **additive hourly surcharge**, NOT a multiplier. Sum both hourly rates, then × 730. For GP Premium Series and GP Premium Series Memory Optimized, the generic `vCore ZR Zone Redundancy` skuName returns an anomalous near-zero rate; always use numbered ZR SKUs (e.g., `8 vCore Zone Redundancy`) for consumption queries.
 
@@ -70,7 +70,7 @@ Quantity: 100
 
 ## Cost Formula
 ```
-compute_retailPrice = SKU-total hourly (queried with SkuName) | sql_license_retailPrice = per-vCore hourly (queried without SkuName)
+compute_retailPrice = SKU-total hourly (queried with SkuName) | sql_license_retailPrice = per-vCore hourly (queried with SkuName: vCore)
 PAYG Monthly = (compute_retailPrice + sql_license_retailPrice × vCoreCount) × 730 + storage_retailPrice × sizeInGB
 AHUB Monthly = compute_retailPrice × 730 + storage_retailPrice × sizeInGB
 Monthly Backup = backup_retailPrice × billableBackupGB

--- a/tests/evals/azure-cost-calculator/tasks/databases/database-migration-service/premium-online-migration.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/databases/database-migration-service/premium-online-migration.yaml
@@ -1,0 +1,52 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:databases/database-migration-service/premium-online-migration
+name: Happy Path - Database Migration Service Premium Online Migration
+description: >
+  Tests cost estimation for Azure Database Migration Service Premium tier used
+  for an online migration. Validates that the agent filters by productName to
+  select the Premium Compute meter and returns a monthly compute cost past the
+  introductory free period.
+tags:
+  - happy-path
+  - single-service
+  - databases
+  - service:database-migration-service
+inputs:
+  prompt: "What is the monthly cost for Azure Database Migration Service Premium tier with 4 vCores for an online migration in East US, running continuously for a full month after the introductory free period has been used?"
+expected:
+  output_contains:
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Database Migration Service|DMS"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: vcore-count-acknowledged
+    config:
+      contains:
+        - "4"
+    weight: 0.5
+  - type: text
+    name: premium-tier-acknowledged
+    config:
+      contains:
+        - "Premium"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0


### PR DESCRIPTION
Refreshes all 11 database service reference files against the live Azure Retail Prices API and current Microsoft Learn documentation, following the `service-reference.md` investigation workflow (two independent pricing investigators + compliance reviewer, tiebreaker on conflict). Matches the prior per-category refreshes (#1011–#1014).

Scope is the reference `.md` files only: routing/catalog and eval tasks are unchanged. One commit per service. Each file passes `Validate-ServiceReference.ps1 -CheckAliasUniqueness -CheckRoutingFileSync`.

## Services refreshed

| Service | Key changes |
| --- | --- |
| cosmos-db-for-postgresql | Shared-serviceName trap scope, Burstable fixed-rate math, backup zero-price status, RI unitPrice/MonthlyCost trap |
| cosmos-db-garnet-cache | Total-node vCPU/disk math, persistence-only disk, v6 tier availability, shard × replication scaling |
| cosmos-db | Live unitOfMeasure values, backup/PITR/analytical storage meters, autoscale hourly-peak billing, serverless/multi-region |
| database-for-mariadb | Retirement date corrected to 19 Sep 2025, all-region pagination + zero-price reservation-artifact traps, Basic meter/storage fixes |
| database-for-mysql | IOPS/SSD v2/ZRS/autoscale I/O/accelerated-logs meters, Business Critical Ev3 tier, corrected RI product and exclusions |
| database-for-postgresql | Compute productName hyphenation fix, Premium SSD v2 / Ultra Disk / IOPS / throughput meters, series expansion, RI/HA guidance |
| database-migration-service | Standard/offline free vs legacy paid meters, private endpoint support, Premium 4-vCore grant, storage zero-price rows |
| horizondb | Public-preview status + current regions, private endpoint support, zero-price free-tier/backup-grant meters, billable-backup formula |
| redis-cache | Enterprise / Enterprise Flash / Azure Managed Redis query patterns, Managed Redis cache-instance meter, PE tier support, per-tier RI |
| sql-database | PITR/LTR backup, I/O operations, ZR storage, free offer, RI vCore skuName + GP zone-redundancy RI, Hyperscale storage/AHUB |
| sql-managed-instance | PITR/LTR backup, IO/IOPS/memory add-on meters, Next-gen GP billing clarification, RI/AHUB vCore skuName, PE sub-resource |

## Reviewer notes

- **database-for-postgresql** reverses a previously documented trap: live-API discovery found compute `productName` values have no hyphen (e.g. `General Purpose Ddsv5`, not `General Purpose - Ddsv5`). Worth a spot-check.
- **redis-cache** is at the 120-line cap; a few blank lines were trimmed in redis-cache / database-for-mysql / sql-database to stay within budget.

## Validation

All 11 files: `RESULT: PASS - All checks passed` (`-CheckAliasUniqueness -CheckRoutingFileSync`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure database pricing guidance across Cosmos DB, MySQL, PostgreSQL, MariaDB, Redis, SQL Database, SQL Managed Instance, HorizonDB, and Database Migration Service.
  * Expanded cost estimates to cover backup storage, IOPS, throughput, autoscaling, performance add-ons, private endpoints, and free allowances.
  * Clarified meter selection, product filtering, reservation pricing, regional behavior, and billing formulas.
  * Added retirement and migration guidance for MariaDB and Cosmos DB for PostgreSQL.
  * Improved guidance for backup tiers, storage persistence, node scaling, and legacy or zero-price billing meters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->