### PR TITLE
docs: refresh web service references against live api

### DIFF
--- a/skills/azure-cost-calculator/references/services/web/cognitive-search.md
+++ b/skills/azure-cost-calculator/references/services/web/cognitive-search.md
@@ -16,7 +16,7 @@ privateEndpoint: true
 
 > **Trap (Semantic Ranker MonthlyCost)**: The `Semantic Ranker Unit` meter uses `1/Day` units. The script auto-multiplies by 30, so `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30`; that would overcount by 30x. The per-query meters (`Semantic Ranker queries`, `Semantic Ranker Overage Queries`) use `1K` units and default to ×1; compute them as `queriesPerMonth ÷ 1000 × retailPrice`.
 
-> **Trap (Agentic Retrieval sub-cent)**: The three Agentic Retrieval reasoning meters (`1K` unit) have sub-cent per-token rates, so the script rounds `MonthlyCost` to zero. Do not report zero to the user; use the Known Rates table and multiply `retailPrice × (tokens ÷ 1000)`.
+> **Trap (Agentic Retrieval sub-cent)**: The three Agentic Retrieval reasoning meters (`1K` unit) have sub-cent per-token rates, so the script rounds `MonthlyCost` to zero. Do not report zero to the user; use the Known Rates table and multiply `retailPrice × (max(0, tokens − freeGrant) ÷ 1000)`. The free grant is level-specific (see Known Rates).
 
 ## Query Pattern
 
@@ -32,6 +32,13 @@ InstanceCount: {searchUnits}
 ServiceName: Azure Cognitive Search
 SkuName: Semantic Ranker
 MeterName: Semantic Ranker Unit
+
+### Semantic Ranker per-query (bills per 1K queries; use for queriesPerMonth)
+
+ServiceName: Azure Cognitive Search
+SkuName: Semantic Ranker
+MeterName: Semantic Ranker queries
+Quantity: ({queriesPerMonth} ÷ 1000)
 
 ### Agentic Retrieval (per 1K tokens; Level = Minimum, Low, or Medium)
 

--- a/skills/azure-cost-calculator/references/services/web/cognitive-search.md
+++ b/skills/azure-cost-calculator/references/services/web/cognitive-search.md
@@ -3,6 +3,7 @@ serviceName: Azure Cognitive Search
 category: web
 aliases: [Azure AI Search, Search Service, Full-text Search]
 primaryCost: "Fixed hourly rate per search unit (SU) × 730, varies by tier"
+hasKnownRates: true
 hasFreeGrant: true
 privateEndpoint: true
 ---
@@ -13,7 +14,9 @@ privateEndpoint: true
 
 > **Trap (CC variants)**: Each tier has a customer-controlled encryption variant (e.g., `Standard S1 CC`). These are separate SKUs with ~10% higher prices; do not confuse with the standard tier.
 
-> **Trap (Semantic Ranker MonthlyCost)**: The Semantic Ranker meter uses `1/Day` units. The script auto-multiplies by 30, so `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30`; that would overcount by 30x.
+> **Trap (Semantic Ranker MonthlyCost)**: The `Semantic Ranker Unit` meter uses `1/Day` units. The script auto-multiplies by 30, so `MonthlyCost` is already the **monthly** cost. Do NOT pass `Quantity: 30`; that would overcount by 30x. The per-query meters (`Semantic Ranker queries`, `Semantic Ranker Overage Queries`) use `1K` units and default to ×1; compute them as `queriesPerMonth ÷ 1000 × retailPrice`.
+
+> **Trap (Agentic Retrieval sub-cent)**: The three Agentic Retrieval reasoning meters (`1K` unit) have sub-cent per-token rates, so the script rounds `MonthlyCost` to zero. Do not report zero to the user; use the Known Rates table and multiply `retailPrice × (tokens ÷ 1000)`.
 
 ## Query Pattern
 
@@ -70,9 +73,10 @@ AI-related add-on meters, including enrichment meters such as Document Cracking 
 
 ```
 Monthly Base  = retailPrice × 730 × searchUnits
-Semantic (if enabled) = semantic_retailPrice × 30
-Agentic (if enabled) = agentic_retailPrice × (tokens ÷ 1000)
-Total = Monthly Base + Semantic + Agentic
+Semantic daily (if enabled)   = semantic_daily_retailPrice × 30
+Semantic queries (if enabled) = semantic_query_retailPrice × (queriesPerMonth ÷ 1000)
+Agentic (if enabled)          = agentic_retailPrice × (max(0, tokens − freeGrant) ÷ 1000)
+Total = Monthly Base + Semantic daily + Semantic queries + Agentic
 ```
 
 ## Notes
@@ -84,3 +88,13 @@ Total = Monthly Base + Semantic + Agentic
 - **Semantic Ranker**: Billed daily, not hourly. Script auto-multiplies `1/Day` by 30. Also has per-query meters (`Semantic Ranker queries` at per-1K, `Semantic Ranker Overage Queries` at higher per-1K rate).
 - **Agentic Retrieval**: Three reasoning levels (Minimum, Low, Medium) billed per 1K tokens at sub-cent rates. Free grants available.
 - **Private Endpoints**: Supported on Basic tier and above. Not available on the Free tier.
+
+## Known Rates
+
+Sub-cent Agentic Retrieval rates the script rounds to `$0.00`. Free monthly grants apply per level (see `Free Agentic Retrieval {Level} Reasoning` SKUs); confirm current allotment on the pricing page.
+
+| Meter                                        | Unit | Published Rate (USD) |
+| -------------------------------------------- | ---- | -------------------- |
+| `Agentic Retrieval Minimum Reasoning Tokens` | 1K   | $0.000022            |
+| `Agentic Retrieval Low Reasoning Tokens`     | 1K   | $0.000022            |
+| `Agentic Retrieval Medium Reasoning Tokens`  | 1K   | $0.0001              |

--- a/skills/azure-cost-calculator/references/services/web/spring-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/spring-apps.md
@@ -9,7 +9,7 @@ privateEndpoint: true
 
 # Azure Spring Apps
 
-> **Warning**: Azure Spring Apps is retiring. No new customers after March 2025; full shutdown March 31, 2028. Migrate to Azure Container Apps or AKS.
+> **Warning**: Azure Spring Apps is retiring. No new customers after March 17, 2025; full shutdown March 31, 2028. Migrate to Azure Container Apps or AKS.
 
 > **Trap (Inflated totals)**: Omitting `SkuName` returns all tiers and tracking meters summed. Always include `SkuName` and `MeterName`. Use `ProductName: Azure Spring Apps` (not `Azure Spring Apps Enterprise`) for all tiers.
 

--- a/skills/azure-cost-calculator/references/services/web/static-web-apps.md
+++ b/skills/azure-cost-calculator/references/services/web/static-web-apps.md
@@ -24,13 +24,16 @@ privateEndpoint: true
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps
+SkuName: Standard
 MeterName: Standard App
+InstanceCount: {appCount}
 Region: eastus2
 
 ### Bandwidth: pass Quantity with total GB to see per-tier unit prices
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps
+SkuName: Standard
 MeterName: Standard Bandwidth Usage
 Quantity: 500
 Region: eastus2
@@ -39,6 +42,7 @@ Region: eastus2
 
 ServiceName: Azure App Service
 ProductName: Static Web Apps
+SkuName: Standard
 MeterName: Standard Azure Front Door Add-on
 Region: eastus2
 
@@ -72,7 +76,7 @@ Total       = App + Bandwidth + AFD Add-on
 
 - **Free tier**: Includes 2 custom domains, 100 GB bandwidth/month, built-in auth, and serverless APIs. No meters in the API; zero cost.
 - **Standard tier**: Query API with eastus2 for current per-app monthly fee. Adds custom auth, SLA, and more APIs.
-- **Bandwidth**: Standard includes 100 GB/month free. Query API for overage rate per GB; the API returns two bandwidth rows per region (free tier and overage tier).
+- **Bandwidth**: 100 GB/month is included free **per subscription** (shared across all apps, not per app). Query API for overage rate per GB; the API returns two bandwidth rows per region (free tier and overage tier). Deduct the 100 GB grant once per subscription, not once per app.
 - **Azure Front Door add-on**: Optional. Provides enterprise-grade edge with WAF, custom rules, and bot protection. Query API for current hourly rate.
 - **Tier limitations**: Free tier: 2 custom domains, 0.5 GB storage, community support. Standard tier: 5 custom domains, 2 GB storage, SLA-backed.
 - **Private Endpoints**: Supported on Standard tier only. Not available on the Free tier.


### PR DESCRIPTION
Refreshes all three `web` category service reference files against the live Azure Retail Prices API. Each was produced by the service-reference orchestration pattern (two independent `pricing-investigator` passes + `compliance-reviewer`, consensus over speculation). No genuine disagreements arose, so no tiebreakers were needed. One commit per file.

## Changes

| Commit | Service | Change (all live-API verified) |
|--------|---------|-------------------------------|
| `da15f3a` | Azure Cognitive Search | Added `hasKnownRates: true` + Known Rates table with the sub-cent Agentic Retrieval rates; extended the Semantic Ranker trap to cover per-query meters; added an Agentic Retrieval trap; completed the Cost Formula. All existing meters verified current; none removed. |
| `6027f27` | Azure Spring Apps | Corrected retirement date to March 17, 2025 (verified against Microsoft Learn); shutdown March 31, 2028 unchanged. Meters, formulas, free grants, PE tiers re-verified accurate. |
| `dd3fa23` | Azure Static Web Apps | Added `SkuName: Standard` to all query blocks and `InstanceCount: {appCount}` to the app-fee query; clarified the 100 GB bandwidth grant is per-subscription (deducted once). Data fully current; no meters added/removed. |

## Validation

- `pwsh tests/Validate-ServiceReference.ps1 -Path <file> -CheckAliasUniqueness -CheckRoutingFileSync` → PASS for all three files.
- All files within `MaxLineCount` (100 / 98 / 82 lines).
- Existing happy-path eval tasks (`standard-s1-multi-su.yaml`, spring-apps, `standard-multi-app.yaml`) still match unchanged meters/SKUs; no eval edits needed.
- `waza check` → no task schema errors (only pre-existing skill-wide readiness advisories, unrelated to these files).
- No routing/catalog changes (display names and aliases unchanged).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Azure Cognitive Search cost formulas and added published rates for Agentic Retrieval and Semantic Ranker usage.
  * Improved guidance to prevent zero or overstated cost estimates from rounding and quantity calculations.
  * Updated Azure Spring Apps retirement guidance with the precise March 17, 2025 cutoff for new customers.
  * Refined Azure Static Web Apps pricing parameters and clarified subscription-wide bandwidth allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->