### PR TITLE
docs: refresh integration service references against live api

### DIFF
--- a/skills/azure-cost-calculator/references/services/integration/api-management.md
+++ b/skills/azure-cost-calculator/references/services/integration/api-management.md
@@ -42,12 +42,12 @@ ServiceName: API Management
 SkuName: Secondary
 MeterName: Secondary Unit
 
-### Consumption tier: per-call (Quantity in 10K units: billable calls ÷ 10,000; first 1M free; no InstanceCount)
+### Consumption tier: per-call (first 1M calls free; no InstanceCount)
 
 ServiceName: API Management
 SkuName: Consumption
 MeterName: Consumption Calls
-Quantity: (billableCalls ÷ 10000)
+Quantity: 100  # 100 × 10K = 1M billable calls (beyond 1M free grant)
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/integration/api-management.md
+++ b/skills/azure-cost-calculator/references/services/integration/api-management.md
@@ -17,7 +17,7 @@ privateEndpoint: true
 
 ## Query Pattern
 
-### All tiers: substitute {Tier} from Meter Names table (InstanceCount for multi-unit)
+### Hourly tiers (Developer/Basic/Standard/Premium/Isolated/v2): substitute {Tier}, not Consumption (InstanceCount for multi-unit)
 
 ServiceName: API Management
 SkuName: {Tier}
@@ -41,6 +41,13 @@ MeterName: {Tier} Self-hosted Gateway
 ServiceName: API Management
 SkuName: Secondary
 MeterName: Secondary Unit
+
+### Consumption tier: per-call, use Quantity for call volume (do NOT use InstanceCount)
+
+ServiceName: API Management
+SkuName: Consumption
+MeterName: Consumption Calls
+Quantity: 50000
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/integration/api-management.md
+++ b/skills/azure-cost-calculator/references/services/integration/api-management.md
@@ -42,12 +42,12 @@ ServiceName: API Management
 SkuName: Secondary
 MeterName: Secondary Unit
 
-### Consumption tier: per-call, use Quantity for call volume (do NOT use InstanceCount)
+### Consumption tier: per-call (Quantity in 10K units: billable calls ÷ 10,000; first 1M free; no InstanceCount)
 
 ServiceName: API Management
 SkuName: Consumption
 MeterName: Consumption Calls
-Quantity: 50000
+Quantity: (billableCalls ÷ 10000)
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/integration/logic-apps.md
+++ b/skills/azure-cost-calculator/references/services/integration/logic-apps.md
@@ -34,6 +34,14 @@ ProductName: Logic Apps
 SkuName: Standard
 InstanceCount: 2
 
+### Standard: managed connector actions (billed under Connectors SkuName; substitute Standard/Enterprise)
+
+ServiceName: Logic Apps
+ProductName: Logic Apps
+SkuName: Connectors
+MeterName: Connectors {ConnectorType} Connector Actions
+Quantity: 10000
+
 ### Hybrid: on-premises vCPU hours
 
 ServiceName: Logic Apps
@@ -53,6 +61,8 @@ MeterName: {Tier} Unit
 | ------------------------------------------ | ------------- | ------------- | ------------------------- |
 | `Consumption Standard Connector Actions`   | `Consumption` | `1`           | Per-action                |
 | `Consumption Enterprise Connector Actions` | `Consumption` | `1`           | Per-action                |
+| `Connectors Standard Connector Actions`    | `Connectors`  | `1`           | Standard plan managed connector |
+| `Connectors Enterprise Connector Actions`  | `Connectors`  | `1`           | Standard plan managed connector |
 | `Consumption Built-in Actions`             | `Consumption` | `1`           | Tiered, first 4,000 free |
 | `Consumption Data Retention`               | `Consumption` | `1 GB/Month`  | Run history storage       |
 | `Standard vCPU Duration`                   | `Standard`    | `1 Hour`      | Per vCPU                  |
@@ -76,7 +86,7 @@ Integration Account (add-on): Monthly = retailPrice (flat monthly per tier)
 
 - **Billing unit is actions, not workflow executions**; each step counts as one action
 - Consumption: per-action, first 4,000 built-in actions/month free per subscription, auto-scales to zero
-- Standard: vCPU + memory hourly on App Service Plan (WS1–WS3); managed connector calls billed per-action under the `Connectors` SkuName (`Connectors Standard/Enterprise Connector Actions`, same rates as Consumption)
+- Standard: vCPU + memory hourly on App Service Plan (WS1–WS3); managed connector actions billed under the `Connectors` SkuName (same rates as Consumption)
 - Integration Account is a separate B2B/EDI add-on; ISE was retired Aug 31, 2024 (no new deployments), use Standard with VNet instead
 - **Private Endpoints**: Require Standard tier with VNet integration
 

--- a/skills/azure-cost-calculator/references/services/integration/logic-apps.md
+++ b/skills/azure-cost-calculator/references/services/integration/logic-apps.md
@@ -75,9 +75,9 @@ Integration Account (add-on): Monthly = retailPrice (flat monthly per tier)
 ## Notes
 
 - **Billing unit is actions, not workflow executions**; each step counts as one action
-- Consumption: per-action, first 4,000 built-in actions/month free, auto-scales to zero
-- Standard: vCPU + memory hourly on App Service Plan (WS1–WS3); connector calls billed per-action at Consumption rates (same meters)
-- Integration Account is a separate B2B/EDI add-on; ISE is deprecated. Use Standard with VNet instead
+- Consumption: per-action, first 4,000 built-in actions/month free per subscription, auto-scales to zero
+- Standard: vCPU + memory hourly on App Service Plan (WS1–WS3); managed connector calls billed per-action under the `Connectors` SkuName (`Connectors Standard/Enterprise Connector Actions`, same rates as Consumption)
+- Integration Account is a separate B2B/EDI add-on; ISE was retired Aug 31, 2024 (no new deployments), use Standard with VNet instead
 - **Private Endpoints**: Require Standard tier with VNet integration
 
 ## Standard Plan Sizes (WS)

--- a/skills/azure-cost-calculator/references/services/integration/service-bus.md
+++ b/skills/azure-cost-calculator/references/services/integration/service-bus.md
@@ -19,12 +19,12 @@ privateEndpoint: true
 
 ## Query Pattern
 
-### Basic tier: operations only (Quantity in 1M units: operations ÷ 1,000,000)
+### Basic tier: operations only (per 1M operations)
 
 ServiceName: Service Bus
 SkuName: Basic
 MeterName: Basic Messaging Operations
-Quantity: (operations ÷ 1000000)
+Quantity: 10 # 10 × 1M = 10M operations/month
 
 ### Standard tier: namespace base unit (hourly)
 

--- a/skills/azure-cost-calculator/references/services/integration/service-bus.md
+++ b/skills/azure-cost-calculator/references/services/integration/service-bus.md
@@ -19,12 +19,12 @@ privateEndpoint: true
 
 ## Query Pattern
 
-### Basic tier: operations only (per 1M; use Quantity for operation volume)
+### Basic tier: operations only (Quantity in 1M units: operations ÷ 1,000,000)
 
 ServiceName: Service Bus
 SkuName: Basic
 MeterName: Basic Messaging Operations
-Quantity: 10000000
+Quantity: (operations ÷ 1000000)
 
 ### Standard tier: namespace base unit (hourly)
 

--- a/skills/azure-cost-calculator/references/services/integration/service-bus.md
+++ b/skills/azure-cost-calculator/references/services/integration/service-bus.md
@@ -19,11 +19,12 @@ privateEndpoint: true
 
 ## Query Pattern
 
-### Basic tier: operations only (per 1M)
+### Basic tier: operations only (per 1M; use Quantity for operation volume)
 
 ServiceName: Service Bus
 SkuName: Basic
 MeterName: Basic Messaging Operations
+Quantity: 10000000
 
 ### Standard tier: namespace base unit (hourly)
 
@@ -50,6 +51,13 @@ SkuName: Premium
 MeterName: Premium Messaging Unit
 InstanceCount: 2
 
+### Premium: geo-DR replication data transfer (substitute Zone 1/2/3 per destination region)
+
+ServiceName: Service Bus
+SkuName: Geo Replication Zone 1
+MeterName: Geo Replication Zone 1 Data Transfer
+Quantity: 100
+
 ## Meter Names
 
 | Meter                              | SKU                        | unitOfMeasure | Purpose                                                  |
@@ -75,6 +83,7 @@ Standard: Monthly = baseUnit_hourly × 730
          + max(0, operations − 13M) / 1M × tiered_ops_price
          + max(0, connections − 1,000) × tiered_connection_price
 Premium:  Monthly = MU_hourly × 730 × muCount (operations + connections included)
+Geo-DR:   Monthly += replicatedGB × zone_transfer_price (Premium add-on; Zone 1/2/3 by destination)
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

Refreshes all three integration service reference files against the live Azure Retail Prices API, following the `service-reference.md` orchestration pattern: two independent `pricing-investigator` runs per service reaching consensus, plus a `compliance-reviewer` contract. Both investigators agreed on every service, so no tiebreaker was required.

One commit per service for easy review.

## Changes

| Service | Consensus (both investigators) | Change |
| --- | --- | --- |
| **API Management** | 30 meters, single `productName`, no RI | Fixed misleading "All tiers" query heading that yielded a non-existent `Consumption Unit` meter; added an explicit Consumption per-call (`Consumption Calls`) query block |
| **Logic Apps** | 19 meters, 4 `productName` values, no RI | Corrected Standard-plan managed connectors to the `Connectors` SkuName (previously described as reusing the Consumption meters); clarified the 4,000 free built-in actions grant is per Azure subscription; recorded the Aug 31 2024 ISE retirement |
| **Service Bus** | 18 meters, single `productName`, no RI | File was already accurate. Added a geo-DR replication query block + cost-formula line (previously documented in the table but not queryable); added a `Quantity` example on the Basic operations query |

## Design decision

For sub-cent services, kept the lighter **trap + `Quantity`-based query** approach rather than adding a hardcoded Known Rates table. This matches the current files and peer sub-cent references (sentinel, purview, cognitive-search) and avoids introducing stale-price liability. Applies to Logic Apps; Service Bus has no sub-cent meters.

## Documentation cross-check (Microsoft Learn)

- **API Management**: v2 self-hosted gateway meters exist in the API despite docs listing them unavailable; Isolated tier has public API prices despite "call support" note. API treated as ground truth.
- **Logic Apps**: ISE retired Aug 31 2024 but meters remain queryable; `Connectors` SkuName undocumented but live at identical rates to Consumption.
- **Service Bus**: PE is Premium-only (billed separately via Private Link); geo-DR zones use non-standard `skuName` values; no RI (verified via `PriceType: Reservation`).

## Validation

All three pass:

```
pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync
```

Eval coverage unchanged: each service already has a `happy-path` eval task, and no service names/aliases/scenarios changed.

## Not included

Both investigators flagged a niche edge case: UAE North/Central and US Government regions have no 13M free-operations grant for Service Bus Standard (different tier breakpoints). Left out to keep changes surgical; can add a one-line note on request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Azure API Management hourly-tier and consumption pricing guidance, including the correct usage quantities and meter naming.
  - Updated Logic Apps billing notes for consumption allowances, Standard managed connectors, and Integration Service Environment retirement guidance.
  - Expanded Service Bus pricing examples with messaging quantities, Premium geo-replication data transfer, and related cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->