### PR TITLE
docs: refresh iot service references against live api

### DIFF
--- a/skills/azure-cost-calculator/references/services/iot/digital-twins.md
+++ b/skills/azure-cost-calculator/references/services/iot/digital-twins.md
@@ -9,9 +9,9 @@ privateEndpoint: true
 
 # Digital Twins
 
-> **Trap (sub-cent pricing)**: All three meters return sub-cent `retailPrice` values (per 1K units). The script displays zero `MonthlyCost` for every meter; this is a rounding artifact, not the actual price. Use the Known Rates table below and calculate manually: `(quantity / 1000) × retailPrice`.
+> **Trap (sub-cent pricing)**: All three meters return sub-cent `retailPrice` values (per 1K units). Queried without `Quantity`, the script rounds `MonthlyCost` to zero; this is a rounding artifact, not the actual price. Supply `Quantity` in 1K units, or use the Known Rates table below and calculate manually: `(quantity / 1000) × retailPrice`.
 
-> **Trap (non-hourly units)**: `unitOfMeasure` is `1K` (per 1,000), not `1/Hour`. The script's `MonthlyCost` (which multiplies by 730) is meaningless. Operations are metered in 1 KB increments of response body; messages in 1 KB increments of payload; a 3 KB response counts as 3 operations.
+> **Trap (non-hourly units)**: `unitOfMeasure` is `1K` (per 1,000), not `1/Hour`. The script maps `1K` to a ×1 multiplier (not the ×730 hourly rate), so supplying `Quantity` in 1K units (e.g. `50` = 50K messages) yields the correct volume-adjusted cost with no hourly inflation. Operations are metered in 1 KB increments of response body; messages in 1 KB increments of payload; a 3 KB response counts as 3 operations.
 
 ## Query Pattern
 

--- a/skills/azure-cost-calculator/references/services/iot/iot-central.md
+++ b/skills/azure-cost-calculator/references/services/iot/iot-central.md
@@ -8,6 +8,8 @@ hasFreeGrant: true
 
 # IoT Central
 
+> **Warning**: Microsoft has announced plans to retire IoT Central; Azure IoT Hub is the recommended migration path. All pricing meters below remain live in the Retail Prices API.
+
 > **Trap (tier selection)**: All Standard tiers share `skuName: Standard`; tier is determined solely by `MeterName` (`Standard Tier 0`, `Standard Tier 1`, `Standard Tier 2`). Always filter by `MeterName` to select a specific tier.
 
 > **Trap (overage meter mismatch)**: ST0 uses `Standard Overage Messages ST0` at a higher per-1K rate, while ST1 and ST2 share `Standard Overage Messages` at a lower rate. Match the overage meter to the device tier.

--- a/skills/azure-cost-calculator/references/services/iot/maps.md
+++ b/skills/azure-cost-calculator/references/services/iot/maps.md
@@ -11,7 +11,7 @@ privateEndpoint: true
 
 > **Trap (tiered free grants)**: Most Gen2 meters return **two rows** per meterName, a free tier (`tierMinimumUnits=0`, zero price) and a paid tier. The `totalMonthlyCost` sums both rows and does not subtract free grants. Use only the paid-tier `retailPrice` and manually deduct the free grant: `max(0, transactions - freeGrant) / 1000 × retailPrice`.
 
-> **Trap (unfiltered query)**: Querying with only `ServiceName: Azure Maps` returns 69+ meters across five SKUs (Location Insights, Maps, Azure Maps Creator, Standard, Standard S1). Always filter with `SkuName` and `MeterName` to isolate specific API categories.
+> **Trap (unfiltered query)**: Querying with only `ServiceName: Azure Maps` returns 69 meters across five SKUs (Location Insights, Maps, Azure Maps Creator, Standard, Standard S1). Always filter with `SkuName` and `MeterName` to isolate specific API categories.
 
 ## Query Pattern
 

--- a/tests/evals/azure-cost-calculator/tasks/iot/iot-central/st1-device-fleet.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/iot/iot-central/st1-device-fleet.yaml
@@ -1,0 +1,66 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:iot/iot-central/st1-device-fleet
+name: Happy Path - IoT Central Standard Tier 1 Device Fleet
+description: >
+  Tests cost estimation for IoT Central Standard Tier 1 (ST1) scaled across a
+  device fleet. IoT Central bills per active device per hour (unitOfMeasure
+  1/Hour), so the monthly cost is retailPrice x 730 x billable devices, with the
+  first two devices per application free. The tier is selected by MeterName
+  (Standard Tier 1), since all Standard tiers share skuName Standard. Validates
+  that the agent isolates the correct tier meter and applies the 730-hour
+  conversion and device-count scaling.
+tags:
+  - happy-path
+  - single-service
+  - iot
+  - service:iot-central
+inputs:
+  prompt: "What is the monthly cost for Azure IoT Central with 100 Standard Tier 1 devices in East US?"
+expected:
+  output_contains:
+    - "IoT Central"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "IoT Central|iot central"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: device-count-acknowledged
+    config:
+      contains:
+        - "100"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "What is the monthly cost for Azure IoT Central with 100 Standard Tier 1 devices in East US?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct billing model for IoT Central (per-device hourly rate multiplied by 730 hours, first two devices free).
+        (3) Accounts for 100 Standard Tier 1 devices as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/iot/iot-hub/s1-multi-unit.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/iot/iot-hub/s1-multi-unit.yaml
@@ -1,0 +1,48 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:iot/iot-hub/s1-multi-unit
+name: Happy Path - IoT Hub S1 Multi-Unit
+description: >
+  Tests cost estimation for IoT Hub Standard S1 tier scaled across multiple
+  units. IoT Hub bills a per-unit monthly flat rate (unitOfMeasure 1/Month),
+  so the monthly cost is retailPrice x unit count with no 730-hour conversion.
+  Validates that the agent isolates the IoT Hub product (not Device Update or
+  DPS meters) and scales by unit count.
+tags:
+  - happy-path
+  - single-service
+  - iot
+  - service:iot-hub
+inputs:
+  prompt: "What is the monthly cost for Azure IoT Hub with 3 S1 tier units in East US?"
+expected:
+  output_contains:
+    - "IoT Hub"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "IoT Hub|iot hub"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: unit-count-acknowledged
+    config:
+      contains:
+        - "3"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/iot/notification-hubs/standard-multi-namespace.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/iot/notification-hubs/standard-multi-namespace.yaml
@@ -1,0 +1,65 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:iot/notification-hubs/standard-multi-namespace
+name: Happy Path - Notification Hubs Standard Multi-Namespace
+description: >
+  Tests cost estimation for Notification Hubs Standard tier scaled across
+  multiple namespaces. Notification Hubs bills a per-namespace monthly flat
+  rate (unitOfMeasure 1/Month), so the base monthly cost is retailPrice x
+  namespace count with no 730-hour conversion. Validates that the agent
+  isolates the Standard Unit base meter (not the tiered Standard Pushes overage
+  rows, which would inflate the total) and scales by namespace count.
+tags:
+  - happy-path
+  - single-service
+  - iot
+  - service:notification-hubs
+inputs:
+  prompt: "What is the monthly cost for Azure Notification Hubs with 2 Standard tier namespaces in East US?"
+expected:
+  output_contains:
+    - "Notification Hubs"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Notification Hubs|Push Notifications"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: namespace-count-acknowledged
+    config:
+      contains:
+        - "2"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "What is the monthly cost for Azure Notification Hubs with 2 Standard tier namespaces in East US?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct billing model for Notification Hubs (per-namespace Standard tier monthly flat rate, not summed overage tiers).
+        (3) Accounts for 2 Standard tier namespaces as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0


### PR DESCRIPTION
Refreshes all 7 IoT category service references against the live Azure Retail Prices API, continuing the ongoing per-category refresh effort (compute, containers, databases, networking, identity, integration already done).

## Method
Each service ran the full `.github/agents/service-reference.md` orchestration pattern: two independent `pricing-investigator` instances plus a `compliance-reviewer`, building consensus before any edit. **No disagreements arose on any service**, so no tiebreakers were needed; the pricing data was already accurate across the board.

## Changes (5 commits; 2 services already current)

| Service | Change |
|---|---|
| Digital Twins | Corrected `1K`-unit trap wording (script maps `1K` to a ×1 multiplier, not ×730) |
| Azure Maps | Meter-count precision in unfiltered-query trap (69+ → exactly 69) |
| IoT Hub | New happy-path eval task (`s1-multi-unit.yaml`); reference data already current |
| IoT Central | New eval task (`st1-device-fleet.yaml`) + retirement Warning; reference data already current |
| Notification Hubs | New eval task (`standard-multi-namespace.yaml`); reference data already current |
| Event Grid | Verified current against live API; no change |
| Event Hubs | Verified current against live API; no change |

## Eval coverage
Closes a pre-existing coverage gap: iot-hub, iot-central, and notification-hubs had meters but no happy-path eval task. IoT now has zero uncovered services.

## Notable
- **IoT Central retirement Warning**: added a dateless `> **Warning**` noting the announced retirement and IoT Hub migration path, while stating all meters remain live in the API. Retirement-notice URLs 404'd on crawl but the Learn migration guide and live meters are confirmed.

## Validation
- `pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync` -> PASS for every changed reference.
- `waza check` -> schema validation passed; coverage check exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Azure Digital Twins metering units, usage counting, and cost calculation behavior.
  * Added an IoT Central retirement notice and recommended Azure IoT Hub migration path.
  * Updated Azure Maps guidance to clarify meter and SKU filtering requirements.

* **Tests**
  * Added cost-estimation evaluation scenarios for IoT Central, IoT Hub, and Notification Hubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->