### PR TITLE
Refresh storage service references against live api

### DIFF
--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -60,7 +60,6 @@ Each entry follows the pattern: `- {display name}: {alias1}, {alias2}, ...`
 
 - Azure Elastic SAN: SAN, Block Storage
 - Azure Managed Lustre: Lustre, HPC Storage
-- Data Box Gateway: Data Box Virtual Appliance, Hybrid Data Transfer Gateway
 - Storage Actions: Storage Data Processing, Storage Task Automation, Serverless Storage Processing
 - StorSimple: Hybrid Cloud Storage, StorSimple Array, StorSimple Virtual Array
 

--- a/docs/service-catalog.md
+++ b/docs/service-catalog.md
@@ -60,7 +60,6 @@ Each entry follows the pattern: `- {display name}: {alias1}, {alias2}, ...`
 
 - Azure Elastic SAN: SAN, Block Storage
 - Azure Managed Lustre: Lustre, HPC Storage
-- Storage Actions: Storage Data Processing, Storage Task Automation, Serverless Storage Processing
 - StorSimple: Hybrid Cloud Storage, StorSimple Array, StorSimple Virtual Array
 
 ## Security (services/security/)

--- a/skills/azure-cost-calculator/references/services/storage/backup.md
+++ b/skills/azure-cost-calculator/references/services/storage/backup.md
@@ -7,56 +7,61 @@ primaryCost: "Protected instance/month (workload type) + storage per-GB/month (r
 privateEndpoint: true
 ---
 
-# Azure Backup
+# Backup
 
-> **Trap**: Unfiltered `ServiceName: Backup` returns ~36 meters across all workload types plus storage, inflating `totalMonthlyCost`. Always filter with `SkuName` for the specific workload (e.g., `Azure VM`) or storage tier (e.g., `Standard`).
+> **Trap (meter-flood)**: Unfiltered `ServiceName: Backup` returns 35+ meters across every workload type plus storage redundancy tiers, inflating `totalMonthlyCost`. Always filter by `SkuName` for the workload (e.g., `Azure VM`) and, for storage, by both `SkuName` and `MeterName` (e.g., `Standard` + `Standard LRS Data Stored`).
+
+> **Trap (productName-split)**: PAYG uses `productName: Backup` — protected-instance meters are singular (`Azure VM Protected Instance`, not `Instances`) and Standard storage meters carry the tier prefix (`Standard LRS Data Stored`). Reserved capacity uses `productName: Backup Reserved Capacity` with unprefixed storage meters (`LRS Data Stored`). Mixing these returns zero results.
 
 ## Query Pattern
 
 ### Azure VM backup: 10 protected VMs
 
 ServiceName: Backup
+ProductName: Backup
 SkuName: Azure VM
-MeterName: Azure VM Protected Instances
+MeterName: Azure VM Protected Instance
 InstanceCount: 10
 
 ### Backup storage: 500 GB LRS
 
 ServiceName: Backup
+ProductName: Backup
 SkuName: Standard
-MeterName: LRS Data Stored
+MeterName: Standard LRS Data Stored
 Quantity: 500
 
 ### SQL Server in Azure VM backup
 
 ServiceName: Backup
+ProductName: Backup
 SkuName: SQL Server in Azure VM
-MeterName: SQL Server in Azure VM Protected Instances
+MeterName: SQL Server in Azure VM Protected Instance
 
 ## Key Fields
 
 | Parameter     | How to determine                                   | Example values                                              |
 | ------------- | -------------------------------------------------- | ----------------------------------------------------------- |
 | `serviceName` | Always `Backup`                                    | `Backup`                                                    |
-| `productName` | `Backup` (PAYG) or `Backup Reserved Capacity` (RC) | `Backup`, `Backup Reserved Capacity`                        |
+| `productName` | `Backup` (PAYG) or `Backup Reserved Capacity` (RI) | `Backup`, `Backup Reserved Capacity`                        |
 | `skuName`     | Workload type or storage tier                      | `Azure VM`, `SQL Server in Azure VM`, `Standard`, `Archive` |
-| `meterName`   | Instance fee or data stored                        | `Azure VM Protected Instances`, `LRS Data Stored`           |
+| `meterName`   | Instance fee (singular) or data stored             | `Azure VM Protected Instance`, `Standard LRS Data Stored`   |
 
 ## Meter Names
 
-| Meter                                        | skuName                  | unitOfMeasure | Notes                       |
-| -------------------------------------------- | ------------------------ | ------------- | --------------------------- |
-| `Azure VM Protected Instances`               | `Azure VM`               | `1/Month`     | Per VM                      |
-| `SQL Server in Azure VM Protected Instances` | `SQL Server in Azure VM` | `1/Month`     | Per SQL instance            |
-| `SAP HANA on Azure VM Protected Instances`   | `SAP HANA on Azure VM`   | `1/Month`     | Per SAP HANA instance       |
-| `Azure Files Protected Instances`            | `Azure Files`            | `1/Month`     | Snapshot-based (no vault)   |
-| `Azure Files Vaulted Protected Instances`    | `Azure Files Vaulted`    | `1/Month`     | Vaulted backup              |
-| `On Premises Server Protected Instances`     | `On Premises Server`     | `1/Month`     | MARS agent                  |
-| `LRS Data Stored`                            | `Standard`               | `1 GB/Month`  | Standard vault storage      |
-| `GRS Data Stored`                            | `Standard`               | `1 GB/Month`  | Geo-redundant vault storage |
-| `Archive LRS Data Stored`                    | `Archive`                | `1 GB/Month`  | Archive tier LRS            |
+| Meter                                       | skuName                  | unitOfMeasure | Notes                         |
+| ------------------------------------------- | ------------------------ | ------------- | ----------------------------- |
+| `Azure VM Protected Instance`               | `Azure VM`               | `1/Month`     | Per VM                        |
+| `SQL Server in Azure VM Protected Instance` | `SQL Server in Azure VM` | `1/Month`     | Per SQL instance              |
+| `SAP HANA on Azure VM Protected Instance`   | `SAP HANA on Azure VM`   | `1/Month`     | Per SAP HANA instance         |
+| `Cosmos DB Protected Instance`              | `Cosmos DB`              | `1/Month`     | Vault backup (not native PITR) |
+| `Azure Files Vaulted Protected Instance`    | `Azure Files Vaulted`    | `1/Month`     | Vaulted Files backup          |
+| `On Premises Server Protected Instance`     | `On Premises Server`     | `1/Month`     | MARS/DPM/MABS agents          |
+| `Standard LRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Standard vault storage (LRS)  |
+| `Standard GRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Geo-redundant vault storage   |
+| `Azure Files Vaulted LRS Data Stored`       | `Azure Files Vaulted`    | `1 GB/Month`  | Vaulted Files storage         |
 
-Other workload types: `PostgreSQL`, `Azure Kubernetes`, `Azure Blob`, `ADLS Gen2 Vaulted`, `SAP ASE on Azure VM`, `Cross region for ADLS and Blobs`. ZRS and RA-GRS storage meters also available. Blob/ADLS Gen2 Vaulted also include per-10K write operation meters by redundancy.
+Other workload SKUs: `Azure Files` (snapshot, no vault storage), `Azure Kubernetes` and `AKS` (per-namespace, unit `1 Count`), `PostgreSQL`, `SAP ASE on Azure VM`, `Azure Blob`, `ADLS Gen2 Vaulted`, `Cross region for ADLS and Blobs`. `Standard` storage also exposes `ZRS`/`RA-GRS` meters; `Archive` (LRS/GRS only) offers sub-cent long-term storage with early-delete fees. `Azure Blob`/`ADLS Gen2 Vaulted` bill per-10K write operations by redundancy. Enhanced-policy workloads (SQL Server, SAP HANA) add a matching `... Snapshot Instance` meter.
 
 ## Cost Formula
 
@@ -73,15 +78,18 @@ Example: 10 VMs with 500 GB LRS storage
 
 - Storage is billed separately from the protected instance fee; always query both components
 - Redundancy options: LRS, GRS, ZRS, RA-GRS; each has a different storage rate
-- Archive tier offers lower storage cost but applies to long-term retention points only; early delete fees apply
-- Reserved capacity available via `productName = 'Backup Reserved Capacity'` for 100 TB or 1 PB commitments (1-Year / 3-Year)
-- Protected instance fees vary significantly by workload: VM/Files are lower-cost per protected instance, SQL is mid-range, and SAP HANA/ASE are among the highest-cost options
+- Protected instance fees vary by workload: VM/Files are lowest, SQL/Cosmos DB mid-range, SAP HANA/ASE highest
+- Enhanced (Instant Restore) policies for SQL Server and SAP HANA add a `... Snapshot Instance` fee plus disk-snapshot storage billed under Managed Disks (`storage/managed-disks.md`)
+- Archive tier applies to long-term retention points only (LRS/GRS); sub-cent per-GB rates and 180-day early-delete fees apply
 - First 31 days of Azure VM backup storage (up to 50 GB per VM) are free (not reflected in API)
-- **Cosmos DB vault backup vs native PITR**: Azure Backup vault protects Cosmos DB using standard vault storage meters (e.g., `LRS Data Stored` under `skuName: Standard`). There is no Cosmos DB-specific workload SKU. Do NOT confuse with Cosmos DB native PITR (`serviceName: Azure Cosmos DB`, `productName: Azure Cosmos DB - PITR`) which is ~9× more expensive per-GB; see `databases/cosmos-db.md`
+- **Cosmos DB vault backup vs native PITR**: vault backup uses `SkuName: Cosmos DB` (`Cosmos DB Protected Instance`) plus `Standard` vault storage; do NOT confuse with Cosmos DB native PITR (`serviceName: Azure Cosmos DB`, `productName: Azure Cosmos DB - PITR`), which is significantly more expensive per-GB — see `databases/cosmos-db.md`
 
 ## Reserved Instance Pricing
 
+Only vault storage capacity is reservable (100 TB or 1 PB commitments, 1-Year / 3-Year); protected instance fees are always PAYG. Reserved meters drop the tier prefix.
+
 ServiceName: Backup
 ProductName: Backup Reserved Capacity
+SkuName: Standard - 100 TB LRS
 MeterName: LRS Data Stored
 PriceType: Reservation

--- a/skills/azure-cost-calculator/references/services/storage/backup.md
+++ b/skills/azure-cost-calculator/references/services/storage/backup.md
@@ -49,17 +49,17 @@ MeterName: SQL Server in Azure VM Protected Instance
 
 ## Meter Names
 
-| Meter                                       | skuName                  | unitOfMeasure | Notes                         |
-| ------------------------------------------- | ------------------------ | ------------- | ----------------------------- |
-| `Azure VM Protected Instance`               | `Azure VM`               | `1/Month`     | Per VM                        |
-| `SQL Server in Azure VM Protected Instance` | `SQL Server in Azure VM` | `1/Month`     | Per SQL instance              |
-| `SAP HANA on Azure VM Protected Instance`   | `SAP HANA on Azure VM`   | `1/Month`     | Per SAP HANA instance         |
+| Meter                                       | skuName                  | unitOfMeasure | Notes                          |
+| ------------------------------------------- | ------------------------ | ------------- | ------------------------------ |
+| `Azure VM Protected Instance`               | `Azure VM`               | `1/Month`     | Per VM                         |
+| `SQL Server in Azure VM Protected Instance` | `SQL Server in Azure VM` | `1/Month`     | Per SQL instance               |
+| `SAP HANA on Azure VM Protected Instance`   | `SAP HANA on Azure VM`   | `1/Month`     | Per SAP HANA instance          |
 | `Cosmos DB Protected Instance`              | `Cosmos DB`              | `1/Month`     | Vault backup (not native PITR) |
-| `Azure Files Vaulted Protected Instance`    | `Azure Files Vaulted`    | `1/Month`     | Vaulted Files backup          |
-| `On Premises Server Protected Instance`     | `On Premises Server`     | `1/Month`     | MARS/DPM/MABS agents          |
-| `Standard LRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Standard vault storage (LRS)  |
-| `Standard GRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Geo-redundant vault storage   |
-| `Azure Files Vaulted LRS Data Stored`       | `Azure Files Vaulted`    | `1 GB/Month`  | Vaulted Files storage         |
+| `Azure Files Vaulted Protected Instance`    | `Azure Files Vaulted`    | `1/Month`     | Vaulted Files backup           |
+| `On Premises Server Protected Instance`     | `On Premises Server`     | `1/Month`     | MARS/DPM/MABS agents           |
+| `Standard LRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Standard vault storage (LRS)   |
+| `Standard GRS Data Stored`                  | `Standard`               | `1 GB/Month`  | Geo-redundant vault storage    |
+| `Azure Files Vaulted LRS Data Stored`       | `Azure Files Vaulted`    | `1 GB/Month`  | Vaulted Files storage          |
 
 Other workload SKUs: `Azure Files` (snapshot, no vault storage), `Azure Kubernetes` and `AKS` (per-namespace, unit `1 Count`), `PostgreSQL`, `SAP ASE on Azure VM`, `Azure Blob`, `ADLS Gen2 Vaulted`, `Cross region for ADLS and Blobs`. `Standard` storage also exposes `ZRS`/`RA-GRS` meters; `Archive` (LRS/GRS only) offers sub-cent long-term storage with early-delete fees. `Azure Blob`/`ADLS Gen2 Vaulted` bill per-10K write operations by redundancy. Enhanced-policy workloads (SQL Server, SAP HANA) add a matching `... Snapshot Instance` meter.
 

--- a/skills/azure-cost-calculator/references/services/storage/container-storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/container-storage.md
@@ -40,9 +40,9 @@ Quantity: 10240 # provisioned GiB (e.g., 10 TiB pool)
 
 ## Meter Names
 
-| Meter                       | unitOfMeasure  | Notes                          |
-| --------------------------- | -------------- | ------------------------------ |
-| `Provisioned Capacity Unit` | `1 GiB/Month`  | Orchestration fee; v1.x.x only |
+| Meter                       | unitOfMeasure | Notes                          |
+| --------------------------- | ------------- | ------------------------------ |
+| `Provisioned Capacity Unit` | `1 GiB/Month` | Orchestration fee; v1.x.x only |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/storage/container-storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/container-storage.md
@@ -10,6 +10,8 @@ hasFreeGrant: true
 
 # Azure Container Storage
 
+> **Trap (shared serviceName)**: `serviceName: Storage` is shared across Blob, Files, Managed Disks, File Sync, and Container Storage. Unfiltered queries return hundreds of unrelated meters. Always filter by `ProductName: Azure Container Storage`.
+
 > **Trap (version billing)**: v2.0.0+ has no orchestration fee; the API meter applies only to v1.x.x. For v2+, only the underlying storage costs (Managed Disks, Elastic SAN) apply.
 
 > **Trap (free tier)**: v1 includes 5 TiB free per storage pool. The API returns a flat rate with no tier structure; manually deduct: `max(0, provisionedGiB - 5120) × retailPrice`.
@@ -56,4 +58,6 @@ Total = orchestration + underlying disk cost (see managed-disks.md)
 - v1.x.x backing storage: Azure Disks, Ephemeral (NVMe/temp SSD), Elastic SAN
 - v2.0.0+ backing storage: Local NVMe, Elastic SAN only (Azure Disks not supported)
 - Orchestration meter covers management only; all data storage, IOPS, and throughput costs are billed through the underlying storage service
+- Provisioned pool size (GiB) is a never-assume parameter; confirm the intended pool size with the user before estimating
+- Global-region USD-only pricing; for non-USD currencies see [regions-and-currencies.md](../../regions-and-currencies.md)
 - Network isolation is handled through AKS cluster networking

--- a/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
@@ -25,12 +25,12 @@ Quantity: 30 # 30 days/month for monthly cost
 
 ## Key Fields
 
-| Parameter     | How to determine                               | Example values           |
-| ------------- | ---------------------------------------------- | ------------------------ |
-| `serviceName` | Always `Data Box` (shared)                     | `Data Box`               |
-| `productName` | Always `Data Box Gateway` for this sub-product | `Data Box Gateway`       |
-| `skuName`     | Always `Standard`                              | `Standard`               |
-| `meterName`   | Daily appliance fee                            | `Standard Service Fee`   |
+| Parameter     | How to determine                               | Example values         |
+| ------------- | ---------------------------------------------- | ---------------------- |
+| `serviceName` | Always `Data Box` (shared)                     | `Data Box`             |
+| `productName` | Always `Data Box Gateway` for this sub-product | `Data Box Gateway`     |
+| `skuName`     | Always `Standard`                              | `Standard`             |
+| `meterName`   | Daily appliance fee                            | `Standard Service Fee` |
 
 ## Meter Names
 

--- a/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box-gateway.md
@@ -48,6 +48,7 @@ Multiple gateways  = retailPrice × 30 × gatewayCount
 ## Notes
 
 - Single SKU (`Standard`) with one meter; no tier selection needed
+- Capacity planning: one gateway = one virtual appliance instance; scale by `gatewayCount` for multiple parallel gateways
 - Virtual appliance runs on-premises (Hyper-V or VMware); the daily fee covers the Azure management service only
 - Azure Storage charges (Blob, Files, transactions) are billed separately under `serviceName: Storage`; see `storage/storage.md`
 - Shares `serviceName: Data Box` with physical transfer devices; see `storage/data-box.md` for offline Data Box products

--- a/skills/azure-cost-calculator/references/services/storage/data-box.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box.md
@@ -42,28 +42,28 @@ Region: Global # retired product; service + extra day fees are Global-only
 
 ## Key Fields
 
-| Parameter     | How to determine                | Example values                                                             |
-| ------------- | ------------------------------- | -------------------------------------------------------------------------- |
-| `serviceName` | Always `Data Box`               | `Data Box`                                                                 |
-| `productName` | Device variant                  | `Data Box`, `Data Box V2`, `Data Box Disk`, `Data Box Heavy`               |
-| `skuName`     | Capacity tier                   | `100 TB`, `120 TB`, `525 TB`, `Standard`                                   |
+| Parameter     | How to determine               | Example values                                                             |
+| ------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `serviceName` | Always `Data Box`              | `Data Box`                                                                 |
+| `productName` | Device variant                 | `Data Box`, `Data Box V2`, `Data Box Disk`, `Data Box Heavy`               |
+| `skuName`     | Capacity tier                  | `100 TB`, `120 TB`, `525 TB`, `Standard`                                   |
 | `meterName`   | Fee component, see Meter Names | `Standard Service Fee`, `100 TB Extra Day Fee`, `Device Standard Shipping` |
 
 ## Meter Names
 
-| Meter                             | productName      | unitOfMeasure | Notes                                |
-| --------------------------------- | ---------------- | ------------- | ------------------------------------ |
-| `Standard Service Fee`            | `Data Box Disk`  | `1`           | Per order                            |
-| `Standard Daily Use Fee`          | `Data Box Disk`  | `1`           | Per disk/day; 3 included days        |
-| `Device Standard Shipping`        | `Data Box Disk`  | `1`           | Per package round-trip               |
-| `100 TB Import Service Fee`       | `Data Box`       | `1`           | Per order; 10 included days          |
-| `100 TB Extra Day Fee`            | `Data Box`       | `1/Day`       | After included days                  |
-| `100 TB Device Standard Shipping` | `Data Box`       | `1`           | Round-trip                           |
+| Meter                             | productName      | unitOfMeasure | Notes                                                  |
+| --------------------------------- | ---------------- | ------------- | ------------------------------------------------------ |
+| `Standard Service Fee`            | `Data Box Disk`  | `1`           | Per order                                              |
+| `Standard Daily Use Fee`          | `Data Box Disk`  | `1`           | Per disk/day; 3 included days                          |
+| `Device Standard Shipping`        | `Data Box Disk`  | `1`           | Per package round-trip                                 |
+| `100 TB Import Service Fee`       | `Data Box`       | `1`           | Per order; 10 included days                            |
+| `100 TB Extra Day Fee`            | `Data Box`       | `1/Day`       | After included days                                    |
+| `100 TB Device Standard Shipping` | `Data Box`       | `1`           | Round-trip                                             |
 | `120 TB Service Fee`              | `Data Box V2`    | `1`           | Absent/zero in most regions; also `525 TB Service Fee` |
-| `120 TB Extra Day Fee`            | `Data Box V2`    | `1/Day`       | Also `525 TB Extra Day Fee`          |
-| `Standard Import Service Fee`     | `Data Box Heavy` | `1`           | Per order; 20 included days          |
-| `Standard Extra Day Fee`          | `Data Box Heavy` | `1/Day`       | After included days                  |
-| `Device Standard Shipping`        | `Data Box Heavy` | `1`           | Freight round-trip                   |
+| `120 TB Extra Day Fee`            | `Data Box V2`    | `1/Day`       | Also `525 TB Extra Day Fee`                            |
+| `Standard Import Service Fee`     | `Data Box Heavy` | `1`           | Per order; 20 included days                            |
+| `Standard Extra Day Fee`          | `Data Box Heavy` | `1/Day`       | After included days                                    |
+| `Device Standard Shipping`        | `Data Box Heavy` | `1`           | Freight round-trip                                     |
 
 > **Note**: Data Box V2 has no shipping meter and no service fee in most regions (Microsoft-managed shipping is free); estimate V2 orders from the extra day fee only.
 

--- a/skills/azure-cost-calculator/references/services/storage/data-box.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-box.md
@@ -5,11 +5,13 @@ aliases: [Data Box Disk, Data Box Heavy, Import/Export]
 primaryCost: "Per-device service fee + shipping fee + daily overage beyond included days"
 ---
 
-# Azure Data Box
+# Data Box
 
-> **Trap**: serviceName is `Data Box`, NOT `Azure Data Box` (returns 0 results). Multiple productNames exist under this serviceName; always filter by `productName` to target a specific variant.
+> **Trap**: serviceName is `Data Box`, NOT `Azure Data Box` (returns 0 results). Multiple productNames — plus `Data Box Gateway`, a separate service — share this serviceName; always filter by `productName`.
 
-> **Trap (Lost/Damaged)**: Each variant includes a Lost or Damaged Device meter with very high penalty prices. Exclude these from cost estimates; they are one-time penalty charges, not recurring costs.
+> **Trap (Lost/Damaged)**: Most variants expose a Lost or Damaged Device meter with very high penalty prices (Data Box Heavy has none). Exclude these one-time penalties from cost estimates.
+
+> **Trap (Global region)**: For `Data Box` (100 TB) and `Data Box Heavy`, the service fee and extra day fee meters are priced only under `armRegionName: Global`; query the target region for shipping only.
 
 ## Query Pattern
 
@@ -24,6 +26,7 @@ InstanceCount: 3
 ServiceName: Data Box
 ProductName: Data Box
 SkuName: 100 TB
+Region: Global # service fee + extra day fee are Global-only; query region for shipping
 
 ### Data Box V2: select skuName 120 TB or 525 TB
 
@@ -35,6 +38,7 @@ SkuName: 120 TB
 
 ServiceName: Data Box
 ProductName: Data Box Heavy
+Region: Global # retired product; service + extra day fees are Global-only
 
 ## Key Fields
 
@@ -55,13 +59,13 @@ ProductName: Data Box Heavy
 | `100 TB Import Service Fee`       | `Data Box`       | `1`           | Per order; 10 included days          |
 | `100 TB Extra Day Fee`            | `Data Box`       | `1/Day`       | After included days                  |
 | `100 TB Device Standard Shipping` | `Data Box`       | `1`           | Round-trip                           |
-| `120 TB Service Fee`              | `Data Box V2`    | `1`           | Per order; also `525 TB Service Fee` |
+| `120 TB Service Fee`              | `Data Box V2`    | `1`           | Absent/zero in most regions; also `525 TB Service Fee` |
 | `120 TB Extra Day Fee`            | `Data Box V2`    | `1/Day`       | Also `525 TB Extra Day Fee`          |
 | `Standard Import Service Fee`     | `Data Box Heavy` | `1`           | Per order; 20 included days          |
 | `Standard Extra Day Fee`          | `Data Box Heavy` | `1/Day`       | After included days                  |
 | `Device Standard Shipping`        | `Data Box Heavy` | `1`           | Freight round-trip                   |
 
-Data Box V2 has no shipping meter in the API; shipping may be bundled into the service fee.
+> **Note**: Data Box V2 has no shipping meter and no service fee in most regions (Microsoft-managed shipping is free); estimate V2 orders from the extra day fee only.
 
 ## Cost Formula
 
@@ -75,7 +79,7 @@ Multi-device = Per order × deviceCount
 
 - Included days before overage: Disk = 3, Data Box 100 TB = 10, V2 120 TB = 10, Heavy = 20, V2 525 TB = 20
 - Data Box Disk capacity: 8 TB usable per disk, up to 5 disks per order (40 TB max)
-- Data Box V2 (120 TB / 525 TB) is the newer generation with higher overage rates
+- Data Box V2 (120 TB / 525 TB) is the current generation; Data Box Heavy is retired (no new orders) and the 100 TB device is being phased out where V2 is available
 - Export orders use the same device fees; Azure Bandwidth egress charges are billed separately
 - Shipping prices vary by region; always filter by the correct armRegionName
-- Data Box Gateway (virtual appliance with daily compute charges) shares this serviceName but is not an offline transfer device
+- Data Box Gateway (virtual appliance with daily compute charges) shares this serviceName but is a separate service; see `storage/data-box-gateway.md`

--- a/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
@@ -66,8 +66,8 @@ MeterName: Cold LRS Data Stored
 | Meter                            | skuName         | unitOfMeasure | Notes                                         |
 | -------------------------------- | --------------- | ------------- | --------------------------------------------- |
 | `Hot LRS Data Stored`            | `Hot LRS`       | `1 GB/Month`  | Tiered (0-50 TB / 50-500 TB / 500+ TB)        |
-| `Hot LRS Index`                  | `Hot LRS`       | `1 GB/Month`  | HNS only, directory metadata cost            |
-| `Hot Write Operations`           | `Hot LRS`       | `10K`         | LRS only: no suffix; ZRS/GRS/GZRS use suffix   |
+| `Hot LRS Index`                  | `Hot LRS`       | `1 GB/Month`  | HNS only, directory metadata cost             |
+| `Hot Write Operations`           | `Hot LRS`       | `10K`         | LRS only: no suffix; ZRS/GRS/GZRS use suffix  |
 | `Hot GRS Write Operations`       | `Hot GRS`       | `10K`         | GRS/RA-GRS shared                             |
 | `Hot Read Operations`            | _(any Hot)_     | `10K`         | Generic, not redundancy-specific              |
 | `Hot Other Operations`           | _(any Hot)_     | `10K`         | Metadata ops (GetProperties, SetMetadata)     |

--- a/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/data-lake-storage.md
@@ -17,6 +17,8 @@ privateEndpoint: true
 
 > **Trap (Tiered Calculation)**: Do NOT multiply the tier-1 rate by the full volume. The API returns separate rows with `tierMinimumUnits` 0, 51200, 512000; each rate applies only to GB within that band. Using a single rate for all GB over-charges large volumes.
 
+> **Trap (Sub-cent Operations)**: Many operation meters and Archive/Cold storage meters return sub-cent `retailPrice`; the script may round the display to zero. Never report zero cost — use the API `retailPrice` directly. `Hot Iterative Write Operations` uses a `100` unit (per-100, not per-10K); divide the op count by 100.
+
 ## Query Pattern
 
 Template: `ServiceName: Storage`, `ProductName: Azure Data Lake Storage Gen2 Hierarchical Namespace`, `SkuName: {Tier} {Redundancy}`, `MeterName: {see Meter Names}`
@@ -65,7 +67,7 @@ MeterName: Cold LRS Data Stored
 | -------------------------------- | --------------- | ------------- | --------------------------------------------- |
 | `Hot LRS Data Stored`            | `Hot LRS`       | `1 GB/Month`  | Tiered (0-50 TB / 50-500 TB / 500+ TB)        |
 | `Hot LRS Index`                  | `Hot LRS`       | `1 GB/Month`  | HNS only, directory metadata cost            |
-| `Hot Write Operations`           | `Hot LRS`       | `10K`         | LRS/ZRS: no redundancy suffix                 |
+| `Hot Write Operations`           | `Hot LRS`       | `10K`         | LRS only: no suffix; ZRS/GRS/GZRS use suffix   |
 | `Hot GRS Write Operations`       | `Hot GRS`       | `10K`         | GRS/RA-GRS shared                             |
 | `Hot Read Operations`            | _(any Hot)_     | `10K`         | Generic, not redundancy-specific              |
 | `Hot Other Operations`           | _(any Hot)_     | `10K`         | Metadata ops (GetProperties, SetMetadata)     |
@@ -93,7 +95,17 @@ Monthly = Σ(storage_retailPrice × GB_in_tier)
 
 ## Notes
 
-- Archive tier: LRS, GRS, RA-GRS only (no ZRS/GZRS); Early Delete charges: Cool 30d, Cold 90d, Archive 180d
+- Archive tier: LRS, GRS, RA-GRS only (no ZRS/GZRS); Early Delete charges: Cool 30d, Cold 90d, Archive 180d. Cool GZRS/RA-GZRS have no Early Delete meter
 - Iterative operations: per-100 unit for writes (Rename ops), per-10K for reads (listing); Hot tier only
 - Flat Namespace product has identical storage pricing but no Index meter and lower transaction costs
-- **Private Endpoints**: sub-resources `dfs` and `blob` (never-assume)
+- Storage bills in binary GiB: the API `1 GB/Month` unit is 1 GiB (2³⁰ bytes), so 1 TB = 1,024 billing GB (per the ADLS pricing page)
+- **Private Endpoints**: sub-resources `dfs` and `blob` (never-assume); see `networking/private-link.md` for PE and DNS zone pricing
+
+## Reserved Instance Pricing
+
+Azure Storage reserved capacity discounts ADLS Gen2 Hot/Cool/Archive data at 100 TB, 1 PB, or 10 PB commitments (1-Year and 3-Year terms; set via `reservationTerm`). Billed under the `Storage Reserved Capacity` product (not the PAYG productName); the reservation applies automatically to eligible usage. Reservation `retailPrice` is the total commitment cost, not a per-month rate.
+
+ServiceName: Storage
+ProductName: Storage Reserved Capacity
+SkuName: Hot - 100 TB LRS
+PriceType: Reservation

--- a/skills/azure-cost-calculator/references/services/storage/file-sync.md
+++ b/skills/azure-cost-calculator/references/services/storage/file-sync.md
@@ -51,5 +51,5 @@ Where `serverCount` is total registered servers; first server is free per Storag
 - Azure Files storage, transactions, and data transfer are billed separately under `serviceName: Storage` with Azure Files product names; see `storage/storage.md`
 - Cloud tiering does not have a separate meter; recall operations generate Azure Files transactions and outbound data transfer charges
 - Prices vary by region (up to ~2.3× the base rate); always query the user's region
-- US Gov regions may lack the `Standard Server - Free` meter; free grant may not apply in government cloud
+- US Gov regions (`usgovarizona`, `usgovtexas`, `usgovvirginia`) lack the `Standard Server - Free` meter; every server is billable there, so use `Monthly = serverCount × retailPrice` (no free grant)
 - Private endpoints supported on the Storage Sync Service resource; see `networking/private-link.md` for PE and DNS zone pricing

--- a/skills/azure-cost-calculator/references/services/storage/managed-disks.md
+++ b/skills/azure-cost-calculator/references/services/storage/managed-disks.md
@@ -12,6 +12,7 @@ privateEndpoint: true
 > **Trap (two-meter)**: Premium SSD returns **both** "Disk" and "Disk Mount" meters; you MUST sum both. Mount fee alone is ~5% of cost; using only mount fee = ~20× underestimate. Standard SSD returns 3 meters (Disk + Disk Mount + Operations per 10K). Standard HDD returns 2 (Disk + Operations, no mount fee). Query each meter by `MeterName` and sum with correct scaling; do not rely on `summary.totalMonthlyCost`.
 
 > **Trap (Premium SSD v2)**: API returns two rows each for IOPS and Throughput; one at zero (free tier), one at paid rate. Use non-zero `retailPrice` and subtract: `max(0, IOPS - 3000)`, `max(0, MBps - 125)`.
+
 > **Trap (Ultra vCPU)**: Ultra Disk has a 4th meter `Ultra LRS Reservation per vCPU Provisioned`; per vCPU on the attached VM.
 
 ## Query Pattern
@@ -41,7 +42,13 @@ ServiceName: Storage
 SkuName: Premium LRS
 ProductName: Azure Premium SSD v2
 
-> **Note**: For ZRS, replace `LRS` with `ZRS` in SkuName (Premium/Standard SSD only). Standard HDD uses `ProductName: Standard HDD Managed Disks`, `SkuName: S{Size} LRS`.
+### Standard HDD (e.g., S30 LRS): LRS only, no mount fee (Disk + Operations)
+
+ServiceName: Storage
+SkuName: S30 LRS
+ProductName: Standard HDD Managed Disks
+
+> **Note**: For ZRS, replace `LRS` with `ZRS` in SkuName (Premium/Standard SSD only; Standard HDD and Ultra disk tiers are LRS-only).
 
 ## Key Fields
 

--- a/skills/azure-cost-calculator/references/services/storage/managed-disks.md
+++ b/skills/azure-cost-calculator/references/services/storage/managed-disks.md
@@ -52,22 +52,22 @@ ProductName: Standard HDD Managed Disks
 
 ## Key Fields
 
-| Parameter     | How to determine            | Example values                                                                                                                  |
-| ------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `serviceName` | Always `Storage`            | `Storage`                                                                                                                       |
+| Parameter     | How to determine            | Example values                                                                                                                 |
+| ------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `serviceName` | Always `Storage`            | `Storage`                                                                                                                      |
 | `productName` | Disk type                   | `Premium SSD Managed Disks`, `Standard SSD Managed Disks`, `Standard HDD Managed Disks`, `Ultra Disks`, `Azure Premium SSD v2` |
-| `skuName`     | {Prefix}{Size} {Redundancy} | `P30 LRS`, `P30 ZRS`, `E30 LRS`, `S30 LRS`, `Ultra LRS`, `Premium LRS`                                                        |
+| `skuName`     | {Prefix}{Size} {Redundancy} | `P30 LRS`, `P30 ZRS`, `E30 LRS`, `S30 LRS`, `Ultra LRS`, `Premium LRS`                                                         |
 | `meterName`   | Meter type per disk         | `P30 LRS Disk`, `P30 LRS Disk Mount`, `E30 LRS Disk Operations`                                                                |
 
 ## Meter Names
 
-| Disk Type      |                          Meters                          | Mount | Operations    |
+| Disk Type      |                          Meters                          | Mount |  Operations   |
 | -------------- | :------------------------------------------------------: | :---: | :-----------: |
 | Premium SSD    |                    Disk + Disk Mount                     |  YES  |      NO       |
-| Standard SSD   | Disk + Disk Mount + Disk Operations (E4+; E1–E3 no Ops) |  YES  | YES (per 10K) |
+| Standard SSD   | Disk + Disk Mount + Disk Operations (E4+; E1–E3 no Ops)  |  YES  | YES (per 10K) |
 | Standard HDD   |                  Disk + Disk Operations                  |  NO   | YES (per 10K) |
-| Ultra Disk     |  Provisioned Capacity, IOPS, Throughput, vCPU Reservation |  -   |       -       |
-| Premium SSD v2 |        Provisioned Capacity, IOPS, Throughput            |   -   |       -       |
+| Ultra Disk     | Provisioned Capacity, IOPS, Throughput, vCPU Reservation |   -   |       -       |
+| Premium SSD v2 |          Provisioned Capacity, IOPS, Throughput          |   -   |       -       |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/storage/netapp-files.md
+++ b/skills/azure-cost-calculator/references/services/storage/netapp-files.md
@@ -58,18 +58,18 @@ MeterName: Backup Capacity
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| ----- | ------- | ------------- | ----- |
-| `Standard Capacity` | `Standard` | `1 GiB/Hour` | × 730 for monthly |
-| `Premium Capacity` | `Premium` | `1 GiB/Hour` | × 730 for monthly |
-| `Ultra Capacity` | `Ultra` | `1 GiB/Hour` | × 730 for monthly |
-| `Backup Capacity` | `Backup` | `1 GiB/Month` | No × 730 needed |
-| `Volume Restore Capacity` | `Volume Restore` | `1 GiB` | One-time per restore |
-| `Elastic Zone Redundant Storage Capacity` | `Elastic Zone Redundant Storage` | `1 GiB/Hour` | Preview; × 730 for monthly |
-| `Standard Storage with Cool Access Capacity` | `Standard Storage with Cool Access` | `1 GiB/Hour` | Cool tier at-rest |
-| `Standard Storage with Cool Access Data Transfer` | `Standard Storage with Cool Access` | `1 GiB` | Per-transfer to/from cool |
-| `Flexible Service Level Capacity` | `Flexible Service Level` | `1 GiB/Hour` | Capacity component |
-| `Flexible Service Level Throughput MiBps` | `Flexible Service Level` | `1/Hour` | Beyond 128 MiBps free |
+| Meter                                             | skuName                             | unitOfMeasure | Notes                      |
+| ------------------------------------------------- | ----------------------------------- | ------------- | -------------------------- |
+| `Standard Capacity`                               | `Standard`                          | `1 GiB/Hour`  | × 730 for monthly          |
+| `Premium Capacity`                                | `Premium`                           | `1 GiB/Hour`  | × 730 for monthly          |
+| `Ultra Capacity`                                  | `Ultra`                             | `1 GiB/Hour`  | × 730 for monthly          |
+| `Backup Capacity`                                 | `Backup`                            | `1 GiB/Month` | No × 730 needed            |
+| `Volume Restore Capacity`                         | `Volume Restore`                    | `1 GiB`       | One-time per restore       |
+| `Elastic Zone Redundant Storage Capacity`         | `Elastic Zone Redundant Storage`    | `1 GiB/Hour`  | Preview; × 730 for monthly |
+| `Standard Storage with Cool Access Capacity`      | `Standard Storage with Cool Access` | `1 GiB/Hour`  | Cool tier at-rest          |
+| `Standard Storage with Cool Access Data Transfer` | `Standard Storage with Cool Access` | `1 GiB`       | Per-transfer to/from cool  |
+| `Flexible Service Level Capacity`                 | `Flexible Service Level`            | `1 GiB/Hour`  | Capacity component         |
+| `Flexible Service Level Throughput MiBps`         | `Flexible Service Level`            | `1/Hour`      | Beyond 128 MiBps free      |
 
 ## Cost Formula
 
@@ -91,12 +91,12 @@ CRR:      Monthly = crr_retailPrice × replicatedGiB   (per GiB replicated; NOT 
 
 ## Known Rates
 
-| Meter | Unit | Published Rate (USD) | Monthly per GiB |
-| ----- | ---- | -------------------- | --------------- |
-| `Standard Capacity` | 1 GiB/Hour | $0.000202 | ~$0.15 |
-| `Premium Capacity` | 1 GiB/Hour | $0.000403 | ~$0.29 |
-| `Ultra Capacity` | 1 GiB/Hour | $0.000538 | ~$0.39 |
-| `Backup Capacity` | 1 GiB/Month | $0.05 | $0.05 |
+| Meter               | Unit        | Published Rate (USD) | Monthly per GiB |
+| ------------------- | ----------- | -------------------- | --------------- |
+| `Standard Capacity` | 1 GiB/Hour  | $0.000202            | ~$0.15          |
+| `Premium Capacity`  | 1 GiB/Hour  | $0.000403            | ~$0.29          |
+| `Ultra Capacity`    | 1 GiB/Hour  | $0.000538            | ~$0.39          |
+| `Backup Capacity`   | 1 GiB/Month | $0.05                | $0.05           |
 
 > These rates are from the Azure Retail Prices API (eastus). The script shows `$0.00` for capacity meters because `1 GiB/Hour` is not recognized as hourly. Multiply `retailPrice × GiB × 730` manually. For non-USD currencies, see [regions-and-currencies.md](../../regions-and-currencies.md).
 

--- a/skills/azure-cost-calculator/references/services/storage/netapp-files.md
+++ b/skills/azure-cost-calculator/references/services/storage/netapp-files.md
@@ -32,6 +32,14 @@ SkuName: Premium
 MeterName: Premium Capacity
 Quantity: 2048
 
+### Flexible tier (capacity + throughput beyond 128 MiBps free)
+
+ServiceName: Azure NetApp Files
+ProductName: Azure NetApp Files
+SkuName: Flexible Service Level
+MeterName: Flexible Service Level Capacity
+Quantity: 4096
+
 ### Backup storage
 
 ServiceName: Azure NetApp Files
@@ -69,14 +77,16 @@ MeterName: Backup Capacity
 Capacity: Monthly = retailPrice × provisionedGiB × 730
 Backup:   Monthly = backup_retailPrice × backupGiB
 Flexible: Monthly = capacity_price × GiB × 730 + max(0, MiBps - 128) × throughput_price × 730
+CRR:      Monthly = crr_retailPrice × replicatedGiB   (per GiB replicated; NOT × 730)
 ```
 
 ## Notes
 
 - Billing is on **provisioned capacity pool size**, not consumed (min 1 TiB, 1 TiB increments); snapshots consume pool capacity at the pool's tier rate
+- Sizes are set in TiB but billed in **GiB** (1 TiB = 1,024 GiB); if a user says "TB" for capacity, treat as TiB and convert ×1,024
 - Standard/Premium/Ultra/Flexible/Elastic ZRS differ in throughput/IOPS; tier is a never-assume parameter
-- Double Encrypted variants: `SkuName: {Tier} Double Encrypted` (~19–21% surcharge)
-- CRR meters: two naming patterns (`CRR -` and `Cross Region Replication -`), region-pair-specific, Days/Hours/Minutes frequency
+- Double Encrypted variants: `SkuName: {Tier} Double Encrypted` (~19–21% surcharge); not RI-eligible
+- CRR meters: two naming patterns (`CRR -` and `Cross Region Replication -`) plus generic `Cross Region Replication`, region-pair-specific, Days/Hours/Minutes frequency; despite `1 GiB/Hour` unit, price is **per GiB replicated per month** (×1, NOT × 730)
 - Network isolation uses **delegated subnets** (`Microsoft.NetApp/volumes`), not Private Link; no PE support
 
 ## Known Rates

--- a/skills/azure-cost-calculator/references/services/storage/storage-actions.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage-actions.md
@@ -41,21 +41,21 @@ Quantity: 2 # millions of operations invoked per month
 
 ## Key Fields
 
-| Parameter     | How to determine                           | Example values                                |
-| ------------- | ------------------------------------------ | --------------------------------------------- |
-| `serviceName` | Always `Storage` (shared serviceName)      | `Storage`                                     |
-| `productName` | Always `Storage Actions`                   | `Storage Actions`                             |
-| `skuName`     | Always `Azure Storage Tasks`               | `Azure Storage Tasks`                         |
-| `meterName`   | Billing dimension, see Meter Names        | `Azure Storage Tasks Task Execution`          |
+| Parameter     | How to determine                      | Example values                       |
+| ------------- | ------------------------------------- | ------------------------------------ |
+| `serviceName` | Always `Storage` (shared serviceName) | `Storage`                            |
+| `productName` | Always `Storage Actions`              | `Storage Actions`                    |
+| `skuName`     | Always `Azure Storage Tasks`          | `Azure Storage Tasks`                |
+| `meterName`   | Billing dimension, see Meter Names    | `Azure Storage Tasks Task Execution` |
 
 ## Meter Names
 
-| Meter                                       | unitOfMeasure | Notes                          |
-| ------------------------------------------- | ------------- | ------------------------------ |
-| `Azure Storage Tasks Task Execution`        | `1`           | Per task execution instance    |
-| `Azure Storage Tasks Objects Targeted`      | `1M`          | Per million objects evaluated  |
-| `Azure Storage Tasks Operations Invoked`    | `1M`          | Per million operations on objects |
-| `Azure Storage Tasks Objects Operated On`   | `1M`          | API-only; not on pricing page — exclude |
+| Meter                                     | unitOfMeasure | Notes                                   |
+| ----------------------------------------- | ------------- | --------------------------------------- |
+| `Azure Storage Tasks Task Execution`      | `1`           | Per task execution instance             |
+| `Azure Storage Tasks Objects Targeted`    | `1M`          | Per million objects evaluated           |
+| `Azure Storage Tasks Operations Invoked`  | `1M`          | Per million operations on objects       |
+| `Azure Storage Tasks Objects Operated On` | `1M`          | API-only; not on pricing page — exclude |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/storage/storage-actions.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage-actions.md
@@ -11,6 +11,8 @@ primaryCost: "Per task execution + per million objects targeted + per million op
 
 > **Trap (multi-meter)**: Storage Actions has three independent billing dimensions. Query each meter separately with explicit `MeterName` and set `Quantity` to actual monthly usage. Do not rely on `totalMonthlyCost` from an unfiltered query; it sums all meters which is meaningless for independent dimensions.
 
+> **Trap (phantom-meter)**: The API returns a fourth meter `Azure Storage Tasks Objects Operated On` that is not on the Azure pricing page and has no defined rate (zero-priced or absent in many regions). Exclude it from estimates; it is not a real billing dimension.
+
 ## Query Pattern
 
 ### Task execution: 100 runs/month
@@ -53,6 +55,7 @@ Quantity: 2 # millions of operations invoked per month
 | `Azure Storage Tasks Task Execution`        | `1`           | Per task execution instance    |
 | `Azure Storage Tasks Objects Targeted`      | `1M`          | Per million objects evaluated  |
 | `Azure Storage Tasks Operations Invoked`    | `1M`          | Per million operations on objects |
+| `Azure Storage Tasks Objects Operated On`   | `1M`          | API-only; not on pricing page — exclude |
 
 ## Cost Formula
 
@@ -68,4 +71,3 @@ Monthly = (executions × exec_retailPrice)
 - No charge for composing/saving task definitions or validating tasks via preview
 - Prices are uniform across all regions for the three core meters; region choice does not affect Storage Actions cost (but underlying storage costs vary by region)
 - Capacity planning: each task execution targets a set of objects (containers/blobs matching filter conditions) and invokes operations on matched objects; estimate all three dimensions
-- The API returns a fourth meter (`Azure Storage Tasks Objects Operated On`) not listed on the pricing page; exclude it from estimates

--- a/skills/azure-cost-calculator/references/services/storage/storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage.md
@@ -7,7 +7,7 @@ primaryCost: "Data stored per-GB/month (tiered) + operations per-10K + data retr
 privateEndpoint: true
 ---
 
-# Storage Accounts (Blob)
+# Storage
 
 > **Trap**: `productName = 'Blob Storage'` only covers **LRS/GRS/RA-GRS**. For ZRS/GZRS/RA-GZRS use `productName = 'General Block Blob v2'`; wrong productName returns zero results.
 
@@ -89,12 +89,27 @@ Monthly = Σ(retailPrice × GB_in_tier) + (readOps/10K × readPrice)
 - Early delete: Cool 30d, Cold 90d, Archive 180d; rate equals data stored rate, prorated
 - Archive tier: LRS/GRS/RA-GRS only (no ZRS/GZRS/RA-GZRS); Cold tier has no Reserved Instances
 - PE sub-resources (never-assume): `blob`, `file`, `queue`, `table`, `dfs`, `web`. Secondary variants (`blob_secondary`, etc.) for RA-GRS/RA-GZRS.
-- Azure Files, Table, and Queue use distinct `productName` values under `serviceName: Storage`; query each sub-product separately
+- Sub-products (see Product Names): Files ops use `LRS Write/Read/Protocol Operations` + a separate `LRS Metadata` (per-GB) meter; Tables (`Write/Read/Scan Operations`) and Queues (`Class 1 Operations`, `Class 2 Operations`) are sub-cent per-10K. Legacy `Files`/`Queues` productNames apply to GPv1 accounts
+
+## Reserved Instance Pricing
+
+Reserved capacity discounts Blob (Hot/Cool/Archive) and Azure Files data at fixed commitments (Blob: 100 TB / 1 PB / 10 PB; Files: 10 TB / 100 TB), 1-Year or 3-Year terms (set via `reservationTerm`). Billed under `Storage Reserved Capacity` (Blob), `Files Reserved Capacity`, or `Premium Files Reserved Capacity` — distinct from PAYG productNames. Not available for Cold tier, Tables, or Queues.
+
+> **Trap (RI MonthlyCost)**: The script's `MonthlyCost` is wrong for Reservation items; it multiplies the full term price by 730. Calculate `unitPrice ÷ 12` (1-Year) or `unitPrice ÷ 36` (3-Year).
+
+ServiceName: Storage
+ProductName: Storage Reserved Capacity
+SkuName: Hot - 100 TB LRS
+PriceType: Reservation
 
 ## Product Names
 
-| Redundancy         | productName             |
-| ------------------ | ----------------------- |
-| LRS, GRS, RA-GRS   | `Blob Storage`          |
-| ZRS, GZRS, RA-GZRS | `General Block Blob v2` |
-| Premium LRS/ZRS    | `Premium Block Blob`    |
+| Sub-product / Redundancy    | productName             | Default skuName | Data Stored meter       |
+| --------------------------- | ----------------------- | --------------- | ----------------------- |
+| Blob LRS, GRS, RA-GRS       | `Blob Storage`          | `Hot LRS`       | `Hot LRS Data Stored`   |
+| Blob ZRS, GZRS, RA-GZRS     | `General Block Blob v2` | `Hot ZRS`       | `Hot ZRS Data Stored`   |
+| Blob Premium LRS/ZRS        | `Premium Block Blob`    | `Premium LRS`   | `Premium LRS Data Stored` |
+| Azure Files (pay-as-you-go) | `Files v2`              | `Standard LRS`  | `LRS Data Stored`       |
+| Azure Files (provisioned)   | `Premium Files`         | `Premium LRS`   | `Premium LRS Provisioned` |
+| Table Storage               | `Tables`                | `Standard LRS`  | `LRS Data Stored`       |
+| Queue Storage               | `Queues v2`             | `Standard LRS`  | `LRS Data Stored`       |

--- a/skills/azure-cost-calculator/references/services/storage/storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage.md
@@ -48,22 +48,22 @@ Quantity: 50
 | Parameter     | How to determine         | Example values                               |
 | ------------- | ------------------------ | -------------------------------------------- |
 | `serviceName` | Always `Storage`         | `Storage`                                    |
-| `skuName`     | Access tier + redundancy | `Hot LRS`, `Cool ZRS`, `Hot RA-GZRS`        |
+| `skuName`     | Access tier + redundancy | `Hot LRS`, `Cool ZRS`, `Hot RA-GZRS`         |
 | `productName` | See Product Names table  | `Blob Storage`, `General Block Blob v2`      |
 | `meterName`   | See Meter Names table    | `Hot LRS Data Stored`, `Hot Read Operations` |
 
 ## Meter Names
 
-| Meter                       | skuName       | productName             | unitOfMeasure | Notes                            |
-| --------------------------- | ------------- | ----------------------- | ------------- | -------------------------------- |
-| `Hot LRS Data Stored`       | `Hot LRS`     | `Blob Storage`          | `1 GB/Month`  | Tiered                           |
-| `Hot ZRS Data Stored`       | `Hot ZRS`     | `General Block Blob v2` | `1 GB/Month`  | Tiered                           |
-| `Hot GRS Data Stored`       | `Hot GRS`     | `Blob Storage`          | `1 GB/Month`  | Tiered                           |
-| `Hot GZRS Data Stored`      | `Hot GZRS`    | `General Block Blob v2` | `1 GB/Month`  | Tiered                           |
-| `Hot RA-GZRS Data Stored`   | `Hot RA-GZRS` | `General Block Blob v2` | `1 GB/Month`  | ~25% more than GZRS              |
-| `Hot Read Operations`       | _(any Hot)_   | _(varies)_              | `10K`         | Generic, not redundancy-specific |
-| `Hot LRS Write Operations`  | `Hot LRS`     | `Blob Storage`          | `10K`         | Redundancy-specific              |
-| `Hot GZRS Write Operations` | `Hot GZRS`    | `General Block Blob v2` | `10K`         | Shared by GZRS & RA-GZRS        |
+| Meter                       | skuName       | productName             | unitOfMeasure | Notes                             |
+| --------------------------- | ------------- | ----------------------- | ------------- | --------------------------------- |
+| `Hot LRS Data Stored`       | `Hot LRS`     | `Blob Storage`          | `1 GB/Month`  | Tiered                            |
+| `Hot ZRS Data Stored`       | `Hot ZRS`     | `General Block Blob v2` | `1 GB/Month`  | Tiered                            |
+| `Hot GRS Data Stored`       | `Hot GRS`     | `Blob Storage`          | `1 GB/Month`  | Tiered                            |
+| `Hot GZRS Data Stored`      | `Hot GZRS`    | `General Block Blob v2` | `1 GB/Month`  | Tiered                            |
+| `Hot RA-GZRS Data Stored`   | `Hot RA-GZRS` | `General Block Blob v2` | `1 GB/Month`  | ~25% more than GZRS               |
+| `Hot Read Operations`       | _(any Hot)_   | _(varies)_              | `10K`         | Generic, not redundancy-specific  |
+| `Hot LRS Write Operations`  | `Hot LRS`     | `Blob Storage`          | `10K`         | Redundancy-specific               |
+| `Hot GZRS Write Operations` | `Hot GZRS`    | `General Block Blob v2` | `10K`         | Shared by GZRS & RA-GZRS          |
 | `Cool Data Retrieval`       | _(any Cool)_  | _(varies)_              | `1 GB`        | Also: Cold/Archive Data Retrieval |
 
 Meter pattern: `{Tier} {Redundancy} Data Stored`, `{Tier} Read Operations` or `{Tier} ZRS Read Operations`, `{Tier} {Redundancy} Write Operations` (RA-* reuses non-RA write meter name, e.g., RA-GZRS → `Hot GZRS Write Operations`, RA-GRS → `Hot GRS Write Operations`)
@@ -102,12 +102,12 @@ PriceType: Reservation
 
 ## Product Names
 
-| Sub-product / Redundancy    | productName             | Default skuName | Data Stored meter       |
-| --------------------------- | ----------------------- | --------------- | ----------------------- |
-| Blob LRS, GRS, RA-GRS       | `Blob Storage`          | `Hot LRS`       | `Hot LRS Data Stored`   |
-| Blob ZRS, GZRS, RA-GZRS     | `General Block Blob v2` | `Hot ZRS`       | `Hot ZRS Data Stored`   |
+| Sub-product / Redundancy    | productName             | Default skuName | Data Stored meter         |
+| --------------------------- | ----------------------- | --------------- | ------------------------- |
+| Blob LRS, GRS, RA-GRS       | `Blob Storage`          | `Hot LRS`       | `Hot LRS Data Stored`     |
+| Blob ZRS, GZRS, RA-GZRS     | `General Block Blob v2` | `Hot ZRS`       | `Hot ZRS Data Stored`     |
 | Blob Premium LRS/ZRS        | `Premium Block Blob`    | `Premium LRS`   | `Premium LRS Data Stored` |
-| Azure Files (pay-as-you-go) | `Files v2`              | `Standard LRS`  | `LRS Data Stored`       |
+| Azure Files (pay-as-you-go) | `Files v2`              | `Standard LRS`  | `LRS Data Stored`         |
 | Azure Files (provisioned)   | `Premium Files`         | `Premium LRS`   | `Premium LRS Provisioned` |
-| Table Storage               | `Tables`                | `Standard LRS`  | `LRS Data Stored`       |
-| Queue Storage               | `Queues v2`             | `Standard LRS`  | `LRS Data Stored`       |
+| Table Storage               | `Tables`                | `Standard LRS`  | `LRS Data Stored`         |
+| Queue Storage               | `Queues v2`             | `Standard LRS`  | `LRS Data Stored`         |

--- a/skills/azure-cost-calculator/references/services/storage/storage.md
+++ b/skills/azure-cost-calculator/references/services/storage/storage.md
@@ -93,9 +93,7 @@ Monthly = Σ(retailPrice × GB_in_tier) + (readOps/10K × readPrice)
 
 ## Reserved Instance Pricing
 
-Reserved capacity discounts Blob (Hot/Cool/Archive) and Azure Files data at fixed commitments (Blob: 100 TB / 1 PB / 10 PB; Files: 10 TB / 100 TB), 1-Year or 3-Year terms (set via `reservationTerm`). Billed under `Storage Reserved Capacity` (Blob), `Files Reserved Capacity`, or `Premium Files Reserved Capacity` — distinct from PAYG productNames. Not available for Cold tier, Tables, or Queues.
-
-> **Trap (RI MonthlyCost)**: The script's `MonthlyCost` is wrong for Reservation items; it multiplies the full term price by 730. Calculate `unitPrice ÷ 12` (1-Year) or `unitPrice ÷ 36` (3-Year).
+Reserved capacity discounts Blob (Hot/Cool/Archive) and Azure Files data at fixed commitments (Blob: 100 TB / 1 PB / 10 PB; Files: 10 TB / 100 TB), 1-Year or 3-Year terms (set via `reservationTerm`). Billed under `Storage Reserved Capacity` (Blob), `Files Reserved Capacity`, or `Premium Files Reserved Capacity` — distinct from PAYG productNames. Not available for Cold tier, Tables, or Queues. Reservation `retailPrice` is the total commitment cost, not a per-month rate.
 
 ServiceName: Storage
 ProductName: Storage Reserved Capacity

--- a/tests/evals/azure-cost-calculator/tasks/storage/backup/vm-backup-with-storage.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/backup/vm-backup-with-storage.yaml
@@ -1,0 +1,51 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/backup/vm-backup-with-storage
+name: Happy Path - Azure Backup VM Protected Instances with Storage
+description: >
+  Tests cost estimation for a two-component service. Azure Backup bills a
+  per-protected-instance fee plus separate per-GB vault storage. Validates
+  that both the protected instance count and the LRS storage volume are
+  acknowledged and summed.
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:backup
+inputs:
+  prompt: "What is the monthly cost to back up 10 Azure VMs with 500 GB of LRS vault storage using Azure Backup in East US?"
+expected:
+  output_contains:
+    - "Backup"
+    - "Assumptions"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Azure Backup|Backup"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: instance-count-acknowledged
+    config:
+      contains:
+        - "10"
+    weight: 0.5
+  - type: text
+    name: storage-acknowledged
+    config:
+      contains:
+        - "500"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/data-box/disk-import-order.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/data-box/disk-import-order.yaml
@@ -1,0 +1,63 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/data-box/disk-import-order
+name: Happy Path - Data Box Disk Import Order
+description: >
+  Tests cost estimation for an Azure Data Box Disk import order. Validates that
+  the agent queries with serviceName 'Data Box' and filters by productName
+  'Data Box Disk', combines the per-order service fee, shipping fee, and daily
+  overage beyond the 3 included days, and scales the daily fee by disk count.
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:data-box
+inputs:
+  prompt: "How much would 3 Azure Data Box Disks cost for a 5-day import job in East US?"
+expected:
+  output_contains:
+    - "Data Box"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Data Box Disk|Data Box"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: disk-count-acknowledged
+    config:
+      contains:
+        - "3"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "How much would 3 Azure Data Box Disks cost for a 5-day import job in East US?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly/total cost using the correct billing model for Data Box Disk (per-order service fee + shipping fee + daily overage beyond the 3 included days, with the daily fee scaled by disk count).
+        (3) Accounts for 3 disks over a 5-day job as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/file-sync/registered-servers.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/file-sync/registered-servers.yaml
@@ -1,0 +1,52 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/file-sync/registered-servers
+name: Happy Path - Azure File Sync Registered Servers with Free Grant
+description: >
+  Tests cost estimation for Azure File Sync per-server billing. The service
+  charges a flat monthly fee per registered server under serviceName Storage,
+  productName File Sync, with the first server per Storage Sync Service free.
+  Validates that the agent acknowledges the server count and applies the
+  first-server-free grant (5 servers registered, 4 billable).
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:file-sync
+inputs:
+  prompt: "What is the monthly cost of Azure File Sync with 5 registered servers in East US?"
+expected:
+  output_contains:
+    - "File Sync"
+    - "Assumptions"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Azure File Sync|File Sync"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: server-count-acknowledged
+    config:
+      contains:
+        - "5"
+    weight: 0.5
+  - type: text
+    name: free-server-acknowledged
+    config:
+      regex_match:
+        - "free|first server"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/managed-disks/premium-ssd-p30-multi-disk.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/managed-disks/premium-ssd-p30-multi-disk.yaml
@@ -1,0 +1,52 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/managed-disks/premium-ssd-p30-multi-disk
+name: Managed Disks - Premium SSD P30 Multi-Disk
+description: >
+  Tests cost estimation for Premium SSD managed disks with multiple instances.
+  Premium SSD returns two meters per disk (Disk + Disk Mount) that must both be
+  summed and scaled by disk count. Validates that the agent includes the mount
+  fee and does not rely on the disk meter alone.
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:managed-disks
+inputs:
+  prompt: "What is the monthly cost for 2 Premium SSD P30 LRS managed disks in East US?"
+expected:
+  output_contains:
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Managed Disks|Premium SSD"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: disk-count-acknowledged
+    config:
+      contains:
+        - "2"
+    weight: 0.5
+  - type: text
+    name: mount-fee-acknowledged
+    config:
+      regex_match:
+        - "[Mm]ount"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/netapp-files/standard-capacity-pool.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/netapp-files/standard-capacity-pool.yaml
@@ -1,0 +1,55 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/netapp-files/standard-capacity-pool
+name: Happy Path - Azure NetApp Files Standard Capacity Pool
+description: >
+  Tests cost estimation for a provisioned capacity pool billed per GiB/hour.
+  Azure NetApp Files capacity meters use unitOfMeasure "1 GiB/Hour" which the
+  pricing script does not treat as hourly, so MonthlyCost returns zero and the
+  agent must multiply retailPrice x provisionedGiB x 730 manually. Validates
+  the manual monthly calculation and correct tier selection.
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:netapp-files
+inputs:
+  prompt: "What is the monthly cost for a 4 TiB Standard tier Azure NetApp Files capacity pool in East US?"
+expected:
+  output_contains:
+    - "Azure NetApp Files"
+    - "730"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      contains:
+        - "Azure NetApp Files"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: monthly-multiplier-applied
+    config:
+      contains:
+        - "730"
+    weight: 1.0
+  - type: text
+    name: capacity-acknowledged
+    config:
+      contains:
+        - "4"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/netapp-files/standard-capacity-pool.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/netapp-files/standard-capacity-pool.yaml
@@ -4,9 +4,10 @@ name: Happy Path - Azure NetApp Files Standard Capacity Pool
 description: >
   Tests cost estimation for a provisioned capacity pool billed per GiB/hour.
   Azure NetApp Files capacity meters use unitOfMeasure "1 GiB/Hour" which the
-  pricing script does not treat as hourly, so MonthlyCost returns zero and the
-  agent must multiply retailPrice x provisionedGiB x 730 manually. Validates
-  the manual monthly calculation and correct tier selection.
+  pricing script does not treat as hourly, so MonthlyCost omits the x730
+  multiplier (and may round to $0.00 for small quantities); the agent must
+  multiply retailPrice x provisionedGiB x 730 manually. Validates the manual
+  monthly calculation and correct tier selection.
 tags:
   - happy-path
   - single-service

--- a/tests/evals/azure-cost-calculator/tasks/storage/storage-actions/multi-meter-estimate.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/storage-actions/multi-meter-estimate.yaml
@@ -1,0 +1,64 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/storage-actions/multi-meter-estimate
+name: Happy Path - Storage Actions Multi-Meter Estimate
+description: >
+  Tests cost estimation for a serverless service with three independent billing
+  dimensions under the shared serviceName: Storage umbrella. Storage Actions
+  requires separate per-execution, per-million-objects, and per-million-operations
+  queries filtered by ProductName: Storage Actions. Validates all three components
+  are present and summed.
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:storage-actions
+inputs:
+  prompt: "What is the monthly cost of Azure Storage Actions in East US for 50 task executions, 10 million objects targeted, and 3 million operations invoked?"
+expected:
+  output_contains:
+    - "Storage Actions"
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Storage Actions|Storage Task"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: operations-acknowledged
+    config:
+      contains:
+        - "3"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "What is the monthly cost of Azure Storage Actions in East US for 50 task executions, 10 million objects targeted, and 3 million operations invoked?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct multi-component billing model for Storage Actions (per task execution + per million objects targeted + per million operations invoked).
+        (3) Accounts for all three quantities as specified (50 executions, 10 million objects targeted, 3 million operations invoked).
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0

--- a/tests/evals/azure-cost-calculator/tasks/storage/storage/hot-lrs-blob-with-operations.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/storage/storage/hot-lrs-blob-with-operations.yaml
@@ -1,0 +1,62 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:storage/storage/hot-lrs-blob-with-operations
+name: Happy Path - Blob Storage Hot LRS with Operations
+description: >
+  Tests cost estimation for Azure Blob Storage with tiered per-GB storage plus
+  per-10K operations. Validates the productName filter (Blob Storage for LRS),
+  tiered Hot pricing, and multi-meter summing (storage + read + write ops).
+tags:
+  - happy-path
+  - single-service
+  - storage
+  - service:storage
+inputs:
+  prompt: "What is the monthly cost for 500 GB of Azure Blob Storage with Hot LRS in East US, with 10 million read operations and 1 million write operations?"
+expected:
+  output_contains:
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Blob Storage|Azure Storage|Storage"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: storage-size-acknowledged
+    config:
+      contains:
+        - "500"
+    weight: 0.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "What is the monthly cost for 500 GB of Azure Blob Storage with Hot LRS in East US, with 10 million read operations and 1 million write operations?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters.
+        (2) Shows a monthly total cost using the correct billing model for Azure Blob Storage
+            (tiered per-GB storage + per-10K operations, queried via productName filter).
+        (3) Accounts for 500 GB storage with 10 million read and 1 million write operations as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5


### PR DESCRIPTION
Refreshes all 10 storage-category service reference files against live Azure Retail Prices API data, following the `service-reference` orchestration pattern (two independent `pricing-investigator` runs + `compliance-reviewer` per file, consensus with scoped tiebreakers on conflicts). One commit per file for reviewability.

## Files refreshed

| Service | Notable change | Eval task |
|---------|----------------|-----------|
| Backup | Corrected protected-instance/Standard storage meter names; added vaulted/Cosmos meters; split product traps | new |
| Container Storage | Confirmed excess-only free-tier formula (tiebreaker + MS Learn); added shared-serviceName trap | existing |
| Data Box Gateway | Capacity-planning note; verified meters | existing |
| Data Box | Global-region service-fee trap; Heavy marked retired; V2 fixes | new |
| Data Lake Storage | Added Reserved Capacity (both investigators missed it; tiebreaker found under `Storage Reserved Capacity`); sub-cent-ops trap; binary-GiB billing | existing |
| Azure File Sync | Sharpened US Gov billing note (no free grant) | new |
| Managed Disks | Standard HDD query block; separated Premium v2/Ultra traps | new |
| Azure NetApp Files | CRR corrected to per-GiB-per-month billing; added Flexible tier; GiB/TiB conversion | new |
| Storage Actions | Elevated phantom-meter exclusion to a trap | new |
| Storage | Added Reserved Capacity section; expanded product-name coverage to Files/Tables/Queues | new |

## Consensus & tiebreakers

Most files reached full agreement between the two pricing investigators with no tiebreaker. Tiebreakers (with MS Learn cross-check) resolved:
- **Container Storage**: excess-only free-tier billing (page had a data-bug example).
- **Data Lake Storage**: Reserved Capacity availability (found under `Storage Reserved Capacity` productName) and binary-GiB billing unit.
- **Managed Disks**: identified `Premium SSD Managed Disks_v8` as a 10-Year Reservation product (retailPrice / 120), excluded as niche.
- **NetApp Files**: CRR is x1 per GiB replicated per month (not x730); Elastic ZRS still Preview.

## Catalog cleanup

Removed stale `docs/service-catalog.md` entries for **Data Box Gateway** and **Storage Actions** (both already implemented; the catalog is for pending services only).

## Reviewer note

For File Sync and Managed Disks, the compliance reviewer suggested splitting `serviceName: Storage` into `serviceName` + `apiServiceName`. This was declined to keep the exact API value per the frontmatter schema and sibling-file convention (`storage.md`, `data-lake-storage.md`). Flagging for confirmation.

## Validation

Every file passes `pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync` and `waza check` (schema + coverage). Remaining `waza check` warnings (orphaned references, SKILL.md token count) are pre-existing and skill-wide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Azure Storage pricing guidance across Backup, Data Lake Storage, Data Box, NetApp Files, Managed Disks, File Sync, Container Storage, and Storage Actions.
  - Clarified meter selection, regional pricing, reservation calculations, billing formulas, service-specific exceptions, and common query pitfalls.
  - Updated the service catalog with Azure Elastic SAN and Azure Managed Lustre, while removing outdated aliases.

- **Tests**
  - Added cost-estimation evaluations covering Backup, Data Box, File Sync, Managed Disks, NetApp Files, Storage Actions, and Blob Storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->