### PR TITLE
Update service reference: Azure Health Bot

### DIFF
--- a/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
@@ -6,6 +6,7 @@ billingNeeds: [Azure App Service, Functions]
 primaryCost: "S1 premium channel messages per 1K (DirectLine/Web Chat); standard channels free"
 pricingRegion: global
 hasFreeGrant: true
+privateEndpoint: true
 ---
 
 # Azure Bot Service
@@ -64,6 +65,7 @@ Free = no charge (10K premium messages/month included; standard channels unlimit
 - **Standard channels are free**: Teams, Slack, Facebook, etc. have no paid meter at any tier
 - **Premium channels**: DirectLine and Web Chat; billable only on S1 tier
 - **Underlying compute**: Bot apps run on Azure App Service or Functions; billed separately under those services
+- **Private endpoint**: Supported only via the Direct Line App Service extension (DL-ASE), not the base bot resource; PE charges billed separately under `networking/private-link.md`
 - **Free tier cap**: 10,000 premium channel messages/month (enforced service-side; API returns zero-price meters)
 - **Sovereign cloud**: US Gov uses separate `S1 Premium Channel Messages` and `Free Standard Channel Messages` meters; `Free Premium Channel Messages` is absent
 - **Health Bot**: For healthcare bot pricing (Agent Tier, Standard daily fee), see `specialist/health-bot.md`

--- a/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
+++ b/skills/azure-cost-calculator/references/services/ai-ml/bot-service.md
@@ -65,7 +65,7 @@ Free = no charge (10K premium messages/month included; standard channels unlimit
 - **Standard channels are free**: Teams, Slack, Facebook, etc. have no paid meter at any tier
 - **Premium channels**: DirectLine and Web Chat; billable only on S1 tier
 - **Underlying compute**: Bot apps run on Azure App Service or Functions; billed separately under those services
-- **Private endpoint**: Supported only via the Direct Line App Service extension (DL-ASE), not the base bot resource; PE charges billed separately under `networking/private-link.md`
+- **PE sub-resources** (never-assume): `Bot` (Direct Line) and `Token`; supported only via the Direct Line App Service extension (DL-ASE), not the base bot resource; see `networking/private-link.md` for PE and DNS zone pricing
 - **Free tier cap**: 10,000 premium channel messages/month (enforced service-side; API returns zero-price meters)
 - **Sovereign cloud**: US Gov uses separate `S1 Premium Channel Messages` and `Free Standard Channel Messages` meters; `Free Premium Channel Messages` is absent
 - **Health Bot**: For healthcare bot pricing (Agent Tier, Standard daily fee), see `specialist/health-bot.md`

--- a/skills/azure-cost-calculator/references/services/specialist/health-bot.md
+++ b/skills/azure-cost-calculator/references/services/specialist/health-bot.md
@@ -67,6 +67,6 @@ Free = no charge (all meters return zero price)
 
 - **Free tier**: Returns zero-price meters (Free MCU, Free Message); included to prevent unnecessary API queries
 - **Standard tier includes monthly allowance**: 10,000 messages and 1,000 MCUs per month; overages billed per-unit above the monthly allowance
-- **MCU (Message Compute Unit)**: 1 MCU = one Health Bot scenario execution; Standard tier includes monthly allowance, overages billed per-unit
+- **MCU (Medical Content Consumption Unit)**: charged per encounter with licensed third-party medical content (e.g. Infermedica symptom checker) or Generative AI features, not per scenario; most tenant-authored scenarios consume zero MCUs; Standard tier includes monthly allowance, overages billed per-unit
 - **Agent Tier**: Per-action billing; action multipliers vary by feature type (1–18 actions per interaction depending on scenario complexity)
 - **Bot Service channels**: Standard channels (Teams, Slack) are free; premium channels (DirectLine, Web Chat) are separate; see `ai-ml/bot-service.md`

--- a/skills/azure-cost-calculator/references/services/specialist/health-bot.md
+++ b/skills/azure-cost-calculator/references/services/specialist/health-bot.md
@@ -5,7 +5,6 @@ aliases: [Healthcare Bot, Health Virtual Assistant, Medical Bot]
 apiServiceName: Azure Bot Service
 primaryCost: "Agent Tier per-action (recommended); Standard daily fee ×30 + overage (legacy); Free available"
 hasFreeGrant: true
-privateEndpoint: true
 ---
 
 # Azure Health Bot
@@ -67,8 +66,7 @@ Free = no charge (all meters return zero price)
 ## Notes
 
 - **Free tier**: Returns zero-price meters (Free MCU, Free Message); included to prevent unnecessary API queries
-- **Standard tier includes daily allowance**: 10,000 messages and 1,000 MCUs per day; overages billed per-unit above daily allowance
-- **MCU (Message Compute Unit)**: 1 MCU = one Health Bot scenario execution; Standard tier includes daily allowance, overages billed per-unit
+- **Standard tier includes monthly allowance**: 10,000 messages and 1,000 MCUs per month; overages billed per-unit above the monthly allowance
+- **MCU (Message Compute Unit)**: 1 MCU = one Health Bot scenario execution; Standard tier includes monthly allowance, overages billed per-unit
 - **Agent Tier**: Per-action billing; action multipliers vary by feature type (1–18 actions per interaction depending on scenario complexity)
-- **PE sub-resources** (never-assume): `Bot`, `Token`; both needed for full network isolation; see `networking/private-link.md` for PE pricing
 - **Bot Service channels**: Standard channels (Teams, Slack) are free; premium channels (DirectLine, Web Chat) are separate; see `ai-ml/bot-service.md`

--- a/skills/azure-cost-calculator/references/services/specialist/health-bot.md
+++ b/skills/azure-cost-calculator/references/services/specialist/health-bot.md
@@ -52,8 +52,8 @@ SkuName: Free
 | `Standard Overage MCU`      | `Standard`   | `1`           | Message Compute Unit overage |
 | `Standard Overage Messages` | `Standard`   | `1K`          | Per 1K messages overage      |
 | `Agent Tier Action`         | `Agent Tier` | `1`           | Per-action billing           |
-| `Free MCU`                  | `Free`       | `1`           | Free tier, zero price       |
-| `Free Message`              | `Free`       | `1K`          | Free tier, zero price       |
+| `Free MCU`                  | `Free`       | `1`           | Free tier, zero price        |
+| `Free Message`              | `Free`       | `1K`          | Free tier, zero price        |
 
 ## Cost Formula
 


### PR DESCRIPTION
## Summary

Corrects two factual errors in the existing `specialist/health-bot.md` reference file, following the `service-reference.md` orchestrator pattern (two independent pricing investigations + compliance review + tiebreaker).

- Standard (S1) tier includes **10,000 messages and 1,000 MCUs per month**, not per day.
- Azure Health Bot (`Microsoft.HealthBot/healthBots`) has **no native Private Endpoint support**, so `privateEndpoint: true` and the PE sub-resources note are removed.

All meters, SKUs, prices, traps, and query patterns were confirmed accurate by consensus and left unchanged.

## Investigation reports

Two independent `pricing-investigator` runs **agreed** on:
- `serviceName: Azure Bot Service`, `productName: Microsoft Azure Health Bot` (shared serviceName trap).
- All 6 meters: `Agent Tier Action` (Agent Tier), `Free MCU`/`Free Message` (Free), `Standard Unit`/`Standard Overage MCU`/`Standard Overage Messages` (Standard).
- `1/Day` daily-billing trap (auto ×30), S1 deprecated Nov 2025, no Reserved Instances, action multipliers 1–18, regional pricing with uniform rates.

**Disagreements (2):**
1. S1 included allowance: per-day vs per-month.
2. Private Endpoint support: inferred (from shared Bot Service resource type) vs unverifiable (`Microsoft.HealthBot` ARM spec has no private-link resources).

## Tiebreaker resolution

A scoped tiebreaker `pricing-investigator` with web search resolved both 2-to-1 against authoritative Microsoft Learn docs:

1. **Allowance = per month.** `learn.microsoft.com/azure/health-bot/pricing-details`: "$500 fixed monthly fee (including 10,000 messages and 1,000 MCUs)."
2. **No Private Endpoint.** `learn.microsoft.com/azure/private-link/availability` lists only `Microsoft.BotService` (Direct Line App Service extension), not `Microsoft.HealthBot`; no Health Bot networking docs exist. The prior claim conflated the two distinct resource providers.

## Compliance contract

Applied `compliance-reviewer` contract: YAML field order and elision rules (removed non-default `privateEndpoint`), MaxLineCount 120, section order, named-trap format, no hardcoded dollar figures in Notes.

## Data-vs-rules conflict

Per the authority hierarchy (Microsoft Learn is authoritative for feature availability), documentation overrode the earlier inferred PE claim.

## Validation

`pwsh tests/Validate-ServiceReference.ps1 -Path skills/azure-cost-calculator/references/services/specialist/health-bot.md -CheckAliasUniqueness -CheckRoutingFileSync` → **PASS** (all checks, 72 lines).

## Eval task

Existing happy-path task `tests/evals/azure-cost-calculator/tasks/specialist/health-bot/agent-tier-actions.yaml` (tagged `happy-path`, `service:health-bot`) already satisfies the coverage contract; no new task required for this update. `waza check` reported only pre-existing repo-wide skill warnings unrelated to this edit.

## Out of scope (flagged for follow-up)

- A parallel legacy billing path exists (`Healthcare Agent Service` under `serviceName: Azure API for FHIR`, same $0.01/action).
- Microsoft Learn now brands this "Healthcare agent service"; routing display name still reads "Azure Health Bot".

---

## Update (follow-up review)

Re-verified all statements against Microsoft Learn and the live Retail Prices API:

- **Private Endpoint (confirmed removal correct):** `Microsoft.HealthBot` ARM spec through `2025-11-01`, the Private Link availability doc, and the Health Bot Learn docs (no networking page) all confirm Health Bot has no PE. The old claim was inherited from the shared `Azure Bot Service` API name.
- **MCU definition fix:** Corrected "Message Compute Unit / one scenario execution" to **Medical Content Consumption Unit** (per-encounter with licensed third-party medical content or GenAI; most tenant scenarios consume zero), per Learn `pricing-details`.
- **Bot Service PE relocated to the correct file:** Added `privateEndpoint: true` + a Direct Line ASE-only caveat to `ai-ml/bot-service.md`, where the capability legitimately belongs.

All 6 meters/SKUs/units/prices re-confirmed against the live API. Both files pass validation.