### PR TITLE
release: v1.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-cost-calculator",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Real-time Azure cost estimation using the Azure Retail Prices API",
   "author": {
     "name": "ahmadabdalla"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 <!-- versions -->
 
+## [1.10.1] - 2026-07-31
+
+### Fixed
+
+- Service references no longer claim the Retail Prices API returns USD-only pricing. `currencyCode` is a top-level query parameter honoured independently of `armRegionName`, so `Global` and empty-region services (`load-balancer.md`, `nat-gateway.md`, `route-server.md`, `private-dns.md`, `dns-private-resolver.md`, `scom-managed-instance.md`, `container-storage.md`) return the target currency directly instead of requiring a derived FX factor.
+- `container-apps.md`, `functions.md`, `app-configuration.md`, `devops.md`, `entra-external-id.md`, `automation.md`, and `netapp-files.md` now query the target currency and use the returned value rather than converting from USD.
+- Direct `API:` URLs in five networking references carry `&currencyCode={currencyCode}`; omitting the parameter or sending it empty silently returns USD with no error.
+- `functions.md`: a `retailPrice` of `0.0` is the free-grant tier (`tierMinimumUnits: 0`), not a missing price.
+
+### Changed
+
+- `shared.md` and `regions-and-currencies.md`: FX derivation is scoped to manual USD rates the API does not publish. The empty API-unavailable table and the USD-only services table are removed in favour of service file front matter.
+- `pitfalls.md`: API-unavailable guidance points at front matter (`pricingRegion: api-unavailable`).
+
+
 ## [1.10.0] - 2026-07-20
 
 ### Changed

--- a/skills/azure-cost-calculator/SKILL.md
+++ b/skills/azure-cost-calculator/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - PowerShell
 metadata:
   author: ahmadabdalla
-  version: "1.10.0"
+  version: "1.10.1"
 ---
 
 # Azure Cost Calculator


### PR DESCRIPTION
Hotfix release cut directly from `main`, outside the usual `dev` → `main` flow.

## Changes

Version bump `1.10.0` → `1.10.1` in `.claude-plugin/plugin.json` and `skills/azure-cost-calculator/SKILL.md`, plus the `CHANGELOG.md` section for this release.

The shipped fix is `5237c6e` (#1039), already merged to `main`.

Issue references: #1038

## Merge instructions

Merge with a **merge commit**, not squash. `create-release.yml` fires on the `release: ` title prefix and will tag `v1.10.1` and publish the GitHub Release.

Follow-up: `main` will be back-merged into `dev` so the next weekly release computes from `1.10.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of non-USD pricing when retrieving Azure service prices.
  - Corrected currency conversion behavior for prices returned by the Azure Retail Prices API.
  - Properly recognizes zero-priced entries as free-grant tiers.
  - Refined foreign exchange calculations for services without published API pricing.

- **Documentation**
  - Added release notes describing the currency and pricing improvements.
  - Updated the plugin and skill version to 1.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->