### PR TITLE
version: v1.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-cost-calculator",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Real-time Azure cost estimation using the Azure Retail Prices API",
   "author": {
     "name": "ahmadabdalla"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 <!-- versions -->
 
+## [1.10.0] - 2026-07-20
+
+### Changed
+
+- Context-management uplift across `SKILL.md`, `shared.md`, and `service-routing.md`: routing map entries now embed each reference file's full relative path so an alias resolves to a file in one hop, and batch service-file reads are bounded to the `## Query Pattern` section. Reduces throwaway context the agent builds while capturing cost figures, with no change to estimated costs.
+- `pitfalls.md`: removed the redundant Troubleshooting section and trimmed over-explained cells; all unique traps and the discovery workflow are retained.
+
 ## [1.9.0] - 2026-07-19
 
 ### Added

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - PowerShell
 metadata:
   author: ahmadabdalla
-  version: "1.9.0"
+  version: "1.10.0"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
## Release v1.10.0

Manual Stage 1 version bump for the v1.10.0 release. Bumps `.claude-plugin/plugin.json`, `SKILL.md`, and `CHANGELOG.md`.

### Included changes (main → dev since v1.9.0)

- **#1030** context-management uplift: path-embedded routing map + grep-bounded batch reads (`SKILL.md`, `shared.md`, `service-routing.md`).
- **#1031** trimmed redundant content from `pitfalls.md`.

### Changelog

### Changed

- Context-management uplift across `SKILL.md`, `shared.md`, and `service-routing.md`: routing map entries now embed each reference file's full relative path so an alias resolves to a file in one hop, and batch service-file reads are bounded to the `## Query Pattern` section. Reduces throwaway context the agent builds while capturing cost figures, with no change to estimated costs.
- `pitfalls.md`: removed the redundant Troubleshooting section and trimmed over-explained cells; all unique traps and the discovery workflow are retained.

---

On merge to `dev`, `create-release-pr.yml` opens the `release: v1.10.0` PR (dev → main). Merge that with a **merge commit** (not squash) to preserve history; `create-release.yml` then tags `v1.10.0` and publishes the GitHub Release.
