### PR TITLE
Refresh developer-tools service references against live pricing API

### DIFF
--- a/skills/azure-cost-calculator/references/services/developer-tools/app-configuration.md
+++ b/skills/azure-cost-calculator/references/services/developer-tools/app-configuration.md
@@ -50,7 +50,7 @@ MeterName: Standard Overage Operations
 | --- | --- | --- | --- |
 | `{Tier} Instance` | per tier | `1/Day` | Daily store fee; Free is zero |
 | `{Tier} Overage Operations` | Dev/Std/Prem | `1K` or `10K` | Developer: `1K`; Standard/Premium: `10K` |
-| `{Tier} Replica Instance` | Std/Prem | `1/Day` | Per additional replica |
+| `{Tier} Replica Instance` | Std/Prem | `1/Day` | Standard bills every replica; Premium: additional only |
 | `{Tier} Replica Overage Operations` | Std/Prem | `10K` | Per-replica request overage |
 | `{Tier} Replica Snapshots Overage` | Std/Prem | `1 MB/Day` | Per-replica snapshot overage; sub-cent |
 | `{Tier} Snapshots Overage` | Dev/Std/Prem | `1 MB/Day` | Sub-cent; see Known Rates |

--- a/skills/azure-cost-calculator/references/services/developer-tools/devops.md
+++ b/skills/azure-cost-calculator/references/services/developer-tools/devops.md
@@ -3,7 +3,7 @@ serviceName: Azure DevOps
 category: developer-tools
 aliases: [ADO, VSTS, Repos, Pipelines, Boards, Artifacts]
 billingConsiderations: [M365 / Windows per-user licensing]
-primaryCost: "Per-user/month license (Basic/Test Plans) + parallel jobs + Artifacts storage per-GB beyond free tier"
+primaryCost: "Per-user/month license (Basic/Test Plans) + parallel jobs (per-job or per-minute) + Artifacts storage/GB"
 pricingRegion: global
 hasKnownRates: true
 hasFreeGrant: true
@@ -11,9 +11,9 @@ hasFreeGrant: true
 
 # Azure DevOps
 
-> **Note**: All Azure DevOps meters are Global-only (`armRegionName: Global`). For Artifacts, the API returns tiered pricing; use the first tier for estimates under 10 GB.
+> **Note**: All Azure DevOps meters are Global-only (`armRegionName: Global`); always pass `Region: Global` or queries return nothing. Artifacts storage is tiered — use the first tier for estimates under 8 GB.
 
-> **Trap**: Do not confuse `Azure DevOps` (this service, the DevOps platform) with `Azure DevOps Server` (on-premises, licensed separately) or `Azure Synapse Pipelines` (data integration, separate service with consumption meters in the API).
+> **Trap (service-confusion)**: Do not confuse `Azure DevOps` (this SaaS platform) with `Azure DevOps Server` (on-premises, licensed separately) or `Azure Synapse Pipelines` (data integration, separate consumption meters). GitHub Advanced Security / Copilot "for AzDO" bill under `serviceName: GitHub`, not here.
 
 ## Query Pattern
 
@@ -33,6 +33,14 @@ MeterName: Microsoft-hosted CI/CD Concurrent Job
 Region: Global
 InstanceCount: 3
 
+### Per-minute hosted agent (pay-per-use, no parallel-job slot)
+
+ServiceName: Azure DevOps
+ProductName: Azure Pipelines
+SkuName: Linux 8-core
+MeterName: Linux 8-core Job
+Region: Global
+
 ### Artifacts storage
 
 ServiceName: Azure DevOps
@@ -44,28 +52,30 @@ Region: Global
 
 | Parameter     | How to determine        | Example values                                                                             |
 | ------------- | ----------------------- | ------------------------------------------------------------------------------------------ |
-| `serviceName` | Always `Azure DevOps`   | `Azure DevOps`                                                                             |
+| `serviceName` | Always `Azure DevOps`   | `Azure DevOps`                                                                              |
 | `productName` | Match billing component | `Azure Repos and Boards (Basic)`, `Azure Pipelines`, `Azure Test Plans`, `Azure Artifacts` |
-| `skuName`     | Varies by product       | `Basic`, `Microsoft-hosted CI/CD`, `Self-hosted CI/CD`, `Standard`                         |
-| `meterName`   | Specific meter          | `Basic User`, `Microsoft-hosted CI/CD Concurrent Job`, `Standard Data Stored`              |
+| `skuName`     | Varies by product       | `Basic`, `Microsoft-hosted CI/CD`, `Self-hosted CI/CD`, `Linux 8-core`, `Standard`         |
+| `meterName`   | Specific meter          | `Basic User`, `Microsoft-hosted CI/CD Concurrent Job`, `Linux 8-core Job`, `Standard Data Stored` |
 
 ## Meter Names
 
-| Meter                                   | productName                      | unitOfMeasure | Notes              |
-| --------------------------------------- | -------------------------------- | ------------- | ------------------ |
-| `Basic User`                            | `Azure Repos and Boards (Basic)` | `1/Month`     | Per-user license   |
-| `Standard User`                         | `Azure Test Plans`               | `1/Month`     | Test Plans license |
-| `Microsoft-hosted CI/CD Concurrent Job` | `Azure Pipelines`                | `1/Month`     | Parallel job       |
-| `Self-hosted CI/CD Concurrent Job`      | `Azure Pipelines`                | `1/Month`     | Parallel job       |
-| `Standard Data Stored`                  | `Azure Artifacts`                | `1 GB/Month`  | Tiered storage     |
+| Meter                                                       | productName                      | unitOfMeasure | Notes                              |
+| ----------------------------------------------------------- | -------------------------------- | ------------- | ---------------------------------- |
+| `Basic User`                                                | `Azure Repos and Boards (Basic)` | `1/Month`     | Per-user license                   |
+| `Standard User`                                             | `Azure Test Plans`               | `1/Month`     | Basic + Test Plans license         |
+| `Microsoft-hosted CI/CD Concurrent Job`                     | `Azure Pipelines`                | `1/Month`     | Parallel job (per-job/month)       |
+| `Self-hosted CI/CD Concurrent Job`                          | `Azure Pipelines`                | `1/Month`     | Parallel job (per-job/month)       |
+| `{Linux/Windows} {8/16}-core Job`, `macOS {Standard/XL} Job`| `Azure Pipelines`                | `1/Minute`    | Per-minute hosted agents (no slot) |
+| `Standard Data Stored`                                      | `Azure Artifacts`                | `1 GB/Month`  | Tiered storage (0/8/98/998 GB)     |
 
-> Also in API: `Advanced User` (enterprise SKU), `Microsoft-hosted CI/CD XAML` (legacy per-minute), `Cloud-Based Load Testing` (deprecated).
+> Also in API: `Advanced User` (`Azure Repos and Boards`, legacy enterprise SKU), `Microsoft-hosted CI/CD XAML` (legacy per-minute), `Cloud-Based Load Testing` (deprecated, sub-cent).
 
 ## Cost Formula
 
 ```
 Monthly = (basic_users × basic_retailPrice) + (testplan_users × testplan_retailPrice)
         + (ms_hosted_jobs × ms_hosted_retailPrice) + (self_hosted_jobs × self_hosted_retailPrice)
+        + (agent_minutes × per_minute_retailPrice)
         + max(0, artifacts_gb - 2) × artifacts_retailPrice
 ```
 
@@ -73,18 +83,19 @@ Monthly = (basic_users × basic_retailPrice) + (testplan_users × testplan_retai
 
 - **Free tier**: First 5 Basic users free, 1 MS-Hosted parallel job (1,800 min/month) free, 1 Self-Hosted parallel job free (unlimited for public projects), 2 GB Artifacts storage free
 - **Stakeholder access** is free and unlimited; provides work item tracking and dashboards only
-- Parallel jobs are billed per-job/month, not per-minute; one parallel job allows one concurrent pipeline run
-- **Artifacts tiered pricing**: 0–8 GB at first-tier rate, 8–98 GB, 98–998 GB, 998+ GB; tiers from API `tierMinimumUnits`
-- Related services billed separately: build agent VMs (if self-hosted on Azure VMs), Azure Test Plans load testing infrastructure
+- **Two pipeline billing models**: classic parallel jobs bill per-job/month (one job = one concurrent run); per-minute hosted agents (`1/Minute` SKUs, added 2026-05-01) bill only for minutes used, with no free grant and no slot to purchase
+- **Artifacts tiered pricing**: 0–8 GB first tier, then 8–98 GB, 98–998 GB, 998+ GB from API `tierMinimumUnits`; the script sums all tiers, so compute the marginal GB per bracket manually
+- Related services billed separately: self-hosted agent VMs (`Virtual Machines`), Azure Load Testing (replaces deprecated Cloud-Based Load Testing), and GitHub Advanced Security / Copilot for AzDO (`serviceName: GitHub`)
 
 ## Known Rates
 
-| Component                  | Unit           | Rate (USD) | Free Grant                            |
-| -------------------------- | -------------- | ---------- | ------------------------------------- |
-| Basic user license         | per-user/month | $6.00      | First 5 users                         |
-| Basic + Test Plans license | per-user/month | $52.00     | N/A                                   |
-| MS-Hosted parallel job     | per-job/month  | $40.00     | 1 job (1,800 min/month)               |
-| Self-Hosted parallel job   | per-job/month  | $15.00     | 1 job (unlimited for public projects) |
-| Artifacts storage          | per-GB/month   | $2.00      | 2 GB                                  |
+| Component                       | Unit           | Rate (USD) | Free Grant                            |
+| ------------------------------- | -------------- | ---------- | ------------------------------------- |
+| Basic user license              | per-user/month | $6.00      | First 5 users                         |
+| Basic + Test Plans license      | per-user/month | $52.00     | N/A                                   |
+| MS-Hosted parallel job          | per-job/month  | $40.00     | 1 job (1,800 min/month)               |
+| Self-Hosted parallel job        | per-job/month  | $15.00     | 1 job (unlimited for public projects) |
+| Per-minute agent (Linux 8-core) | per-minute     | $0.022     | None                                  |
+| Artifacts storage               | per-GB/month   | $2.00      | 2 GB                                  |
 
-> These rates match `retailPrice` values from the API. Published at the [Azure DevOps pricing page](https://azure.microsoft.com/pricing/details/devops/azure-devops-services/). For non-USD currencies, use the currency derivation method in [regions-and-currencies.md](../../regions-and-currencies.md).
+> Rates match `retailPrice` values from the API. Per-minute agents also cover Linux/Windows 16-core and macOS Standard/XL at higher rates. Published at the [Azure DevOps pricing page](https://azure.microsoft.com/pricing/details/devops/azure-devops-services/). For non-USD currencies, use the derivation method in [regions-and-currencies.md](../../regions-and-currencies.md).

--- a/skills/azure-cost-calculator/references/services/developer-tools/managed-grafana.md
+++ b/skills/azure-cost-calculator/references/services/developer-tools/managed-grafana.md
@@ -68,7 +68,7 @@ Essential Monthly = user_retailPrice × active_users
 
 ## Notes
 
-- **Essential tier (Preview, being deprecated)**: No instance charge; user-only billing. Limited to 1 workspace/subscription, 20 dashboards, 5 data sources. Being replaced by Standard tier and Azure Monitor dashboards
+- **Essential tier (deprecated)**: No new Essential workspaces can be created; retiring March 31, 2027. Existing instances still bill via the `Essential User` meter (no instance charge; user-only). Use Standard for new deployments
 - **Instance sizes**: Standard X1 (default) = 2 SUs, Standard X2 = 4 SUs. Instance size determines SU/ZRU quantity multiplier (never-assume)
 - **Active users**: Counted per Azure subscription, not per instance; includes users, service accounts, and API keys
 - **30-day free trial**: First instance free for 30 days (one per subscription). Not reflected in API pricing

--- a/tests/evals/azure-cost-calculator/tasks/developer-tools/devops/basic-users-parallel-jobs.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/developer-tools/devops/basic-users-parallel-jobs.yaml
@@ -1,0 +1,63 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:developer-tools/devops/basic-users-parallel-jobs
+name: Azure DevOps - Basic Users and Parallel Jobs
+description: >
+  Tests cost estimation for Azure DevOps combining per-user Basic licenses with
+  Microsoft-hosted parallel jobs. The counts are given as totals so the agent
+  must apply the free-grant deductions (first 5 Basic users, 1 free parallel
+  job). Validates the per-user/month and per-job/month billing models and
+  Global-only meter pricing.
+tags:
+  - happy-path
+  - single-service
+  - developer-tools
+  - service:devops
+inputs:
+  prompt: "How much would Azure DevOps cost per month for 10 Basic users and 4 Microsoft-hosted parallel jobs?"
+expected:
+  output_contains:
+    - "Assumptions"
+  output_not_contains:
+    - "730"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Azure DevOps|ADO"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: user-count-acknowledged
+    config:
+      contains:
+        - "10"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "How much would Azure DevOps cost per month for 10 Basic users and 4 Microsoft-hosted parallel jobs?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct billing model for Azure DevOps (per-user/month licenses plus per-job/month parallel jobs, not hourly).
+        (3) Applies the free grants (first 5 Basic users free, 1 Microsoft-hosted parallel job free) to the totals of 10 Basic users and 4 parallel jobs.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0


### PR DESCRIPTION
Refreshes all three `developer-tools` service references against the live Azure Retail Prices API. Each service was processed sequentially by an independent orchestrator (dual pricing investigation + compliance review + consensus), with one commit per service.

## Changes

| Service | What changed | Why |
| --- | --- | --- |
| **App Configuration** | Clarified Standard vs Premium replica billing note (`Standard bills every replica; Premium: additional only`) | Live prices verified unchanged; old note misleadingly implied Standard's first replica was free |
| **Azure DevOps** | Added new per-minute GitHub-hosted agent meters (effective 2026-05-01), fixed Artifacts tier note (8 GB, not 10 GB), clarified that GHAS/Copilot for AzDO bill under `serviceName: GitHub`; added happy-path eval task | Primary refresh driver: per-minute hosted-agent billing model was missing from the file |
| **Azure Managed Grafana** | Corrected Essential tier status to deprecated (retiring 2027-03-31, no new workspaces) per Microsoft Learn | Live meters/prices verified unchanged; only feature-availability drift |

## Investigation notes

- All three services: both independent pricing investigators reached **full agreement** on every material meter/SKU/price. No tiebreakers were required.
- Data-vs-rules conflicts: none. Existing YAML frontmatter was confirmed compliant for all three (RI correctly omitted where unavailable; `privateEndpoint`/`hasKnownRates`/`hasFreeGrant` accurate).
- Microsoft Learn cross-check drove the two feature-availability fixes (DevOps per-minute agents, Grafana Essential deprecation) where the public pricing pages lagged.

## Validation

- `Validate-ServiceReference.ps1 ... -CheckAliasUniqueness -CheckRoutingFileSync` -> **PASS** for all three files.
- `waza check` -> schema validation passed; only pre-existing repo-wide advisories remain (unrelated to this change).
- Routing map and catalog unchanged (all three already routed correctly).

## Eval coverage

- App Configuration: existing `standard-multi-instance.yaml` still valid.
- Azure DevOps: new `basic-users-parallel-jobs.yaml` (tagged `happy-path` + `service:devops`).
- Managed Grafana: existing `standard-x1-instance.yaml` still valid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Azure App Configuration replica billing for Standard and Premium tiers.
  * Updated Azure DevOps billing guidance, including hosted-agent minute pricing, pipeline models, artifact storage tiers, meters, formulas, and rates.
  * Revised Managed Grafana Essential tier guidance, including its retirement date and billing behavior.

* **Tests**
  * Added an evaluation scenario for estimating Azure DevOps costs with Basic users and Microsoft-hosted parallel jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->