### PR TITLE
docs: refresh security service references against live api

### DIFF
--- a/skills/azure-cost-calculator/references/services/security/defender-easm.md
+++ b/skills/azure-cost-calculator/references/services/security/defender-easm.md
@@ -24,10 +24,10 @@ Quantity: 500  # billable assets
 
 ## Meter Names
 
-| Meter | skuName | unitOfMeasure | Notes |
-| --- | --- | --- | --- |
-| `Defender EASM Standard Asset` | `Defender EASM Standard` | `1` | Per billable asset per day |
-| `Defender EASM 30 Day Trial Asset` | `Defender EASM 30 Day Trial` | `1` | Free trial (30 days) |
+| Meter                              | skuName                      | unitOfMeasure | Notes                      |
+| ---------------------------------- | ---------------------------- | ------------- | -------------------------- |
+| `Defender EASM Standard Asset`     | `Defender EASM Standard`     | `1`           | Per billable asset per day |
+| `Defender EASM 30 Day Trial Asset` | `Defender EASM 30 Day Trial` | `1`           | Free trial (30 days)       |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/security/defender-for-cloud.md
+++ b/skills/azure-cost-calculator/references/services/security/defender-for-cloud.md
@@ -27,26 +27,26 @@ InstanceCount: {resourceCount} # number of protected resources
 
 ## Meter Names
 
-| Sub-product         | productName                              | skuName            | meterName                   | unitOfMeasure | Formula               |
-| ------------------- | ---------------------------------------- | ------------------ | --------------------------- | ------------- | --------------------- |
-| Servers P1          | `Microsoft Defender for Servers`         | `Standard P1`      | `Standard P1 Node`          | `1/Hour`      | × 730 × serverCount   |
-| Servers P2          | `Microsoft Defender for Servers`         | `Standard P2`      | `Standard P2 Node`          | `1/Hour`      | × 730 × serverCount   |
-| SQL (PaaS)          | `Microsoft Defender for SQL`             | `Standard`         | `Standard Instance`         | `1 Hour`      | × 730 × instanceCount |
-| SQL (Node)          | `Microsoft Defender for SQL`             | `Standard`         | `Standard Node`             | `1/Month`     | × nodeCount           |
-| SQL (vCore)         | `Microsoft Defender for SQL`             | `Standard`         | `Standard vCore`            | `1 Hour`      | × 730 × vCoreCount    |
-| App Service         | `Microsoft Defender for App Service`     | `Standard`         | `Standard Node`             | `1/Hour`      | × 730 × planCount     |
-| Key Vault           | `Microsoft Defender for Key Vault`       | `Per node Std`     | `Per node Std Node`         | `1/Hour`      | × 730 × vaultCount    |
-| Storage             | `Microsoft Defender for Storage`         | `Standard`         | `Standard Node`             | `1/Hour`      | × 730 × accountCount  |
-| Storage (txns)      | `Microsoft Defender for Storage`         | `Standard`         | `Standard Transactions`     | `1M`          | × transactionMillions |
-| Storage (malware)   | `Microsoft Defender for Storage`         | `Malware Scanning` | `Malware Scanning Data Ingested` | `1 GB`   | × scannedGB           |
-| Containers          | `Microsoft Defender for Containers`      | `Standard vCore`   | `Standard vCore vCore Pack` | `1/Hour`      | × 730 × totalVCores   |
-| Containers (images) | `Microsoft Defender for Containers`      | `Standard Images`  | `Standard Images`           | `1`           | × imageScansPerMonth  |
-| Cosmos DB           | `Microsoft Defender for Azure Cosmos DB` | `Standard`         | `Standard 100 RU/s`        | `1/Hour`      | × 730 × (RUs / 100)   |
-| DNS                 | `Microsoft Defender for DNS`             | `Standard`         | `Standard Queries`          | `1M`          | × queryMillions       |
-| Resource Manager    | `Microsoft Defender for Resource Manager`| `Per node Std`     | `Per node Std Node`         | `1/Hour`      | × 730 × subCount      |
-| MySQL               | `Microsoft Defender for MySQL`           | `Standard`         | `Standard Node`             | `1/Month`     | × serverCount         |
-| PostgreSQL          | `Microsoft Defender for PostgreSQL`      | `Standard`         | `Standard Node`             | `1/Month`     | × serverCount         |
-| MariaDB             | `Microsoft Defender for MariaDB`         | `Standard`         | `Standard Instance`         | `1 Hour`      | × 730 × instanceCount |
+| Sub-product         | productName                               | skuName            | meterName                        | unitOfMeasure | Formula               |
+| ------------------- | ----------------------------------------- | ------------------ | -------------------------------- | ------------- | --------------------- |
+| Servers P1          | `Microsoft Defender for Servers`          | `Standard P1`      | `Standard P1 Node`               | `1/Hour`      | × 730 × serverCount   |
+| Servers P2          | `Microsoft Defender for Servers`          | `Standard P2`      | `Standard P2 Node`               | `1/Hour`      | × 730 × serverCount   |
+| SQL (PaaS)          | `Microsoft Defender for SQL`              | `Standard`         | `Standard Instance`              | `1 Hour`      | × 730 × instanceCount |
+| SQL (Node)          | `Microsoft Defender for SQL`              | `Standard`         | `Standard Node`                  | `1/Month`     | × nodeCount           |
+| SQL (vCore)         | `Microsoft Defender for SQL`              | `Standard`         | `Standard vCore`                 | `1 Hour`      | × 730 × vCoreCount    |
+| App Service         | `Microsoft Defender for App Service`      | `Standard`         | `Standard Node`                  | `1/Hour`      | × 730 × planCount     |
+| Key Vault           | `Microsoft Defender for Key Vault`        | `Per node Std`     | `Per node Std Node`              | `1/Hour`      | × 730 × vaultCount    |
+| Storage             | `Microsoft Defender for Storage`          | `Standard`         | `Standard Node`                  | `1/Hour`      | × 730 × accountCount  |
+| Storage (txns)      | `Microsoft Defender for Storage`          | `Standard`         | `Standard Transactions`          | `1M`          | × transactionMillions |
+| Storage (malware)   | `Microsoft Defender for Storage`          | `Malware Scanning` | `Malware Scanning Data Ingested` | `1 GB`        | × scannedGB           |
+| Containers          | `Microsoft Defender for Containers`       | `Standard vCore`   | `Standard vCore vCore Pack`      | `1/Hour`      | × 730 × totalVCores   |
+| Containers (images) | `Microsoft Defender for Containers`       | `Standard Images`  | `Standard Images`                | `1`           | × imageScansPerMonth  |
+| Cosmos DB           | `Microsoft Defender for Azure Cosmos DB`  | `Standard`         | `Standard 100 RU/s`              | `1/Hour`      | × 730 × (RUs / 100)   |
+| DNS                 | `Microsoft Defender for DNS`              | `Standard`         | `Standard Queries`               | `1M`          | × queryMillions       |
+| Resource Manager    | `Microsoft Defender for Resource Manager` | `Per node Std`     | `Per node Std Node`              | `1/Hour`      | × 730 × subCount      |
+| MySQL               | `Microsoft Defender for MySQL`            | `Standard`         | `Standard Node`                  | `1/Month`     | × serverCount         |
+| PostgreSQL          | `Microsoft Defender for PostgreSQL`       | `Standard`         | `Standard Node`                  | `1/Month`     | × serverCount         |
+| MariaDB             | `Microsoft Defender for MariaDB`          | `Standard`         | `Standard Instance`              | `1 Hour`      | × 730 × instanceCount |
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/security/key-vault.md
+++ b/skills/azure-cost-calculator/references/services/security/key-vault.md
@@ -33,15 +33,15 @@ MeterName: Operations
 
 ## Meter Names
 
-| Meter                                    | SKU              | unitOfMeasure | Notes                            |
-| ---------------------------------------- | ---------------- | ------------- | -------------------------------- |
-| `Operations`                             | Standard/Premium | 10K           | Secret/key read/write            |
-| `Advanced Key Operations`                | Standard/Premium | 10K           | RSA/EC cryptographic ops         |
-| `Certificate Renewal Request`            | Standard/Premium | 1             | Per certificate renewal          |
+| Meter                                    | SKU              | unitOfMeasure | Notes                                |
+| ---------------------------------------- | ---------------- | ------------- | ------------------------------------ |
+| `Operations`                             | Standard/Premium | 10K           | Secret/key read/write                |
+| `Advanced Key Operations`                | Standard/Premium | 10K           | RSA/EC cryptographic ops             |
+| `Certificate Renewal Request`            | Standard/Premium | 1             | Per certificate renewal              |
 | `Secret Renewal`                         | Standard/Premium | 1             | Managed storage account key rotation |
-| `Automated Key Rotation`                 | Standard/Premium | 1 Rotation    | Per key auto-rotation            |
-| `Premium HSM-protected RSA 2048-bit key` | Premium          | 1             | Per HSM key, per month           |
-| `Premium HSM-protected Advanced Key`     | Premium          | 1             | Per key, tiered, see trap below |
+| `Automated Key Rotation`                 | Standard/Premium | 1 Rotation    | Per key auto-rotation                |
+| `Premium HSM-protected RSA 2048-bit key` | Premium          | 1             | Per HSM key, per month               |
+| `Premium HSM-protected Advanced Key`     | Premium          | 1             | Per key, tiered, see trap below      |
 
 > **Do NOT use**: `Standard Instance` meter; that is Azure Dedicated HSM (thousands/month).
 

--- a/skills/azure-cost-calculator/references/services/security/key-vault.md
+++ b/skills/azure-cost-calculator/references/services/security/key-vault.md
@@ -38,7 +38,7 @@ MeterName: Operations
 | `Operations`                             | Standard/Premium | 10K           | Secret/key read/write            |
 | `Advanced Key Operations`                | Standard/Premium | 10K           | RSA/EC cryptographic ops         |
 | `Certificate Renewal Request`            | Standard/Premium | 1             | Per certificate renewal          |
-| `Secret Renewal`                         | Standard/Premium | 1             | Per secret auto-renewal          |
+| `Secret Renewal`                         | Standard/Premium | 1             | Managed storage account key rotation |
 | `Automated Key Rotation`                 | Standard/Premium | 1 Rotation    | Per key auto-rotation            |
 | `Premium HSM-protected RSA 2048-bit key` | Premium          | 1             | Per HSM key, per month           |
 | `Premium HSM-protected Advanced Key`     | Premium          | 1             | Per key, tiered, see trap below |

--- a/skills/azure-cost-calculator/references/services/security/purview.md
+++ b/skills/azure-cost-calculator/references/services/security/purview.md
@@ -59,24 +59,24 @@ MeterName: Standard vCore
 
 ## Key Fields
 
-| Parameter | How to determine | Example values |
-| --- | --- | --- |
-| `serviceName` | `Microsoft Purview` (current) or `Azure Purview` (classic) | `Microsoft Purview`, `Azure Purview` |
-| `productName` | Feature area within the platform | `Microsoft Purview Data Governance`, `Azure Purview Data Map` |
-| `skuName` | Tier or feature being billed | `Data Catalog Standard`, `Standard`, `Data Management Basic` |
-| `meterName` | Billing dimension | `Data Catalog Standard Asset`, `Standard Capacity Unit` |
+| Parameter     | How to determine                                           | Example values                                                |
+| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| `serviceName` | `Microsoft Purview` (current) or `Azure Purview` (classic) | `Microsoft Purview`, `Azure Purview`                          |
+| `productName` | Feature area within the platform                           | `Microsoft Purview Data Governance`, `Azure Purview Data Map` |
+| `skuName`     | Tier or feature being billed                               | `Data Catalog Standard`, `Standard`, `Data Management Basic`  |
+| `meterName`   | Billing dimension                                          | `Data Catalog Standard Asset`, `Standard Capacity Unit`       |
 
 ## Meter Names
 
-| Meter | productName | skuName | unitOfMeasure | Notes |
-| --- | --- | --- | --- | --- |
-| `Data Catalog Standard Asset` | `Microsoft Purview Data Governance` | `Data Catalog Standard` | `1/Day` | Per governed asset |
-| `Standard Asset` | `Microsoft Purview Data Security` | `Standard` | `1/Day` | At Rest Protection |
-| `Standard Data Security Processing Unit` | `Microsoft Purview Data Security` | `Standard` | `1` | DSPU, Insider Risk |
-| `Data Management Basic Data Governance Processing Unit` | `Microsoft Purview Data Governance` | `Data Management Basic` | `1` | DGPU, also Standard and Advanced tiers |
-| `Standard Capacity Unit` | `Azure Purview Data Map` | `Standard` | `1 Hour` | Classic Data Map CU |
-| `Standard vCore` | `Azure Purview Scanning Ingestion and Classification` | `Standard` | `1 Hour` | Classic scanning |
-| `Standard Assets` | `Microsoft Purview On-Demand Classification` | `Standard` | `10K` | Per 10K classified |
+| Meter                                                   | productName                                           | skuName                 | unitOfMeasure | Notes                                  |
+| ------------------------------------------------------- | ----------------------------------------------------- | ----------------------- | ------------- | -------------------------------------- |
+| `Data Catalog Standard Asset`                           | `Microsoft Purview Data Governance`                   | `Data Catalog Standard` | `1/Day`       | Per governed asset                     |
+| `Standard Asset`                                        | `Microsoft Purview Data Security`                     | `Standard`              | `1/Day`       | At Rest Protection                     |
+| `Standard Data Security Processing Unit`                | `Microsoft Purview Data Security`                     | `Standard`              | `1`           | DSPU, Insider Risk                     |
+| `Data Management Basic Data Governance Processing Unit` | `Microsoft Purview Data Governance`                   | `Data Management Basic` | `1`           | DGPU, also Standard and Advanced tiers |
+| `Standard Capacity Unit`                                | `Azure Purview Data Map`                              | `Standard`              | `1 Hour`      | Classic Data Map CU                    |
+| `Standard vCore`                                        | `Azure Purview Scanning Ingestion and Classification` | `Standard`              | `1 Hour`      | Classic scanning                       |
+| `Standard Assets`                                       | `Microsoft Purview On-Demand Classification`          | `Standard`              | `10K`         | Per 10K classified                     |
 
 > Other meters: Audit Standard Asset (1K), Communication Compliance Standard/Premium (1K), eDiscovery Premium GB (1/Day), eDiscovery Graph API Standard Export (1 GB, first 50 GB free), Retention GB (1/Day), In Transit Protection Request (sub-cent), Investigations Compute Unit (1 Hour) and GB (1/Day), OCR Transaction (first 2,500 free then sub-cent), Data Lifecycle Management Premium (1K/Day, sub-cent).
 > Classic Data Map add-ons (`Azure Purview`): Resource Set vCore (1 Hour), Data Map Enrichment vCore (1 Hour), Data Policy (1 Hour, `Region: Global` only). `Microsoft Purview Data Map` mirrors Advanced Resource Set vCore (1 Hour) under the current serviceName.

--- a/skills/azure-cost-calculator/references/services/security/purview.md
+++ b/skills/azure-cost-calculator/references/services/security/purview.md
@@ -78,7 +78,8 @@ MeterName: Standard vCore
 | `Standard vCore` | `Azure Purview Scanning Ingestion and Classification` | `Standard` | `1 Hour` | Classic scanning |
 | `Standard Assets` | `Microsoft Purview On-Demand Classification` | `Standard` | `10K` | Per 10K classified |
 
-> Other meters: Audit Standard Asset (1K), Communication Compliance Standard/Premium (1K), eDiscovery Premium GB (1/Day), eDiscovery Graph API Export (1 GB, first 50 GB free), In Transit Protection Request (sub-cent), Investigations Compute Unit (1 Hour) and GB (1/Day), OCR Transaction (first 2,500 free then sub-cent), Data Lifecycle Management Premium (1K/Day, sub-cent).
+> Other meters: Audit Standard Asset (1K), Communication Compliance Standard/Premium (1K), eDiscovery Premium GB (1/Day), eDiscovery Graph API Standard Export (1 GB, first 50 GB free), Retention GB (1/Day), In Transit Protection Request (sub-cent), Investigations Compute Unit (1 Hour) and GB (1/Day), OCR Transaction (first 2,500 free then sub-cent), Data Lifecycle Management Premium (1K/Day, sub-cent).
+> Classic Data Map add-ons (`Azure Purview`): Resource Set vCore (1 Hour), Data Map Enrichment vCore (1 Hour), Data Policy (1 Hour, `Region: Global` only). `Microsoft Purview Data Map` mirrors Advanced Resource Set vCore (1 Hour) under the current serviceName.
 
 ## Cost Formula
 

--- a/skills/azure-cost-calculator/references/services/security/sentinel.md
+++ b/skills/azure-cost-calculator/references/services/security/sentinel.md
@@ -61,7 +61,7 @@ Quantity: 500
 | `Basic Logs Analysis`                         | `Basic Logs`                   | `1 GB`        | Reduced-cost log analysis           |
 | `Data lake storage Data Stored`               | `Data lake storage`            | `1 GB/Month`  | Long-term storage                   |
 | `Data lake ingestion Data Processed`          | `Data lake ingestion`          | `1 GB`        | Ingestion into data lake            |
-| `Free Benefit - M365 Defender Analysis`       | `Free Benefit - M365 Defender` | `1 GB`        | Zero cost, free M365 data          |
+| `Free Benefit - M365 Defender Analysis`       | `Free Benefit - M365 Defender` | `1 GB`        | Zero cost, free M365 data           |
 
 > Other SKUs (query individually): `Data lake query` (1 GB, sub-cent), `Advanced Data Insights` (1 Hour), `Graph` (1 Hour, per compute-hour), `Data processing` (1 GB), `Solution for SAP Applications` (1/Hour), `Classic Auxiliary Logs Analysis` (1 GB), `Free Trial` (1 GB).
 

--- a/skills/azure-cost-calculator/references/services/security/sentinel.md
+++ b/skills/azure-cost-calculator/references/services/security/sentinel.md
@@ -63,7 +63,7 @@ Quantity: 500
 | `Data lake ingestion Data Processed`          | `Data lake ingestion`          | `1 GB`        | Ingestion into data lake            |
 | `Free Benefit - M365 Defender Analysis`       | `Free Benefit - M365 Defender` | `1 GB`        | Zero cost, free M365 data          |
 
-> Other SKUs (query individually): `Data lake query` (1 GB, sub-cent), `Advanced Data Insights` (1 Hour), `Data processing` (1 GB), `Solution for SAP Applications` (1/Hour), `Classic Auxiliary Logs Analysis` (1 GB), `Free Trial` (1 GB).
+> Other SKUs (query individually): `Data lake query` (1 GB, sub-cent), `Advanced Data Insights` (1 Hour), `Graph` (1 Hour, per compute-hour), `Data processing` (1 GB), `Solution for SAP Applications` (1/Hour), `Classic Auxiliary Logs Analysis` (1 GB), `Free Trial` (1 GB).
 
 ## Cost Formula
 

--- a/tests/evals/azure-cost-calculator/tasks/security/sentinel/payg-ingestion.yaml
+++ b/tests/evals/azure-cost-calculator/tasks/security/sentinel/payg-ingestion.yaml
@@ -1,0 +1,61 @@
+# Waza eval task: see docs/ops/evals.md
+id: eval:security/sentinel/payg-ingestion
+name: Sentinel - PAYG Ingestion
+description: >
+  Tests cost estimation for Microsoft Sentinel using Pay-as-you-go ingestion.
+  Validates the agent uses the PAYG per-GB billing model (not a commitment
+  tier) and normalizes a daily ingestion volume to monthly billable GB.
+tags:
+  - happy-path
+  - single-service
+  - security
+  - service:sentinel
+inputs:
+  prompt: "How much would Microsoft Sentinel cost per month for 500 GB per day of log ingestion in East US using Pay-as-you-go pricing?"
+expected:
+  output_contains:
+    - "Assumptions"
+  output_not_contains:
+    - "Summary format"
+graders:
+  - type: text
+    name: correct-service-name
+    config:
+      regex_match:
+        - "Sentinel|Microsoft Sentinel|SIEM"
+    weight: 1.0
+  - type: text
+    name: currency-format
+    config:
+      regex_match:
+        - "\\$[\\d,]+\\.\\d{2}"
+    weight: 1.0
+  - type: text
+    name: ingestion-volume-acknowledged
+    config:
+      contains:
+        - "500"
+    weight: 0.5
+  - type: prompt
+    name: complete-estimate-quality
+    config:
+      continue_session: true
+      prompt: >
+        You are evaluating an AI agent's response to: "How much would Microsoft Sentinel cost per month for 500 GB per day of log ingestion in East US using Pay-as-you-go pricing?"
+
+        The agent's response is in the conversation above. Check it for these criteria:
+        (1) Includes an Assumptions section disclosing safe-default parameters (at minimum the simplified pricing model).
+        (2) Shows a monthly total cost using the Pay-as-you-go billing model for Microsoft Sentinel (retailPrice × total billable GB).
+        (3) Accounts for 500 GB/day (approximately 15,000 GB/month) of ingestion as specified.
+
+        Score 1.0 if all three criteria are met. Score 0.5 if two are met. Score 0.0 if fewer than two are met.
+
+        Return ONLY a decimal number between 0.0 and 1.0 with no other text.
+    weight: 1.5
+  - type: tool_constraint
+    name: uses-pricing-script
+    config:
+      expect_tools:
+        - tool: bash
+          command_pattern: "get-azure-pricing\\.sh"
+    weight: 1.0


### PR DESCRIPTION
## Summary

Refreshes all 5 Azure service reference files in `references/services/security/` against the live Azure Retail Prices API. Each service was investigated by independent pricing sub-agents with consensus-only writes, then validated per-file.

| Service | Outcome |
|---|---|
| defender-easm | Verified accurate, no drift |
| defender-for-cloud | Verified accurate (17-meter table confirmed) |
| key-vault | Fixed `Secret Renewal` description (managed storage account key rotation) |
| purview | eDiscovery meter rename + new meters in "Other meters" note |
| sentinel | Added `Graph` compute add-on meter; created missing happy-path eval task |

## Validation

- `Validate-ServiceReference.ps1` passes for all changed files (routing + alias uniqueness).
- `waza check`: schema valid, 125 task files validated.
- Sentinel eval coverage gap closed (new `payg-ingestion` task).

## Notes

Single-source / false-positive findings were deliberately excluded: Defender AI Services/OSS-DB additions (niche, already deferred in Notes), Sentinel Pre-Purchase Plan (single-source), `hasFreeGrant` on sentinel (author deliberately omitted, "No native free tier" documented).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Azure Key Vault meter guidance to clarify Secret Renewal pricing as managed storage account key rotation.
  - Expanded Microsoft Purview meter documentation with eDiscovery, retention, and Classic Data Map add-on details, including regional availability notes.
  - Added Graph to the Microsoft Sentinel SKU list for individual pricing queries.

- **Tests**
  - Added coverage for Microsoft Sentinel pay-as-you-go ingestion estimates, including assumptions, monthly calculations, currency, and pricing tool usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->