### PR TITLE
docs: refresh monitoring service references against live api

### DIFF
--- a/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
@@ -43,20 +43,20 @@ Quantity: 43800 # 1 test every 5 minutes from 5 locations for 730 hours
 
 ## Key Fields
 
-| Parameter     | How to determine                                       | Example values                                                                            |
-| ------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `serviceName` | Billing surface for telemetry or availability tests    | `Log Analytics`, `Azure Monitor`                                                          |
-| `productName` | Match the service billing surface                      | `Log Analytics`, `Azure Monitor`                                                          |
-| `skuName`     | PAYG logs or Standard Web Test                         | `Analytics Logs`, `Standard Web Test`                                                      |
-| `meterName`   | Ingestion, retention, or web test execution meter      | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention`, `Standard Web Test Execution` |
+| Parameter     | How to determine                                    | Example values                                                                                  |
+| ------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `serviceName` | Billing surface for telemetry or availability tests | `Log Analytics`, `Azure Monitor`                                                                |
+| `productName` | Match the service billing surface                   | `Log Analytics`, `Azure Monitor`                                                                |
+| `skuName`     | PAYG logs or Standard Web Test                      | `Analytics Logs`, `Standard Web Test`                                                           |
+| `meterName`   | Ingestion, retention, or web test execution meter   | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention`, `Standard Web Test Execution` |
 
 ## Meter Names
 
 | Meter                           | productName     | skuName             | unitOfMeasure | Notes                                          |
 | ------------------------------- | --------------- | ------------------- | ------------- | ---------------------------------------------- |
-| `Analytics Logs Data Ingestion` | `Log Analytics` | `Analytics Logs`    | `1 GB`        | Application telemetry data ingestion (tiered) |
+| `Analytics Logs Data Ingestion` | `Log Analytics` | `Analytics Logs`    | `1 GB`        | Application telemetry data ingestion (tiered)  |
 | `Analytics Logs Data Retention` | `Log Analytics` | `Analytics Logs`    | `1 GB/Month`  | Application telemetry retention beyond 90 days |
-| `Standard Web Test Execution`   | `Azure Monitor` | `Standard Web Test` | `1`           | Availability test execution (sub-cent)        |
+| `Standard Web Test Execution`   | `Azure Monitor` | `Standard Web Test` | `1`           | Availability test execution (sub-cent)         |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
@@ -78,7 +78,8 @@ The first 90 days of retention are **free** for Application Insights data (App\*
 
 ```
 Retained GB = dailyIngestionGB × chargeableDays
-where chargeableDays = max(0, retentionPeriodDays - 90)  (at steady-state)
+where dailyIngestionGB = monthlyIngestionGB / 30  (house convention: 30-day month)
+      chargeableDays   = max(0, retentionPeriodDays - 90)  (at steady-state)
 ```
 
 > **Note**: For newly created workspaces that haven't accumulated a full retention period of data, use `max(0, min(retentionPeriodDays, actualDaysOfData) - 90)`. At steady state, `actualDaysOfData` always exceeds the retention period, so the formula simplifies to `max(0, retentionPeriodDays - 90)`.

--- a/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
@@ -4,6 +4,7 @@ category: monitoring
 aliases: [App Insights, APM, Application Performance Monitoring, Application Performance, AppInsights, Azure Application Insights]
 billingNeeds: [Log Analytics, Azure Monitor]
 apiServiceName: Log Analytics
+queryServiceNames: [Azure Monitor]
 primaryCost: "Data ingestion, retention, and optional web test executions"
 hasFreeGrant: true
 privateEndpoint: true

--- a/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/application-insights.md
@@ -2,9 +2,9 @@
 serviceName: Application Insights
 category: monitoring
 aliases: [App Insights, APM, Application Performance Monitoring, Application Performance, AppInsights, Azure Application Insights]
-billingNeeds: [Log Analytics]
+billingNeeds: [Log Analytics, Azure Monitor]
 apiServiceName: Log Analytics
-primaryCost: "Data ingestion per-GB + retention (via Log Analytics workspace)"
+primaryCost: "Data ingestion, retention, and optional web test executions"
 hasFreeGrant: true
 privateEndpoint: true
 ---
@@ -14,12 +14,14 @@ privateEndpoint: true
 > **Trap**: Workspace-based Application Insights has no separate ingestion cost; all telemetry is billed through the Log Analytics workspace. If Microsoft Sentinel is enabled on the workspace (simplified pricing), App Insights ingestion is **absorbed into Sentinel meters**; do NOT add a separate App Insights or Log Analytics ingestion charge; include App Insights GB in Sentinel's `total_IsBillable_GB` instead (see `security/sentinel.md`). Classic (non-workspace-based) is deprecated.
 > **Trap (ingestion free tier)**: The first **5 GB/month** of ingestion is free per Log Analytics billing account (PAYG only). This credit does **not** apply when Sentinel simplified pricing is active on the workspace (default for workspaces created after July 2023), because ingestion shifts to Sentinel meters. Only deduct when Sentinel is NOT enabled or uses classic pricing: `billable_GB = total_GB - 5`.
 > **Trap (retention calculation)**: The first **90 days** of retention are free for Application Insights data (App\* tables). For extended retention, the chargeable window is `max(0, retentionDays - 90)`. At steady-state ingestion of X GB/day, the retained data volume is `X × max(0, retentionDays - 90)`.
+> **Trap (web test sub-cent)**: Standard Web Test Execution uses sub-cent regional rates; use `UnitPrice`/`retailPrice` from the API and multiply by execution count. Do not treat a zero-formatted `MonthlyCost` as free.
 
 ## Query Pattern
 
 ### Application Insights data ingestion (via Log Analytics workspace, tiered PAYG meter)
 
 ServiceName: Log Analytics
+ProductName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Ingestion
 Quantity: 50 # estimated GB/month
@@ -27,23 +29,34 @@ Quantity: 50 # estimated GB/month
 ### Application Insights data retention (via Log Analytics workspace)
 
 ServiceName: Log Analytics
+ProductName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Retention
 
+### Application Insights availability tests (Standard Web Test)
+
+ServiceName: Azure Monitor
+ProductName: Azure Monitor
+SkuName: Standard Web Test
+MeterName: Standard Web Test Execution
+Quantity: 43800 # 1 test every 5 minutes from 5 locations for 730 hours
+
 ## Key Fields
 
-| Parameter     | How to determine                                   | Example values                                                  |
-| ------------- | -------------------------------------------------- | --------------------------------------------------------------- |
-| `serviceName` | Fixed value - uses Log Analytics workspace pricing | `Log Analytics`                                                 |
-| `skuName`     | Fixed value for pay-as-you-go tier                 | `Analytics Logs`                                                |
-| `meterName`   | Either ingestion or retention meter                | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention` |
+| Parameter     | How to determine                                       | Example values                                                                            |
+| ------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `serviceName` | Billing surface for telemetry or availability tests    | `Log Analytics`, `Azure Monitor`                                                          |
+| `productName` | Match the service billing surface                      | `Log Analytics`, `Azure Monitor`                                                          |
+| `skuName`     | PAYG logs or Standard Web Test                         | `Analytics Logs`, `Standard Web Test`                                                      |
+| `meterName`   | Ingestion, retention, or web test execution meter      | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention`, `Standard Web Test Execution` |
 
 ## Meter Names
 
-| Meter                           | skuName          | unitOfMeasure | Notes                                          |
-| ------------------------------- | ---------------- | ------------- | ---------------------------------------------- |
-| `Analytics Logs Data Ingestion` | `Analytics Logs` | `1 GB`        | Application telemetry data ingestion (tiered) |
-| `Analytics Logs Data Retention` | `Analytics Logs` | `1 GB/Month`  | Application telemetry retention beyond 90 days |
+| Meter                           | productName     | skuName             | unitOfMeasure | Notes                                          |
+| ------------------------------- | --------------- | ------------------- | ------------- | ---------------------------------------------- |
+| `Analytics Logs Data Ingestion` | `Log Analytics` | `Analytics Logs`    | `1 GB`        | Application telemetry data ingestion (tiered) |
+| `Analytics Logs Data Retention` | `Log Analytics` | `Analytics Logs`    | `1 GB/Month`  | Application telemetry retention beyond 90 days |
+| `Standard Web Test Execution`   | `Azure Monitor` | `Standard Web Test` | `1`           | Availability test execution (sub-cent)        |
 
 ## Cost Formula
 
@@ -51,7 +64,9 @@ MeterName: Analytics Logs Data Retention
 Monthly Ingestion (no Sentinel or classic pricing) = applicable_tier_price_per_GB × max(0, estimatedGB_per_month - 5)
 Monthly Ingestion (Sentinel simplified pricing)    = absorbed into Sentinel; include App Insights GB in Sentinel's total_IsBillable_GB; see security/sentinel.md
 Monthly Retention = retention_price_per_GB × retainedGB  (retention charges start after 90 free days)
-Total = Monthly Ingestion + Monthly Retention
+Monthly Web Tests = webtest_unitPrice × executionsPerMonth
+  where executionsPerMonth = tests × locations × (730 × 60 / frequencyMinutes)
+Total = Monthly Ingestion + Monthly Retention + Monthly Web Tests
 ```
 
 ### Retention Calculation Detail
@@ -79,12 +94,12 @@ Monthly retention cost = retentionPrice × 450
 
 - Application Insights requires a Log Analytics workspace (workspace-based model)
 - Classic Application Insights (non-workspace-based) is deprecated and scheduled for retirement
-- `Analytics Logs Data Ingestion` is tiered: 0-price at tier 0, paid ingestion starts at tier 5 GB; do not trust the script `summary.totalMonthlyCost` for this meter—apply the 5 GB PAYG grant manually
+- `Analytics Logs Data Ingestion` is tiered: 0-price at tier 0, paid ingestion starts at tier 5 GB; do not trust the script `summary.totalMonthlyCost` for this meter; apply the 5 GB PAYG grant manually
 - First 5 GB/month ingestion free per billing account (PAYG only, shared with all services using the workspace); does not apply under Sentinel simplified pricing
 - First 90 days of retention included free for Application Insights data (App\* tables); other workspace tables get 31 days
 - Sampling can reduce telemetry volume and costs (e.g., 50% sampling = 50% less data ingested)
 - Typical telemetry volume per instance: 0.1–0.5 GB/month (minimal), 0.5–2 GB/month (standard), 2–10 GB/month (verbose); varies by traffic and sampling config
-- Availability tests: Standard web tests use `ServiceName: Azure Monitor`, `SkuName: Standard Web Test`, `MeterName: Standard Web Test Execution`; multi-step web tests use `ServiceName: Application Insights`, `SkuName: Basic`, `MeterName: Multi-step Web Test`
+- Availability tests: Standard web tests use `ServiceName: Azure Monitor`, `ProductName: Azure Monitor`, `SkuName: Standard Web Test`, `MeterName: Standard Web Test Execution`; multi-step web tests are legacy and use `ServiceName: Application Insights`, `SkuName: Basic`, `MeterName: Multi-step Web Test`
 - Maximum retention period: 730 days (2 years)
 - For commitment tier pricing (100+ GB/day), see `log-analytics.md` commitment tiers section
 - Private endpoints require AMPLS (Azure Monitor Private Link Scope)

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -66,7 +66,7 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 Ingestion (PAYG)  = tier2_retailPrice × max(0, estimatedGB_per_month - 5)
 Retention         = retention_retailPrice × dailyIngestionGB × max(0, retentionDays - freeDays)
   where freeDays = 90 (Sentinel enabled) or 31 (standard)
-  dailyIngestionGB = all _IsBillable=true data (grants don't reduce retention volume)
+  dailyIngestionGB = monthlyIngestionGB / 30 (30-day month); all _IsBillable=true data (grants don't reduce retention volume)
 Commitment Tier   = commitment_retailPrice × 30   # unitOfMeasure = 1/Day
 Total = Ingestion + Retention (+ Commitment Tier if applicable, replaces Ingestion)
 ```

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -10,7 +10,8 @@ privateEndpoint: true
 
 # Log Analytics
 
-> **Trap (tiered meter)**: The correct ingestion meter `'Analytics Logs Data Ingestion'` returns **two rows per region** (tiered pricing): tier 1 at `tierMinimumUnits=0` is free (first 5 GB), tier 2 at `tierMinimumUnits=5` is the charged rate. Use the tier-2 `retailPrice` for per-GB cost. The legacy meter `'Analytics Logs Data Analyzed'` lacks current tiered free/paid rows and returns near-identical legacy rates in most regions — do NOT use it.
+> **Trap (tiered meter)**: The correct ingestion meter `'Analytics Logs Data Ingestion'` returns **two rows per region** (tiered pricing): tier 1 at `tierMinimumUnits=0` is free (first 5 GB), tier 2 at `tierMinimumUnits=5` is the charged rate. Use the tier-2 `retailPrice` for per-GB cost. The legacy meter `'Analytics Logs Data Analyzed'` lacks current tiered free/paid rows and returns near-identical legacy rates in most regions; do NOT use it.
+> **Trap (legacy OMS SKUs)**: Unfiltered `ServiceName: Log Analytics` queries also return legacy `Free`, `Standard`, and `Premium` OMS SKUs alongside `Analytics Logs`. These retired SKUs are not used by current workspaces and can bypass the tiered 5 GB free grant. Always filter by `SkuName: Analytics Logs` and the specific `MeterName`.
 > **Trap (ingestion free tier)**: The first **5 GB/month** is free, **PAYG only** (not commitment tiers), per **billing account** (not per workspace). Deduct from billable total: `billable_GB = max(0, total_GB - 5)`. This free tier does NOT apply when Sentinel simplified pricing is enabled (ingestion shifts to Sentinel meters; see `security/sentinel.md`).
 > **Trap (retention calculation)**: Free retention: **90 days** (Sentinel-enabled) or **31 days** (standard). Chargeable window = `retentionDays - freeDays`. Retention volume uses ALL `_IsBillable=true` data (Defender P2 grants reduce ingestion cost but NOT retention volume).
 
@@ -19,6 +20,7 @@ privateEndpoint: true
 ### Log Analytics: pay-as-you-go ingestion (per GB, 50 GB/month example)
 
 ServiceName: Log Analytics
+ProductName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Ingestion
 Quantity: 50
@@ -28,12 +30,14 @@ Quantity: 50
 ### Log Analytics: data retention (beyond free period)
 
 ServiceName: Log Analytics
+ProductName: Log Analytics
 SkuName: Analytics Logs
 MeterName: Analytics Logs Data Retention
 
 ### Commitment tier (100+ GB/day): uses ServiceName: Azure Monitor
 
 ServiceName: Azure Monitor
+ProductName: Azure Monitor
 SkuName: 100 GB Commitment Tier
 MeterName: 100 GB Commitment Tier Capacity Reservation
 
@@ -41,18 +45,20 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 
 ## Key Fields
 
-| Parameter     | How to determine                                | Example values                                                    |
-| ------------- | ----------------------------------------------- | ----------------------------------------------------------------- |
-| `serviceName` | Fixed value for Log Analytics workspace pricing | `Log Analytics`                                                   |
-| `skuName`     | Fixed for PAYG; tier-specific for commitments   | `Analytics Logs`, `100 GB Commitment Tier`                        |
-| `meterName`   | Ingestion, retention, or commitment tier meter  | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention`  |
+| Parameter     | How to determine                                | Example values                                                   |
+| ------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
+| `serviceName` | Billing surface for workspace pricing           | `Log Analytics`, `Azure Monitor`                                 |
+| `productName` | Match the service billing surface               | `Log Analytics`, `Azure Monitor`                                 |
+| `skuName`     | Fixed for PAYG; tier-specific for commitments   | `Analytics Logs`, `100 GB Commitment Tier`                       |
+| `meterName`   | Ingestion, retention, or commitment tier meter  | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention` |
 
 ## Meter Names
 
-| Meter                           | skuName          | unitOfMeasure | Notes                                                              |
-| ------------------------------- | ---------------- | ------------- | ------------------------------------------------------------------ |
-| `Analytics Logs Data Ingestion` | `Analytics Logs` | `1 GB`        | PAYG ingestion (tiered: 0–5 GB free, >5 GB charged)               |
-| `Analytics Logs Data Retention` | `Analytics Logs` | `1 GB/Month`  | Retention beyond free period (90 days Sentinel / 31 days standard) |
+| Meter                                         | productName     | skuName                    | unitOfMeasure | Notes                                                              |
+| --------------------------------------------- | --------------- | -------------------------- | ------------- | ------------------------------------------------------------------ |
+| `Analytics Logs Data Ingestion`               | `Log Analytics` | `Analytics Logs`           | `1 GB`        | PAYG ingestion (tiered: 0–5 GB free, >5 GB charged)                |
+| `Analytics Logs Data Retention`               | `Log Analytics` | `Analytics Logs`           | `1 GB/Month`  | Retention beyond free period (90 days Sentinel / 31 days standard) |
+| `{N} GB Commitment Tier Capacity Reservation` | `Azure Monitor` | `{N} GB Commitment Tier`   | `1/Day`       | Volume discounts for 100–50000 GB/day commitments                  |
 
 ## Cost Formula
 
@@ -73,7 +79,7 @@ Total = Ingestion + Retention (+ Commitment Tier if applicable, replaces Ingesti
 - Interactive retention maximum: 730 days (2 years); long-term retention (archive): up to 12 years via `Data Archive` meter under Azure Monitor
 - Application Insights data flows into Log Analytics workspace when using workspace-based Application Insights
 - Sentinel simplified pricing workspaces: all ingestion billed via Sentinel meters; do NOT add LA ingestion; only LA retention meters apply beyond 90 days (see `security/sentinel.md`)
-- Commitment tiers (100–50000 GB/day) save ~15–36% vs PAYG; overage billed at discounted effective rate
+- Commitment tiers (100–50000 GB/day) save ~15–36% vs PAYG; query the target region because regional variance applies
 - For Defender for Cloud free data grants, see `security/defender-for-cloud.md`
 - Private endpoints require AMPLS (Azure Monitor Private Link Scope)
-- For Basic Logs, Auxiliary Logs, archive, search, restore, export, and commitment tier meters see `monitoring/monitor.md` (ServiceName: Azure Monitor)
+- For Basic Logs, Auxiliary Logs, archive, search, restore, export, data replication, log processing, and other Azure Monitor meters see `monitoring/monitor.md` (ServiceName: Azure Monitor)

--- a/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/log-analytics.md
@@ -45,20 +45,20 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 
 ## Key Fields
 
-| Parameter     | How to determine                                | Example values                                                   |
-| ------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
-| `serviceName` | Billing surface for workspace pricing           | `Log Analytics`, `Azure Monitor`                                 |
-| `productName` | Match the service billing surface               | `Log Analytics`, `Azure Monitor`                                 |
-| `skuName`     | Fixed for PAYG; tier-specific for commitments   | `Analytics Logs`, `100 GB Commitment Tier`                       |
-| `meterName`   | Ingestion, retention, or commitment tier meter  | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention` |
+| Parameter     | How to determine                               | Example values                                                   |
+| ------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| `serviceName` | Billing surface for workspace pricing          | `Log Analytics`, `Azure Monitor`                                 |
+| `productName` | Match the service billing surface              | `Log Analytics`, `Azure Monitor`                                 |
+| `skuName`     | Fixed for PAYG; tier-specific for commitments  | `Analytics Logs`, `100 GB Commitment Tier`                       |
+| `meterName`   | Ingestion, retention, or commitment tier meter | `Analytics Logs Data Ingestion`, `Analytics Logs Data Retention` |
 
 ## Meter Names
 
-| Meter                                         | productName     | skuName                    | unitOfMeasure | Notes                                                              |
-| --------------------------------------------- | --------------- | -------------------------- | ------------- | ------------------------------------------------------------------ |
-| `Analytics Logs Data Ingestion`               | `Log Analytics` | `Analytics Logs`           | `1 GB`        | PAYG ingestion (tiered: 0–5 GB free, >5 GB charged)                |
-| `Analytics Logs Data Retention`               | `Log Analytics` | `Analytics Logs`           | `1 GB/Month`  | Retention beyond free period (90 days Sentinel / 31 days standard) |
-| `{N} GB Commitment Tier Capacity Reservation` | `Azure Monitor` | `{N} GB Commitment Tier`   | `1/Day`       | Volume discounts for 100–50000 GB/day commitments                  |
+| Meter                                         | productName     | skuName                  | unitOfMeasure | Notes                                                              |
+| --------------------------------------------- | --------------- | ------------------------ | ------------- | ------------------------------------------------------------------ |
+| `Analytics Logs Data Ingestion`               | `Log Analytics` | `Analytics Logs`         | `1 GB`        | PAYG ingestion (tiered: 0–5 GB free, >5 GB charged)                |
+| `Analytics Logs Data Retention`               | `Log Analytics` | `Analytics Logs`         | `1 GB/Month`  | Retention beyond free period (90 days Sentinel / 31 days standard) |
+| `{N} GB Commitment Tier Capacity Reservation` | `Azure Monitor` | `{N} GB Commitment Tier` | `1/Day`       | Volume discounts for 100–50000 GB/day commitments                  |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/monitoring/monitor.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/monitor.md
@@ -2,45 +2,56 @@
 serviceName: Azure Monitor
 category: monitoring
 aliases: [Metrics, Alerts, Diagnostics, Platform Metrics, Basic Logs, Auxiliary Logs, Data Archive]
-primaryCost: "Log-tier ingestion per-GB + Prometheus metrics per-10M + alerts per-rule/month"
+primaryCost: "Metric samples + log ingestion/archive/search/export + alerts/notifications per unit"
 hasFreeGrant: true
 privateEndpoint: true
 ---
 
 # Azure Monitor
 
-> **Note**: This file covers custom/Prometheus metrics, log-tier meters, alerts, and notifications billed under `ServiceName: Azure Monitor`. For `ServiceName: Log Analytics` meters (Analytics Logs ingestion/retention), see `log-analytics.md`. For Application Insights, see `application-insights.md`.
+> **Note**: This file covers custom/Prometheus metrics, log-tier meters, alerts, and notifications billed under `ServiceName: Azure Monitor` and `ProductName: Azure Monitor`. For `ServiceName: Log Analytics` meters (Analytics Logs ingestion/retention), see `log-analytics.md`. For Application Insights, see `application-insights.md`.
 
 > **Trap**: Platform metrics (CPU, memory, network, etc.) emitted by Azure resources are **free**; do not include them in cost estimates. Only custom metrics and Prometheus (Azure Monitor workspace) metrics are billable.
 
 > **Trap (Data Restore minimum)**: Data Restore has a minimum of 2 TB and 12-hour duration; even restoring 1 GB incurs the 2 TB minimum charge.
 
-> **Trap (mixed units)**: Azure Monitor meters use `10M`, `1 GB`, `1 GB/Month`, `1 GB/Day`, `1/Day`, `1/Month`, `1K`, and `1` units. The script's `MonthlyCost` is only correct for hourly and `1/Day` meters; verify units before reporting costs.
+> **Trap (mixed units)**: Azure Monitor meters use `10M`, `1 GB`, `1 GB/Month`, `1 GB/Day`, `1/Day`, `1/Month`, `1K`, and `1` units. For tiered/sub-cent meters, read `unitPrice` and `tierMinimumUnits`; do not use summed totals.
 
 ## Query Pattern
 
 ### Basic Logs ingestion
 
 ServiceName: Azure Monitor
+ProductName: Azure Monitor
 SkuName: Basic Logs
 MeterName: Basic Logs Data Ingestion
 Quantity: 50
 
-### Prometheus / Azure Monitor workspace ingestion
+### Metrics / Azure Monitor workspace ingestion
 
 ServiceName: Azure Monitor
-SkuName: Metric Samples Ingested
-MeterName: Metric Samples Ingested Metric samples
+ProductName: Azure Monitor
+SkuName: Metrics ingestion
+MeterName: Metrics ingestion Metric samples
+
+### Advanced platform metrics ingestion
+
+ServiceName: Azure Monitor
+ProductName: Azure Monitor
+SkuName: Advanced Platform Metric Samples Ingested
+MeterName: Advanced Platform Metric Samples Ingested Metric samples
 
 ### Prometheus metrics queries
 
 ServiceName: Azure Monitor
+ProductName: Azure Monitor
 SkuName: Prometheus Metrics Queries
 MeterName: Prometheus Metrics Queries Metric samples
 
 ### Commitment tier (100 GB example)
 
 ServiceName: Azure Monitor
+ProductName: Azure Monitor
 SkuName: 100 GB Commitment Tier
 MeterName: 100 GB Commitment Tier Capacity Reservation
 
@@ -48,14 +59,16 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 
 ## Meter Names
 
+All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monitor`.
+
 | Meter                                         | skuName                          | unitOfMeasure | Notes                                                 |
 | --------------------------------------------- | -------------------------------- | ------------- | ----------------------------------------------------- |
-| `Metrics ingestion Metric samples`            | `Metrics ingestion`              | `10M`         | Custom metrics (preview, not yet billed)              |
-| `Metric Samples Ingested Metric samples`      | `Metric Samples Ingested`        | `10M`         | Prometheus / AMW ingestion                            |
-| `Metric Samples Processed Metric samples`     | `Metric Samples Processed`       | `10M`         | Prometheus / AMW DCR processing                       |
+| `Metrics ingestion Metric samples`            | `Metrics ingestion`              | `10M`         | Custom / Prometheus workspace metrics ingestion       |
+| `Advanced Platform Metric Samples Ingested Metric samples` | `Advanced Platform Metric Samples Ingested` | `10M` | Advanced platform metrics ingestion                   |
 | `Prometheus Metrics Queries Metric samples`   | `Prometheus Metrics Queries`     | `10M`         | PromQL query cost (sub-cent)                          |
 | `Metrics Export Metric Samples Exported`      | `Metrics Export`                 | `1K`          | Metric data export via DCE (sub-cent)                 |
 | `Native Metric Queries API Calls`             | `Native Metric Queries`          | `1K`          | Tiered: first 1M calls free                           |
+| `API Calls Standard API Call`                 | `API Calls`                      | `1`           | Tiered: first 1M calls free; paid tier is sub-cent    |
 | `Basic Logs Data Ingestion`                   | `Basic Logs`                     | `1 GB`        | ~78% cheaper than Analytics; 30-day fixed retention   |
 | `Auxiliary Logs Data Ingestion`               | `Auxiliary Logs`                 | `1 GB`        | Cheapest tier; custom tables only                     |
 | `Logs Emitted From Cloud Pipeline Data Emitted` | `Logs Emitted From Cloud Pipeline` | `1 GB`     | Cloud pipeline log emission                           |
@@ -69,31 +82,39 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 | `Data Replication Data Replicated`            | `Data Replication`               | `1 GB`        | Cross-workspace replication                           |
 | `Standard Web Test Execution`                 | `Standard Web Test`              | `1`           | Availability test execution (sub-cent)                |
 | `Alerts Metric Monitored`                     | `Alerts`                         | `1/Month`     | Tiered: first 10 signals free                         |
+| `Alerts Dynamic Threshold`                    | `Alerts`                         | `1/Month`     | Dynamic threshold metric alert signal                 |
+| `Dynamic Threshold Log Alerts`                | `Dynamic Threshold Log Alerts`   | `1/Month`     | Dynamic threshold log alert meter                     |
 | `Alerts Resource Monitored at {N} Minute Frequency` | `Alerts`                   | `1/Month`     | Log search alerts: 1/5/10/15 min frequencies          |
 | `Alerts System Log Monitored at {N} Minute Frequency` | `Alerts`                 | `1/Month`     | System log alerts: 10× Resource Monitored rate        |
+| `Emails`                                      | `Emails`                         | `1`           | Tiered: first 1K emails free                          |
+| `Notifications ITSM Connector Create/Update Event` | `Notifications`             | `1`           | Tiered: first 1K events free                          |
+| `Notifications Push Notification`             | `Notifications`                  | `1`           | Tiered: first 1K notifications free                   |
+| `Notifications Secure web hook`               | `Notifications`                  | `10`          | Tiered: first 100 notifications free                  |
+| `Notifications Web hook`                      | `Notifications`                  | `10`          | Tiered: first 10K notifications free                  |
 | `{N} GB Commitment Tier Capacity Reservation` | `{N} GB Commitment Tier`         | `1/Day`       | Volume discounts (100–50000 GB/day)                   |
 
-> **Note**: Notification meters (Emails, SMS, Voice Calls, Webhooks, Push, ITSM) also bill under Azure Monitor with tiered pricing and free grants. Query with `SkuName: Notifications`, `SkuName: Emails`, or `SkuName: SMS Country Code {N}`.
+> **Note**: SMS and voice also bill under Azure Monitor. Query `SMS Country Code {N} Notification` or `Voice Calls Voice Call Country Code {N}` for country-specific rates.
 
 ## Cost Formula
 
 ```
-Prometheus     = (samples / 10M × ingestion_retailPrice) + (samples / 10M × processing_retailPrice)
+Metrics        = samples / 10M × retailPrice (per metric SKU)
 Log Ingestion  = ingestedGB × retailPrice (per log tier: Basic, Auxiliary, Cloud Pipeline)
 Archive        = archiveGB × retailPrice (per GB/month)
-Search/Restore = scannedGB × retailPrice (per query/job)
-Alerts         = alertRules × retailPrice (per rule/month; first 10 metric signals free)
+Search         = scannedGB × retailPrice (per query/job)
+Restore        = max(restoredGB × days, 2048 × 0.5) × retailPrice
+Alerts         = max(0, metricSignals - 10) × retailPrice + logAlertRules × frequency_retailPrice
+Notifications  = max(0, events - freeGrant) / unitSize × retailPrice
 Commitment     = retailPrice × 30 (unit is 1/Day)
 ```
 
 ## Notes
 
-- **Platform metrics are free**; only custom metrics and Prometheus metrics are billable
-- **Prometheus / AMW**: Ingestion + processing are separate meters; queries are sub-cent per 10M samples
+- **Prometheus / AMW**: Ingestion and query meters are billable; `Metric Samples Processed` no longer appears in the live API
 - **Basic Logs**: Search-only (no alerts/dashboards); 30-day retention. **Auxiliary Logs**: cheapest tier; custom tables only via Logs Ingestion API
 - **Sentinel-enabled workspaces**: Basic Logs ingestion uses Sentinel meters; Auxiliary Logs remain under Azure Monitor
 - **Data Restore**: Minimum 2 TB × 12-hour duration; plan restores carefully
 - Commitment tiers (100–50000 GB/day) provide volume discounts; overage billed at effective rate
 - Alerts: metric alerts (first 10 signals free), log search alerts priced by evaluation frequency, dynamic thresholds priced per signal
-- For Log Analytics workspace ingestion/retention, see `log-analytics.md`; for Application Insights, see `application-insights.md`
+- Notifications/API calls: tiered free grants and sub-cent paid tiers require `tierMinimumUnits` handling
 - Private endpoints require AMPLS (Azure Monitor Private Link Scope)

--- a/skills/azure-cost-calculator/references/services/monitoring/monitor.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/monitor.md
@@ -83,14 +83,14 @@ All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monit
 | `Standard Web Test Execution`                              | `Standard Web Test`                         | `1`           | Availability test execution (sub-cent)              |
 | `Alerts Metric Monitored`                                  | `Alerts`                                    | `1/Month`     | Tiered: first 10 signals free                       |
 | `Alerts Dynamic Threshold`                                 | `Alerts`                                    | `1/Month`     | Dynamic threshold metric alert signal               |
-| `Dynamic Threshold Log Alerts`                             | `Dynamic Threshold Log Alerts`              | `1/Month`     | Dynamic threshold log alert meter                   |
+| `Dynamic Threshold Log Alerts`                             | `Dynamic Threshold Log Alerts`              | `1/Month`     | Returns zero price in all regions (no paid tier)    |
 | `Alerts Resource Monitored at {N} Minute Frequency`        | `Alerts`                                    | `1/Month`     | Log search alerts: 1/5/10/15 min frequencies        |
 | `Alerts System Log Monitored at {N} Minute Frequency`      | `Alerts`                                    | `1/Month`     | System log alerts: 10× Resource Monitored rate      |
 | `Emails`                                                   | `Emails`                                    | `1`           | Tiered: first 1K emails free                        |
 | `Notifications ITSM Connector Create/Update Event`         | `Notifications`                             | `1`           | Tiered: first 1K events free                        |
 | `Notifications Push Notification`                          | `Notifications`                             | `1`           | Tiered: first 1K notifications free                 |
-| `Notifications Secure web hook`                            | `Notifications`                             | `10`          | Tiered: first 100 notifications free                |
-| `Notifications Web hook`                                   | `Notifications`                             | `10`          | Tiered: first 10K notifications free                |
+| `Notifications Secure web hook`                            | `Notifications`                             | `10`          | Tiered: first 1K notifications free (100 units)     |
+| `Notifications Web hook`                                   | `Notifications`                             | `10`          | Tiered: first 100K notifications free (10K units)   |
 | `{N} GB Commitment Tier Capacity Reservation`              | `{N} GB Commitment Tier`                    | `1/Day`       | Volume discounts (100–50000 GB/day)                 |
 
 > **Note**: SMS and voice also bill under Azure Monitor. Query `SMS Country Code {N} Notification` or `Voice Calls Voice Call Country Code {N}` for country-specific rates.
@@ -100,10 +100,11 @@ All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monit
 ```
 Metrics        = samples / 10M × retailPrice (per metric SKU)
 Log Ingestion  = ingestedGB × retailPrice (per log tier: Basic, Auxiliary, Cloud Pipeline)
-Archive        = archiveGB × retailPrice (per GB/month)
-Search         = scannedGB × retailPrice (per query/job)
-Restore        = max(restoredGB × days, 2048 × 0.5) × retailPrice
-Alerts         = max(0, metricSignals - 10) × retailPrice + logAlertRules × frequency_retailPrice
+Archive/Search = GB × retailPrice (per GB/month, or per query/job scanned)
+Restore        = max(restoredGB × restoreDays, 2048 × 0.5) × retailPrice  # min 2 TB × 0.5 day (12 h)
+API Calls      = max(0, calls - 1M) / unitSize × retailPrice  # Native Metric Queries & API Calls: first 1M free
+Metric Alerts  = max(0, metricSignals - 10) × retailPrice  # static or dynamic threshold, per signal
+Log Alerts     = logAlertRules × frequency_retailPrice  # Resource/System Log at 1/5/10/15 min; System Log ≈ 10× Resource
 Notifications  = max(0, events - freeGrant) / unitSize × retailPrice
 Commitment     = retailPrice × 30 (unit is 1/Day)
 ```
@@ -113,8 +114,6 @@ Commitment     = retailPrice × 30 (unit is 1/Day)
 - **Prometheus / AMW**: Ingestion and query meters are billable; `Metric Samples Processed` no longer appears in the live API
 - **Basic Logs**: Search-only (no alerts/dashboards); 30-day retention. **Auxiliary Logs**: cheapest tier; custom tables only via Logs Ingestion API
 - **Sentinel-enabled workspaces**: Basic Logs ingestion uses Sentinel meters; Auxiliary Logs remain under Azure Monitor
-- **Data Restore**: Minimum 2 TB × 12-hour duration; plan restores carefully
 - Commitment tiers (100–50000 GB/day) provide volume discounts; overage billed at effective rate
-- Alerts: metric alerts (first 10 signals free), log search alerts priced by evaluation frequency, dynamic thresholds priced per signal
 - Notifications/API calls: tiered free grants and sub-cent paid tiers require `tierMinimumUnits` handling
 - Private endpoints require AMPLS (Azure Monitor Private Link Scope)

--- a/skills/azure-cost-calculator/references/services/monitoring/monitor.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/monitor.md
@@ -61,37 +61,37 @@ MeterName: 100 GB Commitment Tier Capacity Reservation
 
 All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monitor`.
 
-| Meter                                         | skuName                          | unitOfMeasure | Notes                                                 |
-| --------------------------------------------- | -------------------------------- | ------------- | ----------------------------------------------------- |
-| `Metrics ingestion Metric samples`            | `Metrics ingestion`              | `10M`         | Custom / Prometheus workspace metrics ingestion       |
-| `Advanced Platform Metric Samples Ingested Metric samples` | `Advanced Platform Metric Samples Ingested` | `10M` | Advanced platform metrics ingestion                   |
-| `Prometheus Metrics Queries Metric samples`   | `Prometheus Metrics Queries`     | `10M`         | PromQL query cost (sub-cent)                          |
-| `Metrics Export Metric Samples Exported`      | `Metrics Export`                 | `1K`          | Metric data export via DCE (sub-cent)                 |
-| `Native Metric Queries API Calls`             | `Native Metric Queries`          | `1K`          | Tiered: first 1M calls free                           |
-| `API Calls Standard API Call`                 | `API Calls`                      | `1`           | Tiered: first 1M calls free; paid tier is sub-cent    |
-| `Basic Logs Data Ingestion`                   | `Basic Logs`                     | `1 GB`        | ~78% cheaper than Analytics; 30-day fixed retention   |
-| `Auxiliary Logs Data Ingestion`               | `Auxiliary Logs`                 | `1 GB`        | Cheapest tier; custom tables only                     |
-| `Logs Emitted From Cloud Pipeline Data Emitted` | `Logs Emitted From Cloud Pipeline` | `1 GB`     | Cloud pipeline log emission                           |
-| `Data Archive`                                | `Data Archive`                   | `1 GB/Month`  | Long-term archive (up to 12 years)                    |
-| `Search Queries Scanned`                      | `Search Queries`                 | `1 GB`        | Query cost for Basic/Auxiliary tables                 |
-| `Search Jobs Scanned`                         | `Search Jobs`                    | `1 GB`        | Archive search job cost                               |
-| `Data Restore`                                | `Data Restore`                   | `1 GB/Day`    | Archive restore, minimum 2 TB × 12 hours              |
-| `Log Analytics data export Data Exported`     | `Log Analytics data export`      | `1 GB`        | Continuous data export                                |
-| `Platform Logs Data Processed`                | `Platform Logs`                  | `1 GB`        | Diagnostic settings → Storage/Event Hub               |
-| `Logs Processed GB`                           | `Logs Processed`                 | `1`           | DCR transformation processing                         |
-| `Data Replication Data Replicated`            | `Data Replication`               | `1 GB`        | Cross-workspace replication                           |
-| `Standard Web Test Execution`                 | `Standard Web Test`              | `1`           | Availability test execution (sub-cent)                |
-| `Alerts Metric Monitored`                     | `Alerts`                         | `1/Month`     | Tiered: first 10 signals free                         |
-| `Alerts Dynamic Threshold`                    | `Alerts`                         | `1/Month`     | Dynamic threshold metric alert signal                 |
-| `Dynamic Threshold Log Alerts`                | `Dynamic Threshold Log Alerts`   | `1/Month`     | Dynamic threshold log alert meter                     |
-| `Alerts Resource Monitored at {N} Minute Frequency` | `Alerts`                   | `1/Month`     | Log search alerts: 1/5/10/15 min frequencies          |
-| `Alerts System Log Monitored at {N} Minute Frequency` | `Alerts`                 | `1/Month`     | System log alerts: 10× Resource Monitored rate        |
-| `Emails`                                      | `Emails`                         | `1`           | Tiered: first 1K emails free                          |
-| `Notifications ITSM Connector Create/Update Event` | `Notifications`             | `1`           | Tiered: first 1K events free                          |
-| `Notifications Push Notification`             | `Notifications`                  | `1`           | Tiered: first 1K notifications free                   |
-| `Notifications Secure web hook`               | `Notifications`                  | `10`          | Tiered: first 100 notifications free                  |
-| `Notifications Web hook`                      | `Notifications`                  | `10`          | Tiered: first 10K notifications free                  |
-| `{N} GB Commitment Tier Capacity Reservation` | `{N} GB Commitment Tier`         | `1/Day`       | Volume discounts (100–50000 GB/day)                   |
+| Meter                                                      | skuName                                     | unitOfMeasure | Notes                                               |
+| ---------------------------------------------------------- | ------------------------------------------- | ------------- | --------------------------------------------------- |
+| `Metrics ingestion Metric samples`                         | `Metrics ingestion`                         | `10M`         | Custom / Prometheus workspace metrics ingestion     |
+| `Advanced Platform Metric Samples Ingested Metric samples` | `Advanced Platform Metric Samples Ingested` | `10M`         | Advanced platform metrics ingestion                 |
+| `Prometheus Metrics Queries Metric samples`                | `Prometheus Metrics Queries`                | `10M`         | PromQL query cost (sub-cent)                        |
+| `Metrics Export Metric Samples Exported`                   | `Metrics Export`                            | `1K`          | Metric data export via DCE (sub-cent)               |
+| `Native Metric Queries API Calls`                          | `Native Metric Queries`                     | `1K`          | Tiered: first 1M calls free                         |
+| `API Calls Standard API Call`                              | `API Calls`                                 | `1`           | Tiered: first 1M calls free; paid tier is sub-cent  |
+| `Basic Logs Data Ingestion`                                | `Basic Logs`                                | `1 GB`        | ~78% cheaper than Analytics; 30-day fixed retention |
+| `Auxiliary Logs Data Ingestion`                            | `Auxiliary Logs`                            | `1 GB`        | Cheapest tier; custom tables only                   |
+| `Logs Emitted From Cloud Pipeline Data Emitted`            | `Logs Emitted From Cloud Pipeline`          | `1 GB`        | Cloud pipeline log emission                         |
+| `Data Archive`                                             | `Data Archive`                              | `1 GB/Month`  | Long-term archive (up to 12 years)                  |
+| `Search Queries Scanned`                                   | `Search Queries`                            | `1 GB`        | Query cost for Basic/Auxiliary tables               |
+| `Search Jobs Scanned`                                      | `Search Jobs`                               | `1 GB`        | Archive search job cost                             |
+| `Data Restore`                                             | `Data Restore`                              | `1 GB/Day`    | Archive restore, minimum 2 TB × 12 hours            |
+| `Log Analytics data export Data Exported`                  | `Log Analytics data export`                 | `1 GB`        | Continuous data export                              |
+| `Platform Logs Data Processed`                             | `Platform Logs`                             | `1 GB`        | Diagnostic settings → Storage/Event Hub             |
+| `Logs Processed GB`                                        | `Logs Processed`                            | `1`           | DCR transformation processing                       |
+| `Data Replication Data Replicated`                         | `Data Replication`                          | `1 GB`        | Cross-workspace replication                         |
+| `Standard Web Test Execution`                              | `Standard Web Test`                         | `1`           | Availability test execution (sub-cent)              |
+| `Alerts Metric Monitored`                                  | `Alerts`                                    | `1/Month`     | Tiered: first 10 signals free                       |
+| `Alerts Dynamic Threshold`                                 | `Alerts`                                    | `1/Month`     | Dynamic threshold metric alert signal               |
+| `Dynamic Threshold Log Alerts`                             | `Dynamic Threshold Log Alerts`              | `1/Month`     | Dynamic threshold log alert meter                   |
+| `Alerts Resource Monitored at {N} Minute Frequency`        | `Alerts`                                    | `1/Month`     | Log search alerts: 1/5/10/15 min frequencies        |
+| `Alerts System Log Monitored at {N} Minute Frequency`      | `Alerts`                                    | `1/Month`     | System log alerts: 10× Resource Monitored rate      |
+| `Emails`                                                   | `Emails`                                    | `1`           | Tiered: first 1K emails free                        |
+| `Notifications ITSM Connector Create/Update Event`         | `Notifications`                             | `1`           | Tiered: first 1K events free                        |
+| `Notifications Push Notification`                          | `Notifications`                             | `1`           | Tiered: first 1K notifications free                 |
+| `Notifications Secure web hook`                            | `Notifications`                             | `10`          | Tiered: first 100 notifications free                |
+| `Notifications Web hook`                                   | `Notifications`                             | `10`          | Tiered: first 10K notifications free                |
+| `{N} GB Commitment Tier Capacity Reservation`              | `{N} GB Commitment Tier`                    | `1/Day`       | Volume discounts (100–50000 GB/day)                 |
 
 > **Note**: SMS and voice also bill under Azure Monitor. Query `SMS Country Code {N} Notification` or `Voice Calls Voice Call Country Code {N}` for country-specific rates.
 

--- a/skills/azure-cost-calculator/references/services/monitoring/monitor.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/monitor.md
@@ -82,7 +82,7 @@ All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monit
 | `Data Replication Data Replicated`                         | `Data Replication`                          | `1 GB`        | Cross-workspace replication                         |
 | `Standard Web Test Execution`                              | `Standard Web Test`                         | `1`           | Availability test execution (sub-cent)              |
 | `Alerts Metric Monitored`                                  | `Alerts`                                    | `1/Month`     | Tiered: first 10 signals free                       |
-| `Alerts Dynamic Threshold`                                 | `Alerts`                                    | `1/Month`     | Dynamic threshold metric alert signal               |
+| `Alerts Dynamic Threshold`                                 | `Alerts`                                    | `1/Month`     | Dynamic threshold metric alert; no free tier        |
 | `Dynamic Threshold Log Alerts`                             | `Dynamic Threshold Log Alerts`              | `1/Month`     | Returns zero price in all regions (no paid tier)    |
 | `Alerts Resource Monitored at {N} Minute Frequency`        | `Alerts`                                    | `1/Month`     | Log search alerts: 1/5/10/15 min frequencies        |
 | `Alerts System Log Monitored at {N} Minute Frequency`      | `Alerts`                                    | `1/Month`     | System log alerts: 10× Resource Monitored rate      |
@@ -98,14 +98,14 @@ All listed meters use `ServiceName: Azure Monitor` and `ProductName: Azure Monit
 ## Cost Formula
 
 ```
-Metrics        = samples / 10M × retailPrice (per metric SKU)
+Metrics        = samples / 10M × retailPrice (single tier, no free grant)
 Log Ingestion  = ingestedGB × retailPrice (per log tier: Basic, Auxiliary, Cloud Pipeline)
 Archive/Search = GB × retailPrice (per GB/month, or per query/job scanned)
 Restore        = max(restoredGB × restoreDays, 2048 × 0.5) × retailPrice  # min 2 TB × 0.5 day (12 h)
-API Calls      = max(0, calls - 1M) / unitSize × retailPrice  # Native Metric Queries & API Calls: first 1M free
-Metric Alerts  = max(0, metricSignals - 10) × retailPrice  # static or dynamic threshold, per signal
+Tiered meters  = max(0, rawCount / unitSize - tierMinimumUnits) × retailPrice
+                 # Metric Alerts, Emails, Notifications, API Calls: take tierMinimumUnits + retailPrice from the PAID-tier row
+                 # unitSize = numeric part of unitOfMeasure (1, 10, 1K = 1000); free grant = tierMinimumUnits × unitSize
 Log Alerts     = logAlertRules × frequency_retailPrice  # Resource/System Log at 1/5/10/15 min; System Log ≈ 10× Resource
-Notifications  = max(0, events - freeGrant) / unitSize × retailPrice
 Commitment     = retailPrice × 30 (unit is 1/Day)
 ```
 

--- a/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
@@ -36,19 +36,19 @@ Region: Global
 
 ## Key Fields
 
-| Parameter     | How to determine                     | Example values                                        |
-| ------------- | ------------------------------------ | ----------------------------------------------------- |
-| `serviceName` | Always `Azure Monitor`               | `Azure Monitor`                                       |
-| `productName` | Fixed, single product               | `Azure Monitor SCOM Managed Instance`                 |
-| `skuName`     | Tier: `Basic` (paid) or free benefit | `Basic`, `Free Benefit- Azure`                        |
-| `meterName`   | Matches the endpoint billing meter   | `Basic Endpoint`, `Free Benefit- Azure Endpoint`      |
+| Parameter     | How to determine                     | Example values                                   |
+| ------------- | ------------------------------------ | ------------------------------------------------ |
+| `serviceName` | Always `Azure Monitor`               | `Azure Monitor`                                  |
+| `productName` | Fixed, single product                | `Azure Monitor SCOM Managed Instance`            |
+| `skuName`     | Tier: `Basic` (paid) or free benefit | `Basic`, `Free Benefit- Azure`                   |
+| `meterName`   | Matches the endpoint billing meter   | `Basic Endpoint`, `Free Benefit- Azure Endpoint` |
 
 ## Meter Names
 
-| Meter                          | skuName                | unitOfMeasure | Notes                            |
-| ------------------------------ | ---------------------- | ------------- | -------------------------------- |
-| `Basic Endpoint`               | `Basic`                | `1/Month`     | Per monitored non-Azure endpoint |
-| `Free Benefit- Azure Endpoint` | `Free Benefit- Azure`  | `1/Month`     | Azure-native endpoints, free    |
+| Meter                          | skuName               | unitOfMeasure | Notes                            |
+| ------------------------------ | --------------------- | ------------- | -------------------------------- |
+| `Basic Endpoint`               | `Basic`               | `1/Month`     | Per monitored non-Azure endpoint |
+| `Free Benefit- Azure Endpoint` | `Free Benefit- Azure` | `1/Month`     | Azure-native endpoints, free     |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
+++ b/skills/azure-cost-calculator/references/services/monitoring/scom-managed-instance.md
@@ -11,7 +11,7 @@ hasFreeGrant: true
 
 # Azure SCOM Managed Instance
 
-> **Trap (serviceName)**: API `serviceName` is `Azure Monitor`, shared with all Azure Monitor products. An unfiltered query returns hundreds of unrelated meters. Always filter by `ProductName: Azure Monitor SCOM Managed Instance` to isolate SCOM MI pricing.
+> **Trap (serviceName)**: API `serviceName` is `Azure Monitor`, shared with all Azure Monitor products. An unfiltered query returns many unrelated meters. Always filter by `ProductName: Azure Monitor SCOM Managed Instance` to isolate SCOM MI pricing.
 
 > **Warning**: **Global-only pricing**: All meters use `armRegionName = 'Global'`. Standard region queries (e.g., `eastus`) return zero results. Use `Region: Global`. Prices are USD-only; for non-USD currencies, derive a conversion factor per [regions-and-currencies.md](../../regions-and-currencies.md).
 
@@ -61,6 +61,6 @@ Azure-benefit endpoints (Azure VMs connected via managed identity) incur no SCOM
 ## Notes
 
 - **Free tier**: Azure-native endpoints monitored via managed identity are free (`Free Benefit- Azure` SKU); non-Azure and on-premises endpoints billed at retailPrice per endpoint per month
-- **Platform fee only**: The per-endpoint meter covers the SCOM MI management fee only; underlying infrastructure (SQL MI, VMSS, Load Balancer, VNet, Key Vault) is billed separately under their respective Azure services
+- **Platform fee only**: The API exposes endpoint management-fee meters only; no full-stack SCOM MI compute, storage, or networking meter exists. Price SQL MI, VM/VMSS, Load Balancer, VNet, and Key Vault separately
 - **Endpoint count** is a never-assume parameter; always ask the user for the number of monitored endpoints
 - For other Azure Monitor meters (custom metrics, Basic Logs, archive), see `monitor.md`; for Log Analytics workspace pricing, see `log-analytics.md`


### PR DESCRIPTION
Refresh all four `monitoring/` service reference files against the live Azure Retail Prices API, following the `.github/agents/service-reference.md` consensus pattern (two independent `pricing-investigator` runs + `compliance-reviewer`, with a scoped tiebreaker on any disagreement). One commit per service for granular review.

## Changes per service

| Service | Summary |
| --- | --- |
| **Application Insights** | Added Azure Monitor `Standard Web Test Execution` meter + query and `ProductName` filters for Log Analytics meters; added sub-cent web-test trap and formula. Investigators disagreed only on web-test handling (resolved by tiebreaker: formal query, no Known Rates table since the API returns region-specific sub-cent `UnitPrice`). |
| **Log Analytics** | Added `ProductName` filters, a commitment-tier capacity-reservation meter row, and a legacy OMS SKU trap (`Free`/`Standard`/`Premium`); expanded the Azure Monitor cross-reference. |
| **Azure Monitor** | Removed retired `Metric Samples Ingested`/`Metric Samples Processed` SKUs; added current `Metrics ingestion`, `Advanced Platform Metric Samples Ingested`, `API Calls`, dynamic-threshold alert, and notification meters; added `ProductName` filters; corrected metrics/restore/alerts/notifications formulas. |
| **Azure SCOM Managed Instance** | Clarified that only endpoint management-fee meters exist (no full-stack SCOM compute/storage/networking meter); underlying infra billed separately. File was already accurate; wording refinements only. |

## Data-vs-rules handling
- **Authority hierarchy applied**: API evidence for what exists, Microsoft Learn for feature availability, schema/CONTRIBUTING for formatting. All case-sensitive `serviceName`/`productName`/`skuName`/`meterName` values used verbatim.
- **Drift guard (orchestrator override)**: a proposed `14.8%–36.0% in East US` commitment-tier savings figure in `log-analytics.md` was reverted to an approximate `~15–36%` range plus a regional-variance caveat, to avoid a region-snapshot number that will drift.

## Validation
`pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync` passes for all four files (`RESULT: PASS`). Line counts within the 120 limit (`monitor.md` at 120/120).

## Eval tasks
Unchanged. Existing happy-path tasks depend on meter names/query patterns that remained stable, so no task edits were required.

## Routing / catalog
Unchanged. All four services were already implemented in the routing map; `routing_file_sync` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure Application Insights guidance to include availability-test execution costs and detailed retention calculations.
  * Clarified Log Analytics ingestion and retention meter selection, tiered pricing, and filtering requirements.
  * Refined Azure Monitor pricing formulas, supported meters, alert charges, commitment tiers, and Prometheus guidance.
  * Clarified SCOM Managed Instance pricing scope and service filtering recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->